### PR TITLE
Add a query index to the search callback.

### DIFF
--- a/src/t8_forest/t8_forest_ghost.cxx
+++ b/src/t8_forest/t8_forest_ghost.cxx
@@ -839,7 +839,8 @@ t8_forest_ghost_search_boundary (t8_forest_t forest, t8_locidx_t ltreeid,
                                  const t8_element_t * element,
                                  const int is_leaf,
                                  t8_element_array_t * leafs,
-                                 t8_locidx_t tree_leaf_index, void *query)
+                                 t8_locidx_t tree_leaf_index, void *query,
+                                 size_t query_index)
 {
   t8_forest_ghost_boundary_data_t *data =
     (t8_forest_ghost_boundary_data_t *) t8_forest_get_user_data (forest);

--- a/src/t8_forest/t8_forest_iterate.cxx
+++ b/src/t8_forest/t8_forest_iterate.cxx
@@ -246,7 +246,7 @@ t8_forest_search_recursion (t8_forest_t forest, t8_locidx_t ltreeid,
   }
   /* Call the callback function for the element */
   ret = search_fn (forest, ltreeid, element, is_leaf, leaf_elements,
-                   tree_lindex_of_first_leaf, NULL);
+                   tree_lindex_of_first_leaf, NULL, 0);
 
   if (!ret) {
     /* The function returned false. We abort the recursion */
@@ -267,7 +267,7 @@ t8_forest_search_recursion (t8_forest_t forest, t8_locidx_t ltreeid,
     current_query = sc_array_index (queries, query_index);
     query_ret =
       query_fn (forest, ltreeid, element, is_leaf, leaf_elements,
-                tree_lindex_of_first_leaf, current_query);
+                tree_lindex_of_first_leaf, current_query, query_index);
     if (!is_leaf && query_ret) {
       /* If element is not a leaf and this query returned true, we add this
        * query to the new active queries */

--- a/src/t8_forest/t8_forest_iterate.h
+++ b/src/t8_forest/t8_forest_iterate.h
@@ -50,6 +50,8 @@ typedef int         (*t8_forest_iterate_face_fn) (t8_forest_t forest,
  *                 (or the element itself if \a is_leaf is true)
  * tree_leaf_index the local index of the first leaf in \a leaf_elements
  * query           if not NULL, a query that is passed through from the search function
+ * query_index     if \a query is not NULL the index of \a query in the queries array from
+ *                 \ref t8_forest_search
  *
  * return          if \a query is not NULL: true if and only if the element 'matches' the query
  *                 if \a query is NULL: true if and only if the search should continue withe the
@@ -64,7 +66,8 @@ typedef int         (*t8_forest_search_query_fn) (t8_forest_t forest,
                                                   leaf_elements,
                                                   t8_locidx_t
                                                   tree_leaf_index,
-                                                  void *query);
+                                                  void *query,
+                                                  size_t query_index);
 
 T8_EXTERN_C_BEGIN ();
 

--- a/test/t8_test_search.cxx
+++ b/test/t8_test_search.cxx
@@ -40,7 +40,8 @@ t8_test_search_all_fn (t8_forest_t forest,
                        const int is_leaf,
                        t8_element_array_t *
                        leaf_elements,
-                       t8_locidx_t tree_leaf_index, void *query)
+                       t8_locidx_t tree_leaf_index, void *query,
+                       size_t query_index)
 {
   SC_CHECK_ABORT (query == NULL,
                   "Search callback must not be called with query argument.");

--- a/test/t8_test_search.cxx
+++ b/test/t8_test_search.cxx
@@ -79,7 +79,8 @@ t8_test_search_query_all_fn (t8_forest_t forest,
                              const int is_leaf,
                              t8_element_array_t *
                              leaf_elements,
-                             t8_locidx_t tree_leaf_index, void *query)
+                             t8_locidx_t tree_leaf_index, void *query,
+                             size_t query_index)
 {
   /* The query callback is allways called with a query */
   SC_CHECK_ABORT (query != NULL,
@@ -87,6 +88,11 @@ t8_test_search_query_all_fn (t8_forest_t forest,
   /* The query is an int with value 42 (see below) */
   SC_CHECK_ABORT (*(int *) query == 42,
                   "Wrong query argument passed to query callback.");
+  /* The query index gives the position of the query in the queries array
+   * of the calling search forest_search. Since there is only one query in the
+   * array in this test, the index must always be 0. */
+  SC_CHECK_ABORT (query_index == 0,
+                  "Wrong query index passed to query callback.");
   if (is_leaf) {
     /* Test whether tree_leaf_index is actually the index of the element */
     t8_locidx_t         tree_offset;


### PR DESCRIPTION
The search callback gets as additional information
the index of the query in the global queries array.
This allows us easily to identify the current query.
An example usage would be to pass an array of lenght
number of queries as user pointer and store the matching
elements for each query and the correct position in
this array.