### PR TITLE
Feature search with points

### DIFF
--- a/src/t8_forest/t8_forest_ghost.cxx
+++ b/src/t8_forest/t8_forest_ghost.cxx
@@ -839,8 +839,7 @@ t8_forest_ghost_search_boundary (t8_forest_t forest, t8_locidx_t ltreeid,
                                  const t8_element_t * element,
                                  const int is_leaf,
                                  t8_element_array_t * leafs,
-                                 t8_locidx_t tree_leaf_index,
-                                 void * query)
+                                 t8_locidx_t tree_leaf_index, void *query)
 {
   t8_forest_ghost_boundary_data_t *data =
     (t8_forest_ghost_boundary_data_t *) t8_forest_get_user_data (forest);
@@ -1025,7 +1024,7 @@ t8_forest_ghost_fill_remote_v3 (t8_forest_t forest)
   /* Set the user data for the search routine */
   t8_forest_set_user_data (forest, &data);
   /* Loop over the trees of the forest */
-  t8_forest_search (forest, t8_forest_ghost_search_boundary);
+  t8_forest_search (forest, t8_forest_ghost_search_boundary, NULL, NULL);
 
   /* Reset the user data from before search */
   t8_forest_set_user_data (forest, store_user_data);

--- a/src/t8_forest/t8_forest_ghost.cxx
+++ b/src/t8_forest/t8_forest_ghost.cxx
@@ -837,8 +837,10 @@ typedef struct
 static int
 t8_forest_ghost_search_boundary (t8_forest_t forest, t8_locidx_t ltreeid,
                                  const t8_element_t * element,
+                                 const int is_leaf,
                                  t8_element_array_t * leafs,
-                                 t8_locidx_t tree_leaf_index)
+                                 t8_locidx_t tree_leaf_index,
+                                 void * query)
 {
   t8_forest_ghost_boundary_data_t *data =
     (t8_forest_ghost_boundary_data_t *) t8_forest_get_user_data (forest);
@@ -925,7 +927,7 @@ t8_forest_ghost_search_boundary (t8_forest_t forest, t8_locidx_t ltreeid,
       upper = parent_upper;
     }
 
-    if (tree_leaf_index < 0) {
+    if (!is_leaf) {
       /* The element is not a leaf, we compute bounds for the face neighbor owners,
        * if all face neighbors are owned by this rank, and the element is completely
        * owned, then we do not continue the search. */
@@ -964,6 +966,7 @@ t8_forest_ghost_search_boundary (t8_forest_t forest, t8_locidx_t ltreeid,
     }
   }                             /* end face loop */
 #if 0
+  /* TODO: can we remove this code? */
   if (element_is_owned || face_totally_owned) {
     /* Either all descendants of element are owned by the current rank
      * or all of its leafs at the face are. */

--- a/src/t8_forest/t8_forest_iterate.cxx
+++ b/src/t8_forest/t8_forest_iterate.cxx
@@ -178,32 +178,58 @@ t8_forest_iterate_faces (t8_forest_t forest, t8_locidx_t ltreeid,
 /* The recursion that is called from t8_forest_search_tree
  * Input is an element and an array of all leaf elements of this element.
  * The callback function is called on element and if it returns true,
- * the search continues with the children of the element. */
+ * the search continues with the children of the element.
+ * Additionally a query function and a set of queries can be given.
+ * In this case the recursion stops when either the search_fn function
+ * returns false or the query_fn function returns false for all active queries.
+ * (Thus, if there are no active queries left, the recursion also stops.)
+ * A query is active for an element if the query_fn callback returned true
+ * for the parent element.
+ * If the callback function (search_fn) returns false for an element, its
+ * the query function is not called for this element.
+ */
 static void
 t8_forest_search_recursion (t8_forest_t forest, t8_locidx_t ltreeid,
                             t8_eclass_t eclass, t8_element_t * element,
                             t8_eclass_scheme_c * ts,
                             t8_element_array_t * leaf_elements,
                             t8_locidx_t tree_lindex_of_first_leaf,
-                            t8_forest_search_query_fn search_fn)
+                            t8_forest_search_query_fn search_fn,
+                            t8_forest_search_query_fn query_fn,
+                            sc_array_t * queries, sc_array_t * active_queries)
 {
   t8_element_t       *leaf, **children;
   int                 num_children, ichild;
   size_t             *split_offsets, indexa, indexb;
   t8_element_array_t  child_leafs;
   size_t              elem_count;
-  int                 ret;
+  size_t              num_active;
+  int                 ret, query_ret, is_leaf;
+  void               *current_query;
+  size_t              iactive, query_index;
+  sc_array_t         *new_active_queries = NULL;
 
+  /* Assertions to check for necessary requirements */
+  /* The forest must be committed */
   T8_ASSERT (t8_forest_is_committed (forest));
+  /* The tree must be local */
   T8_ASSERT (0 <= ltreeid
              && ltreeid < t8_forest_get_num_local_trees (forest));
+  /* If we have queries, we also must have a query function */
+  T8_ASSERT ((queries == NULL) == (query_fn == NULL));
 
   elem_count = t8_element_array_get_count (leaf_elements);
   if (elem_count == 0) {
     /* There are no leafs left, so we have nothing to do */
     return;
   }
+  num_active = queries == NULL ? 0 : active_queries->elem_count;
+  if (queries != NULL && num_active == 0) {
+    /* There are no queries left. We stop the recursion */
+    return;
+  }
 
+  is_leaf = 0;
   if (elem_count == 1) {
     /* There is only one leaf left, we check whether it is the same as element
      * and if so call the callback function */
@@ -214,64 +240,101 @@ t8_forest_search_recursion (t8_forest_t forest, t8_locidx_t ltreeid,
                     "Search: element level greater than leaf level\n");
     if (ts->t8_element_level (element) == ts->t8_element_level (leaf)) {
       T8_ASSERT (!ts->t8_element_compare (element, leaf));
-      /* The element is the leaf, we are at the last stage of the recursion
-       * and can call the callback. */
-      (void) search_fn (forest, ltreeid, leaf, leaf_elements,
-                        tree_lindex_of_first_leaf);
-      return;
+      /* The element is the leaf */
+      is_leaf = 1;
     }
   }
-  /* Call the callback function for the element, we pass -index -1 as index to indicate
-   * element is not a leaf */
-  ret = search_fn (forest, ltreeid, element, leaf_elements,
-                   -tree_lindex_of_first_leaf - 1);
+  /* Call the callback function for the element */
+  ret = search_fn (forest, ltreeid, element, is_leaf, leaf_elements,
+                   tree_lindex_of_first_leaf, NULL);
 
-  if (ret) {
-    /* Enter the recursion */
-    /* We compute all children of E, compute their leaf arrays and
-     * call search_recursion */
-    /* allocate the memory to store the children */
-    num_children = ts->t8_element_num_children (element);
-    children = T8_ALLOC (t8_element_t *, num_children);
-    ts->t8_element_new (num_children, children);
-    /* Memory for the indices that split the leaf_elements array */
-    split_offsets = T8_ALLOC (size_t, num_children + 1);
-    /* Compute the children */
-    ts->t8_element_children (element, num_children, children);
-    /* Split the leafs array in portions belonging to the children of element */
-    t8_forest_split_array (element, leaf_elements, split_offsets);
-    for (ichild = 0; ichild < num_children; ichild++) {
-      /* Check if there are any leaf elements for this child */
-      indexa = split_offsets[ichild];   /* first leaf of this child */
-      indexb = split_offsets[ichild + 1];       /* first leaf of next child */
-      if (indexa < indexb) {
-        /* There exist leafs of this child in leaf_elements,
-         * we construct an array of these leafs */
-        t8_element_array_init_view (&child_leafs, leaf_elements, indexa,
-                                    indexb - indexa);
-        /* Enter the recursion */
-        t8_forest_search_recursion (forest, ltreeid, eclass, children[ichild],
-                                    ts, &child_leafs,
-                                    indexa + tree_lindex_of_first_leaf,
-                                    search_fn);
-      }
+  if (!ret) {
+    /* The function returned false. We abort the recursion */
+    return;
+  }
+
+  /* Check the queries.
+   * If the current element is not a leaf, we store the queries that
+   * return true in order to pass them on to the children of the element. */
+
+  if (!is_leaf && num_active > 0) {
+    /* Initialize the new active query array */
+    new_active_queries = sc_array_new (sizeof (size_t));
+  }
+  /* Call the query function for all active queries */
+  for (iactive = 0; iactive < num_active; ++iactive) {
+    query_index = *(size_t *) sc_array_index (active_queries, iactive);
+    current_query = sc_array_index (queries, query_index);
+    query_ret =
+      query_fn (forest, ltreeid, element, is_leaf, leaf_elements,
+                tree_lindex_of_first_leaf, current_query);
+    if (!is_leaf && query_ret) {
+      /* If element is not a leaf and this query returned true, we add this
+       * query to the new active queries */
+      *(size_t *) sc_array_push (new_active_queries) = query_index;
     }
-    /* clean-up */
-    ts->t8_element_destroy (num_children, children);
-    T8_FREE (children);
-    T8_FREE (split_offsets);
+  }
+  if (is_leaf) {
+    /* The element was a leaf. We abort the recursion. */
+    return;
+  }
+
+  if (num_active > 0 && new_active_queries->elem_count == 0) {
+    /* No queries returned true for this element. We abort the recursion */
+    return;
+  }
+
+  /* Enter the recursion (the element is definitely not a leaf at this point) */
+  /* We compute all children of E, compute their leaf arrays and
+   * call search_recursion */
+  /* allocate the memory to store the children */
+  num_children = ts->t8_element_num_children (element);
+  children = T8_ALLOC (t8_element_t *, num_children);
+  ts->t8_element_new (num_children, children);
+  /* Memory for the indices that split the leaf_elements array */
+  split_offsets = T8_ALLOC (size_t, num_children + 1);
+  /* Compute the children */
+  ts->t8_element_children (element, num_children, children);
+  /* Split the leafs array in portions belonging to the children of element */
+  t8_forest_split_array (element, leaf_elements, split_offsets);
+  for (ichild = 0; ichild < num_children; ichild++) {
+    /* Check if there are any leaf elements for this child */
+    indexa = split_offsets[ichild];     /* first leaf of this child */
+    indexb = split_offsets[ichild + 1]; /* first leaf of next child */
+    if (indexa < indexb) {
+      /* There exist leafs of this child in leaf_elements,
+       * we construct an array of these leafs */
+      t8_element_array_init_view (&child_leafs, leaf_elements, indexa,
+                                  indexb - indexa);
+      /* Enter the recursion */
+      t8_forest_search_recursion (forest, ltreeid, eclass, children[ichild],
+                                  ts, &child_leafs,
+                                  indexa + tree_lindex_of_first_leaf,
+                                  search_fn, query_fn, queries,
+                                  new_active_queries);
+    }
+  }
+  /* clean-up */
+  ts->t8_element_destroy (num_children, children);
+  T8_FREE (children);
+  T8_FREE (split_offsets);
+  if (num_active > 0) {
+    sc_array_destroy (new_active_queries);
   }
 }
 
 /* Perform a top-down search in one tree of the forest */
 static void
 t8_forest_search_tree (t8_forest_t forest, t8_locidx_t ltreeid,
-                       t8_forest_search_query_fn search_fn)
+                       t8_forest_search_query_fn search_fn,
+                       t8_forest_search_query_fn query_fn,
+                       sc_array_t * queries)
 {
   t8_eclass_t         eclass;
   t8_eclass_scheme_c *ts;
   t8_element_t       *nca, *first_el, *last_el;
   t8_element_array_t *leaf_elements;
+  sc_array_t         *active_queries = NULL;
 
   /* Get the element class, scheme and leaf elements of this tree */
   eclass = t8_forest_get_eclass (forest, ltreeid);
@@ -289,19 +352,39 @@ t8_forest_search_tree (t8_forest_t forest, t8_locidx_t ltreeid,
   /* Compute their nearest common ancestor */
   ts->t8_element_new (1, &nca);
   ts->t8_element_nca (first_el, last_el, nca);
+
+  /* If we have queries build a list of all active queries,
+   * thus all queries in the array */
+  if (queries != NULL) {
+    size_t              iquery;
+    size_t              num_queries = queries->elem_count;
+    /* build an array and write 0, 1, 2, 3,... into it */
+    active_queries = sc_array_new_count (sizeof (size_t), num_queries);
+    for (iquery = 0; iquery < num_queries; ++iquery) {
+      *(size_t *) sc_array_index (active_queries, iquery) = iquery;
+    }
+  }
+
   /* Start the top-down search */
   t8_forest_search_recursion (forest, ltreeid, eclass, nca, ts, leaf_elements,
-                              0, search_fn);
+                              0, search_fn, query_fn, queries,
+                              active_queries);
+
+  /* Clean up the array of active queries */
+  if (queries != NULL) {
+    sc_array_destroy (active_queries);
+  }
 }
 
 void
-t8_forest_search (t8_forest_t forest, t8_forest_search_query_fn search_fn)
+t8_forest_search (t8_forest_t forest, t8_forest_search_query_fn search_fn,
+                  t8_forest_search_query_fn query_fn, sc_array_t * queries)
 {
   t8_locidx_t         num_local_trees, itree;
 
   num_local_trees = t8_forest_get_num_local_trees (forest);
   for (itree = 0; itree < num_local_trees; itree++) {
-    t8_forest_search_tree (forest, itree, search_fn);
+    t8_forest_search_tree (forest, itree, search_fn, query_fn, queries);
   }
 }
 

--- a/src/t8_forest/t8_forest_iterate.cxx
+++ b/src/t8_forest/t8_forest_iterate.cxx
@@ -25,7 +25,6 @@
 #include <t8_forest.h>
 #include <t8_element_cxx.hxx>
 
-
 /* We want to export the whole implementation to be callable from "C" */
 T8_EXTERN_C_BEGIN ();
 
@@ -186,8 +185,7 @@ t8_forest_search_recursion (t8_forest_t forest, t8_locidx_t ltreeid,
                             t8_eclass_scheme_c * ts,
                             t8_element_array_t * leaf_elements,
                             t8_locidx_t tree_lindex_of_first_leaf,
-                            t8_forest_search_query_fn search_fn,
-                            void *user_data)
+                            t8_forest_search_query_fn search_fn)
 {
   t8_element_t       *leaf, **children;
   int                 num_children, ichild;
@@ -218,14 +216,14 @@ t8_forest_search_recursion (t8_forest_t forest, t8_locidx_t ltreeid,
       T8_ASSERT (!ts->t8_element_compare (element, leaf));
       /* The element is the leaf, we are at the last stage of the recursion
        * and can call the callback. */
-      (void) search_fn (forest, ltreeid, leaf, leaf_elements, user_data,
+      (void) search_fn (forest, ltreeid, leaf, leaf_elements,
                         tree_lindex_of_first_leaf);
       return;
     }
   }
   /* Call the callback function for the element, we pass -index -1 as index to indicate
    * element is not a leaf */
-  ret = search_fn (forest, ltreeid, element, leaf_elements, user_data,
+  ret = search_fn (forest, ltreeid, element, leaf_elements,
                    -tree_lindex_of_first_leaf - 1);
 
   if (ret) {
@@ -255,7 +253,7 @@ t8_forest_search_recursion (t8_forest_t forest, t8_locidx_t ltreeid,
         t8_forest_search_recursion (forest, ltreeid, eclass, children[ichild],
                                     ts, &child_leafs,
                                     indexa + tree_lindex_of_first_leaf,
-                                    search_fn, user_data);
+                                    search_fn);
       }
     }
     /* clean-up */
@@ -268,7 +266,7 @@ t8_forest_search_recursion (t8_forest_t forest, t8_locidx_t ltreeid,
 /* Perform a top-down search in one tree of the forest */
 static void
 t8_forest_search_tree (t8_forest_t forest, t8_locidx_t ltreeid,
-                       t8_forest_search_query_fn search_fn, void *user_data)
+                       t8_forest_search_query_fn search_fn)
 {
   t8_eclass_t         eclass;
   t8_eclass_scheme_c *ts;
@@ -293,18 +291,17 @@ t8_forest_search_tree (t8_forest_t forest, t8_locidx_t ltreeid,
   ts->t8_element_nca (first_el, last_el, nca);
   /* Start the top-down search */
   t8_forest_search_recursion (forest, ltreeid, eclass, nca, ts, leaf_elements,
-                              0, search_fn, user_data);
+                              0, search_fn);
 }
 
 void
-t8_forest_search (t8_forest_t forest, t8_forest_search_query_fn search_fn,
-                  void *user_data)
+t8_forest_search (t8_forest_t forest, t8_forest_search_query_fn search_fn)
 {
   t8_locidx_t         num_local_trees, itree;
 
   num_local_trees = t8_forest_get_num_local_trees (forest);
   for (itree = 0; itree < num_local_trees; itree++) {
-    t8_forest_search_tree (forest, itree, search_fn, user_data);
+    t8_forest_search_tree (forest, itree, search_fn);
   }
 }
 

--- a/src/t8_forest/t8_forest_iterate.h
+++ b/src/t8_forest/t8_forest_iterate.h
@@ -45,6 +45,7 @@ typedef int         (*t8_forest_search_query_fn) (t8_forest_t forest,
                                                   t8_locidx_t ltreeid,
                                                   const t8_element_t *
                                                   element,
+                                                  const int is_leaf,
                                                   t8_element_array_t *
                                                   leaf_elements,
                                                   t8_locidx_t

--- a/src/t8_forest/t8_forest_iterate.h
+++ b/src/t8_forest/t8_forest_iterate.h
@@ -41,6 +41,20 @@ typedef int         (*t8_forest_iterate_face_fn) (t8_forest_t forest,
                                                   t8_locidx_t
                                                   tree_leaf_index);
 
+/*
+ * forest          the forest
+ * ltreeid         the local tree id of the current tree
+ * element         the element for which the query is executed
+ * is_leaf         true if and only if \a element is a leaf element
+ * leaf_elements   the leaf elements in \a forest that are descendants of \a element
+ *                 (or the element itself if \a is_leaf is true)
+ * tree_leaf_index the local index of the first leaf in \a leaf_elements
+ * query           if not NULL, a query that is passed through from the search function
+ *
+ * return          if \a query is not NULL: true if and only if the element 'matches' the query
+ *                 if \a query is NULL: true if and only if the search should continue withe the
+ *                 children of \a element and the queries should be performed for this element.
+ */
 typedef int         (*t8_forest_search_query_fn) (t8_forest_t forest,
                                                   t8_locidx_t ltreeid,
                                                   const t8_element_t *
@@ -49,7 +63,8 @@ typedef int         (*t8_forest_search_query_fn) (t8_forest_t forest,
                                                   t8_element_array_t *
                                                   leaf_elements,
                                                   t8_locidx_t
-                                                  tree_leaf_index);
+                                                  tree_leaf_index,
+                                                  void *query);
 
 T8_EXTERN_C_BEGIN ();
 
@@ -84,7 +99,9 @@ void                t8_forest_iterate_faces (t8_forest_t forest,
  * To pass user data to the search_fn function use \ref t8_forest_set_user_data
  */
 void                t8_forest_search (t8_forest_t forest,
-                                      t8_forest_search_query_fn search_fn);
+                                      t8_forest_search_query_fn search_fn,
+                                      t8_forest_search_query_fn query_fn,
+                                      sc_array_t * queries);
 
 /** Given two forest where the elemnts in one forest are either direct children or
  * parents of the elements in the other forest

--- a/src/t8_forest/t8_forest_iterate.h
+++ b/src/t8_forest/t8_forest_iterate.h
@@ -47,7 +47,6 @@ typedef int         (*t8_forest_search_query_fn) (t8_forest_t forest,
                                                   element,
                                                   t8_element_array_t *
                                                   leaf_elements,
-                                                  void *user_data,
                                                   t8_locidx_t
                                                   tree_leaf_index);
 
@@ -81,14 +80,14 @@ void                t8_forest_iterate_faces (t8_forest_t forest,
  * intermediate element. The search will enter each tree at least once.
  * If the callback returns false for an element, its descendants
  * are not further searched.
+ * To pass user data to the search_fn function use \ref t8_forest_set_user_data
  */
 void                t8_forest_search (t8_forest_t forest,
-                                      t8_forest_search_query_fn search_fn,
-                                      void *user_data);
+                                      t8_forest_search_query_fn search_fn);
 
 /** Given two forest where the elemnts in one forest are either direct children or
- * parents of the elements in the other forest.
- * Compare the two forests and for each refined element or coarsened
+ * parents of the elements in the other forest
+ * compare the two forests and for each refined element or coarsened
  * family in the old one, call a callback function providing the local indices
  * of the old and new elements.
  * \param [in]  forest_new  A forest, each element is a parent or child of an element in \a forest_old.

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -14,7 +14,8 @@ t8code_test_programs = \
 	test/t8_test_forest_commit \
 	test/t8_test_transform \
 	test/t8_test_half_neighbors \
-  test/t8_test_element_count_leafs
+  test/t8_test_element_count_leafs \
+  test/t8_test_search
 
 test_t8_test_eclass_SOURCES = test/t8_test_eclass.c
 test_t8_test_bcast_SOURCES = test/t8_test_bcast.c
@@ -28,6 +29,7 @@ test_t8_test_forest_commit_SOURCES = test/t8_test_forest_commit.cxx
 test_t8_test_transform_SOURCES = test/t8_test_transform.cxx
 test_t8_test_half_neighbors_SOURCES = test/t8_test_half_neighbors.cxx
 test_t8_test_element_count_leafs_SOURCES = test/t8_test_element_count_leafs.cxx
+test_t8_test_search_SOURCES = test/t8_test_search.cxx
 
 TESTS += $(t8code_test_programs)
 check_PROGRAMS += $(t8code_test_programs)

--- a/test/t8_test_search.cxx
+++ b/test/t8_test_search.cxx
@@ -1,0 +1,199 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element types in parallel.
+
+  Copyright (C) 2010 The University of Texas System
+  Written by Carsten Burstedde, Lucas C. Wilcox, and Tobin Isaac
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+#include <t8_eclass.h>
+#include <t8_cmesh.h>
+#include <t8_forest.h>
+#include <t8_forest/t8_forest_iterate.h>
+#include <t8_schemes/t8_default_cxx.hxx>
+
+/* A search function that matches all elements.
+ * This function assumes that the forest user pointer is an sc_array
+ * with one int for each local leaf.
+ * If this function is called for a leaf, it sets the corresponding entry to 1.
+ */
+static int
+t8_test_search_all_fn (t8_forest_t forest,
+                       t8_locidx_t ltreeid,
+                       const t8_element_t *
+                       element,
+                       const int is_leaf,
+                       t8_element_array_t *
+                       leaf_elements,
+                       t8_locidx_t tree_leaf_index, void *query)
+{
+  SC_CHECK_ABORT (query == NULL,
+                  "Search callback must not be called with query argument.");
+
+  sc_array_t         *matched_leafs =
+    (sc_array_t *) t8_forest_get_user_data (forest);
+  if (is_leaf) {
+    t8_locidx_t         tree_offset;
+    t8_locidx_t         test_ltreeid;
+    t8_element_t       *test_element;
+    t8_eclass_scheme_c *ts;
+    t8_eclass_t         tree_class =
+      t8_forest_get_tree_class (forest, ltreeid);
+    ts = t8_forest_get_eclass_scheme (forest, tree_class);
+
+    tree_offset = t8_forest_get_tree_element_offset (forest, ltreeid);
+    /* Set the corresponding entry to 1 */
+    *(int *) t8_sc_array_index_locidx (matched_leafs,
+                                       tree_offset + tree_leaf_index) = 1;
+    /* Test whether tree_leaf_index is actually the index of the element */
+    test_element =
+      t8_forest_get_element (forest, tree_offset + tree_leaf_index,
+                             &test_ltreeid);
+    SC_CHECK_ABORT (ts->t8_element_compare (element, test_element) == 0,
+                    "Element and index passed to search callback do not match.");
+    SC_CHECK_ABORT (ltreeid == test_ltreeid, "Tree missmatch in search.");
+  }
+  return 1;
+}
+
+static int
+t8_test_search_query_all_fn (t8_forest_t forest,
+                             t8_locidx_t ltreeid,
+                             const t8_element_t *
+                             element,
+                             const int is_leaf,
+                             t8_element_array_t *
+                             leaf_elements,
+                             t8_locidx_t tree_leaf_index, void *query)
+{
+  /* The query callback is allways called with a query */
+  SC_CHECK_ABORT (query != NULL,
+                  "query callback must be called with query argument.");
+  /* The query is an int with value 42 (see below) */
+  SC_CHECK_ABORT (*(int *) query == 42,
+                  "Wrong query argument passed to query callback.");
+  if (is_leaf) {
+    /* Test whether tree_leaf_index is actually the index of the element */
+    t8_locidx_t         tree_offset;
+    t8_locidx_t         test_ltreeid;
+    t8_element_t       *test_element;
+    t8_eclass_t         tree_class =
+      t8_forest_get_tree_class (forest, ltreeid);
+    ts = t8_forest_get_eclass_scheme (forest, tree_class);
+
+    tree_offset = t8_forest_get_tree_element_offset (forest, ltreeid);
+    test_element =
+      t8_forest_get_element (forest, tree_offset + tree_leaf_index,
+                             &test_ltreeid);
+    SC_CHECK_ABORT (ts->t8_element_compare (element, test_element) == 0,
+                    "Element and index passed to search callback do not match.");
+    SC_CHECK_ABORT (ltreeid == test_ltreeid, "Tree missmatch in search.");
+  }
+
+  return 1;
+}
+
+static void
+t8_test_search_one_query_matches_all (sc_MPI_Comm comm, t8_eclass_t eclass,
+                                      int level)
+{
+  t8_cmesh_t          cmesh;
+  t8_forest_t         forest;
+  t8_scheme_cxx_t    *default_scheme;
+  const int           query = 42;
+  t8_locidx_t         ielement;
+  t8_locidx_t         num_elements;
+  sc_array_t          queries;
+  sc_array_t          matched_leafs;
+
+  default_scheme = t8_scheme_new_default_cxx ();
+  /* Construct a cube coarse mesh */
+  cmesh = t8_cmesh_new_hypercube (eclass, comm, 0, 0, 0);
+  /* Build a uniform forest */
+  forest = t8_forest_new_uniform (cmesh, default_scheme, level, 0, comm);
+
+  /* set up a single query containing our query */
+  sc_array_init_size (&queries, sizeof (int), 1);
+  *(int *) sc_array_index (&queries, 0) = query;
+
+  num_elements = t8_forest_get_num_element (forest);
+  /* set up an array in which we flag whether an element was matched in the
+   * search */
+  sc_array_init_size (&matched_leafs, sizeof (int), num_elements);
+  /* write 0 in every entry */
+  for (ielement = 0; ielement < num_elements; ++ielement) {
+    *(int *) t8_sc_array_index_locidx (&matched_leafs, ielement) = 0;
+  }
+
+  /* Set the array as user data so that we can access it in the search callback */
+  t8_forest_set_user_data (forest, &matched_leafs);
+  /* Call search. This search matches all elements. After this call we expect
+   * all entries in the matched_leafs array to be set to 1. */
+  t8_forest_search (forest, t8_test_search_all_fn,
+                    t8_test_search_query_all_fn, &queries);
+
+  /* Check whether matched_leafs entries are all 1 */
+  for (ielement = 0; ielement < num_elements; ++ielement) {
+    SC_CHECK_ABORTF (*(int *)
+                     t8_sc_array_index_locidx (&matched_leafs, ielement) == 1,
+                     "Search did not match all leafs. First missmatch at leaf %i.",
+                     ielement);
+  }
+
+  t8_forest_unref (&forest);
+  sc_array_reset (&matched_leafs);
+  sc_array_reset (&queries);
+}
+
+int
+main (int argc, char **argv)
+{
+  int                 mpiret;
+  sc_MPI_Comm         mpic;
+  int                 ieclass;
+  int                 ilevel;
+  const int           maxlevel = 6;     /* the maximum refinement level to which we test */
+
+  mpiret = sc_MPI_Init (&argc, &argv);
+  SC_CHECK_MPI (mpiret);
+
+  mpic = sc_MPI_COMM_WORLD;
+  sc_init (mpic, 1, 1, NULL, SC_LP_PRODUCTION);
+  p4est_init (NULL, SC_LP_ESSENTIAL);
+  t8_init (SC_LP_DEFAULT);
+
+  for (ieclass = T8_ECLASS_VERTEX; ieclass < T8_ECLASS_COUNT; ieclass++) {
+    if (ieclass != T8_ECLASS_PYRAMID) {
+      /* TODO: does not work with pyramids yet */
+      for (ilevel = 0; ilevel <= maxlevel; ++ilevel) {
+        t8_global_productionf
+          ("Testing search that matches all with eclass %s, level %i\n",
+           t8_eclass_to_string[ieclass], ilevel);
+        t8_test_search_one_query_matches_all (mpic, (t8_eclass_t) ieclass,
+                                              ilevel);
+      }
+    }
+  }
+
+  sc_finalize ();
+
+  mpiret = sc_MPI_Finalize ();
+  SC_CHECK_MPI (mpiret);
+
+  return 0;
+}

--- a/test/t8_test_search.cxx
+++ b/test/t8_test_search.cxx
@@ -51,9 +51,9 @@ t8_test_search_all_fn (t8_forest_t forest,
     t8_locidx_t         tree_offset;
     t8_locidx_t         test_ltreeid;
     t8_element_t       *test_element;
-    t8_eclass_scheme_c *ts;
     t8_eclass_t         tree_class =
       t8_forest_get_tree_class (forest, ltreeid);
+    t8_eclass_scheme_c *ts;
     ts = t8_forest_get_eclass_scheme (forest, tree_class);
 
     tree_offset = t8_forest_get_tree_element_offset (forest, ltreeid);
@@ -94,6 +94,7 @@ t8_test_search_query_all_fn (t8_forest_t forest,
     t8_element_t       *test_element;
     t8_eclass_t         tree_class =
       t8_forest_get_tree_class (forest, ltreeid);
+    t8_eclass_scheme_c *ts;
     ts = t8_forest_get_eclass_scheme (forest, tree_class);
 
     tree_offset = t8_forest_get_tree_element_offset (forest, ltreeid);


### PR DESCRIPTION
We extend the forest_search with a set of queries and a query callback.
For all elements that match the element callback, the query callback is called with each active query.
Query for which this call returns 0 are deactivated for the next recursion step.
If all active queries return 0 on an element, the recursion does not continue.