### PR TITLE
Feature cmesh face info getter

### DIFF
--- a/src/t8_cmesh.h
+++ b/src/t8_cmesh.h
@@ -532,6 +532,26 @@ t8_gloidx_t         t8_cmesh_get_global_id (t8_cmesh_t cmesh,
 t8_locidx_t         t8_cmesh_get_local_id (t8_cmesh_t cmesh,
                                            t8_gloidx_t global_id);
 
+/** Given a local tree id and a face number, get information about the face neighbor tree.
+ * \param [in]      cmesh     The cmesh to be considered.
+ * \param [in]      ltreeid   The local id of a tree or a ghost.
+ * \param [in]      face      A face number of the tree/ghost.
+ * \param [out]     dual_face If not NULL, the face number of the neighbor tree at this connection.
+ * \param [out]     orientation If not NULL, the face orientation of the connection.
+ * \return                    If non-negative: The local id of the neighbor tree or ghost.
+ *                            If negative: There is no neighbor across this face. \a dual_face and
+ *                            \a orientation remain unchanged.
+ * \note If \a ltreeid is a ghost and it has a neighbor which is neither a local tree or ghost,
+ *       then the return value will be negative.
+ *       This, a negative return value does not necessarily mean that this is a domain boundary.
+ *       To find out whether a tree is a domain boundary or not \see t8_cmesh_tree_face_is_boundary.
+ */
+t8_locidx_t         t8_cmesh_get_face_neighbor (const t8_cmesh_t cmesh,
+                                                const t8_locidx_t ltreeid,
+                                                const int face,
+                                                int *dual_face,
+                                                int *orientation);
+
 /** Print the collected statistics from a cmesh profile.
  * \param [in]    cmesh         The cmesh.
  *

--- a/src/t8_cmesh.h
+++ b/src/t8_cmesh.h
@@ -516,7 +516,7 @@ t8_ctree_t          t8_cmesh_get_tree (t8_cmesh_t cmesh,
 t8_eclass_t         t8_cmesh_get_tree_class (t8_cmesh_t cmesh,
                                              t8_locidx_t ltree_id);
 
-/** Query whether a face of a local tree is at the domain boundary.
+/** Query whether a face of a local tree or ghost is at the domain boundary.
  * \param [in]    cmesh         The cmesh to be considered.
  * \param [in]    ltree_id       The local id of a tree.
  * \param [in]    face          The number of a face of the tree.
@@ -527,7 +527,6 @@ t8_eclass_t         t8_cmesh_get_tree_class (t8_cmesh_t cmesh,
 int                 t8_cmesh_tree_face_is_boundary (t8_cmesh_t cmesh,
                                                     t8_locidx_t ltree_id,
                                                     int face);
-/* TODO: Add a t8_cmesh_tree_face_is_boundary function for ghosts (or make the function work for ghosts too) */
 
 /** Return the eclass of a given local ghost.
  * TODO: Should we refer to indices or consequently use cghost_t?

--- a/src/t8_cmesh.h
+++ b/src/t8_cmesh.h
@@ -574,7 +574,7 @@ t8_locidx_t         t8_cmesh_get_local_id (t8_cmesh_t cmesh,
  *                            \a orientation remain unchanged.
  * \note If \a ltreeid is a ghost and it has a neighbor which is neither a local tree or ghost,
  *       then the return value will be negative.
- *       This, a negative return value does not necessarily mean that this is a domain boundary.
+ *       Thus, a negative return value does not necessarily mean that this is a domain boundary.
  *       To find out whether a tree is a domain boundary or not \see t8_cmesh_tree_face_is_boundary.
  */
 t8_locidx_t         t8_cmesh_get_face_neighbor (const t8_cmesh_t cmesh,

--- a/src/t8_cmesh.h
+++ b/src/t8_cmesh.h
@@ -496,6 +496,7 @@ t8_eclass_t         t8_cmesh_get_tree_class (t8_cmesh_t cmesh,
 int                 t8_cmesh_tree_face_is_boundary (t8_cmesh_t cmesh,
                                                     t8_locidx_t ltree_id,
                                                     int face);
+/* TODO: Add a t8_cmesh_tree_face_is_boundary function for ghosts (or make the function work for ghosts too) */
 
 /** Return the eclass of a given local ghost.
  * TODO: Should we refer to indices or consequently use cghost_t?

--- a/src/t8_cmesh.h
+++ b/src/t8_cmesh.h
@@ -438,6 +438,37 @@ t8_locidx_t         t8_cmesh_get_num_ghosts (t8_cmesh_t cmesh);
  */
 t8_gloidx_t         t8_cmesh_get_first_treeid (t8_cmesh_t cmesh);
 
+/** Query whether a given t8_locidx_t belongs to a local tree of a cmesh.
+ * \param [in] cmesh       The cmesh to be considered.
+ * \param [in] ltreeid     An (possible) tree index.
+ * \return                 True if \a ltreeid matches the range of local trees of \a cmesh.
+ *                         False if not.
+ * \a cmesh must be committed before calling this function.
+ */
+int                 t8_cmesh_treeid_is_local_tree (const t8_cmesh_t cmesh,
+                                                   const t8_locidx_t ltreeid);
+
+/** Query whether a given t8_locidx_t belongs to a ghost of a cmesh.
+ * \param [in] cmesh       The cmesh to be considered.
+ * \param [in] ltreeid     An (possible) ghost index.
+ * \return                 True if \a ltreeid matches the range of ghost trees of \a cmesh.
+ *                         False if not.
+ * \a cmesh must be committed before calling this function.
+ */
+int                 t8_cmesh_treeid_is_ghost (const t8_cmesh_t cmesh,
+                                              const t8_locidx_t ltreeid);
+
+/** Given a local tree id that belongs to a ghost, return the index of the ghost.
+ * \param [in] cmesh       The cmesh to be considered.
+ * \param [in] ltreeid     The local id of a ghost, satisfying \ref t8_cmesh_treeid_is_ghost,
+ *                         thus num_trees <= \a ltreeid < num_trees + num_ghosts
+ * \return                 The index of the ghost whithin all ghosts, thus an index
+ *                         0 <= index < num_ghosts
+ * \a cmesh must be committed before calling this function.
+ */
+t8_locidx_t         t8_cmesh_ltreeid_to_ghostid (const t8_cmesh_t cmesh,
+                                                 const t8_locidx_t ltreeid);
+
 /* TODO: Replace this iterator with a new one that does not need the
  *        treeid to be part of the ctree struct */
 /* TODO: should this and the next function be part of the interface? */

--- a/src/t8_cmesh/t8_cmesh.c
+++ b/src/t8_cmesh/t8_cmesh.c
@@ -1298,6 +1298,11 @@ t8_cmesh_get_face_neighbor (const t8_cmesh_t cmesh, const t8_locidx_t ltreeid,
   t8_locidx_t         face_neigh;
   int                 dual_face_temp, orientation_temp;
 
+  /* If this is a domain boundary, return -1 */
+  if (t8_cmesh_tree_face_is_boundary (cmesh, ltreeid, face)) {
+    return -1;
+  }
+
   if (!is_ghost) {
     /* The local tree id belongs to a local tree (not a ghost) */
     /* Get the tree */
@@ -1310,10 +1315,6 @@ t8_cmesh_get_face_neighbor (const t8_cmesh_t cmesh, const t8_locidx_t ltreeid,
     T8_ASSERT (0 <= face && face < t8_eclass_num_faces[eclass]);
 #endif
 
-    /* If this is a domain boundary, return -1 */
-    if (t8_cmesh_tree_face_is_boundary (cmesh, ltreeid, face)) {
-      return -1;
-    }
     /* Get the local id of the face neighbor */
     face_neigh = t8_cmesh_trees_get_face_neighbor_ext (tree, face, &ttf);
   }
@@ -1325,7 +1326,8 @@ t8_cmesh_get_face_neighbor (const t8_cmesh_t cmesh, const t8_locidx_t ltreeid,
     const t8_cghost_t   ghost =
       t8_cmesh_trees_get_ghost (cmesh->trees, lghostid);
 
-    t8_gloidx_t         ghost_face_neigh;
+    t8_gloidx_t         global_face_neigh;
+
 #ifdef T8_ENABLE_DEBUG
     /* Get the eclass */
     t8_eclass_t         eclass = ghost->eclass;
@@ -1334,10 +1336,10 @@ t8_cmesh_get_face_neighbor (const t8_cmesh_t cmesh, const t8_locidx_t ltreeid,
 #endif
 
     /* Get the global id of the face neighbor */
-    ghost_face_neigh =
+    global_face_neigh =
       t8_cmesh_trees_get_ghost_face_neighbor_ext (ghost, face, &ttf);
     /* Convert it into a local id */
-    face_neigh = t8_cmesh_get_local_id (cmesh, ghost_face_neigh);
+    face_neigh = t8_cmesh_get_local_id (cmesh, global_face_neigh);
 
     /* TODO: Check whether this face is a boundary face */
     if (face_neigh < 0) {

--- a/src/t8_cmesh/t8_cmesh.c
+++ b/src/t8_cmesh/t8_cmesh.c
@@ -1260,7 +1260,9 @@ t8_cmesh_get_local_id (t8_cmesh_t cmesh, t8_gloidx_t global_id)
     return global_id;
   }
   temp_local_id = global_id - cmesh->first_tree;
-  if (0 <= temp_local_id && temp_local_id < cmesh->num_local_trees) {
+  /* Check that we do not get wrong numbers when converting to locidx */
+  T8_ASSERT ((t8_locidx_t) temp_local_id == temp_local_id);
+  if (t8_cmesh_treeid_is_local_tree (cmesh, temp_local_id)) {
     /* The tree is a local tree */
     return temp_local_id;
   }

--- a/src/t8_cmesh/t8_cmesh.c
+++ b/src/t8_cmesh/t8_cmesh.c
@@ -327,12 +327,10 @@ t8_cmesh_set_partition_range (t8_cmesh_t cmesh, int set_face_knowledge,
     cmesh->first_tree = first_local_tree;
     cmesh->first_tree_shared = 0;
   }
-  cmesh->num_local_trees = last_local_tree - first_local_tree + 1;
+  cmesh->num_local_trees = last_local_tree - cmesh->first_tree + 1;
   cmesh->set_partition = 1;
   /* Overwrite previous partition settings */
   if (cmesh->tree_offsets != NULL) {
-    cmesh->first_tree = -1;
-    cmesh->first_tree_shared = -1;
     t8_shmem_array_destroy (&cmesh->tree_offsets);
     cmesh->tree_offsets = NULL;
   }

--- a/src/t8_cmesh/t8_cmesh.c
+++ b/src/t8_cmesh/t8_cmesh.c
@@ -1290,6 +1290,7 @@ t8_cmesh_get_face_neighbor (const t8_cmesh_t cmesh, const t8_locidx_t ltreeid,
     /* Convert it into a local id */
     face_neigh = t8_cmesh_get_local_id (cmesh, ghost_face_neigh);
 
+    /* TODO: Check whether this face is a boundary face */
     if (face_neigh < 0) {
       /* The neighbor is not local, return -1 */
       return -1;

--- a/src/t8_cmesh/t8_cmesh_commit.c
+++ b/src/t8_cmesh/t8_cmesh_commit.c
@@ -171,9 +171,15 @@ t8_cmesh_commit_replicated_new (t8_cmesh_t cmesh)
       (void) t8_cmesh_trees_get_tree_ext (cmesh->trees, joinface->id2,
                                           &face_neigh2, &ttf2);
       face_neigh[joinface->face1] = (t8_locidx_t) joinface->id2;
-      ttf[joinface->face1] = joinface->orientation * F + joinface->face2;
+      ttf[joinface->face1] =
+        t8_cmesh_tree_to_face_encode (cmesh->dimension,
+                                      (t8_locidx_t) joinface->face2,
+                                      joinface->orientation);
       face_neigh2[joinface->face2] = (t8_locidx_t) joinface->id1;
-      ttf2[joinface->face2] = joinface->orientation * F + joinface->face1;
+      ttf2[joinface->face2] =
+        t8_cmesh_tree_to_face_encode (cmesh->dimension,
+                                      (t8_locidx_t) joinface->face1,
+                                      joinface->orientation);
     }
   }
 }

--- a/src/t8_cmesh/t8_cmesh_commit.c
+++ b/src/t8_cmesh/t8_cmesh_commit.c
@@ -507,6 +507,13 @@ t8_cmesh_commit_partitioned_new (t8_cmesh_t cmesh, sc_MPI_Comm comm)
   sc_mempool_destroy (ghost_facejoin_mempool);
 
   id1 = cmesh->num_local_trees;
+  /* We must not count shared trees. Thus, we subtract one if
+   * the first tree is shared. However, we exclude the case where
+   * this cmesh has no trees but nevertheless the first tree is marked
+   * as shared. */
+  if (cmesh->first_tree_shared && id1 > 0) {
+    id1--;
+  }
   sc_MPI_Allreduce (&id1, &cmesh->num_trees, 1, T8_MPI_GLOIDX,
                     sc_MPI_SUM, comm);
 

--- a/src/t8_cmesh/t8_cmesh_commit.c
+++ b/src/t8_cmesh/t8_cmesh_commit.c
@@ -118,7 +118,6 @@ t8_cmesh_commit_replicated_new (t8_cmesh_t cmesh)
   int8_t             *ttf, *ttf2;
   t8_stash_joinface_struct_t *joinface;
   t8_ctree_t          tree1;
-  int                 F;
   size_t              si;
 
   if (cmesh->stash != NULL && cmesh->stash->classes.elem_count > 0) {
@@ -165,11 +164,11 @@ t8_cmesh_commit_replicated_new (t8_cmesh_t cmesh)
     for (si = 0; si < cmesh->stash->joinfaces.elem_count; si++) {
       joinface = (t8_stash_joinface_struct_t *)
         sc_array_index (&cmesh->stash->joinfaces, si);
-      F = t8_eclass_max_num_faces[cmesh->dimension];
       (void) t8_cmesh_trees_get_tree_ext (cmesh->trees, joinface->id1,
                                           &face_neigh, &ttf);
       (void) t8_cmesh_trees_get_tree_ext (cmesh->trees, joinface->id2,
                                           &face_neigh2, &ttf2);
+      /* Set the correct face neighbors and tree_fo_face values */
       face_neigh[joinface->face1] = (t8_locidx_t) joinface->id2;
       ttf[joinface->face1] =
         t8_cmesh_tree_to_face_encode (cmesh->dimension,

--- a/src/t8_cmesh/t8_cmesh_trees.c
+++ b/src/t8_cmesh/t8_cmesh_trees.c
@@ -818,6 +818,53 @@ t8_cmesh_trees_get_numproc (t8_cmesh_trees_t trees)
   return trees->from_proc->elem_count;
 }
 
+/* Compute the tree-to-face information given a face and orientation value
+ *  of a face connection.
+ * \param [in]        dimension The dimension of the corresponding eclasses.
+ * \param [in]        face      A face number
+ * \param [in]        orientation A face-to-face orientation.
+ * \return            The tree-to-face entry corresponding to the face/orientation combination.
+ * It is computed as t8_eclass_max_num_faces[dimension] * orientation + face
+ */
+int8_t
+t8_cmesh_tree_to_face_encode (const int dimension, const t8_locidx_t face,
+                              const int orientation)
+{
+  const int           F = t8_eclass_max_num_faces[dimension];
+
+  /* Check that face is valid */
+  T8_ASSERT (0 <= face && face < F);
+  /* Check for overflow error */
+  T8_ASSERT ((int) orientation * F + face ==
+             (int8_t) (orientation * F + face));
+
+  /* Compute and return the tree to face value */
+  return orientation * F + face;
+}
+
+/* Given a tree-to-face value, get its encoded face number and orientation.
+ * \param [in]        dimension The dimension of the corresponding eclasses.
+ * \param [in]        tree_to_face A tree-to-face value
+ * \param [out]       face      On output filled with the stored face value.
+ * \param [out]       orientation On output filled with the stored orientation value.
+ * \note This function is the invers operation of \ref t8_cmesh_tree_to_face_encode
+ * If F = t8_eclass_max_num_faces[dimension], we get
+ *  orientation = tree_to_face / F
+ *  face = tree_to_face % F
+ */
+void
+t8_cmesh_tree_to_face_decode (const int dimension, const int8_t tree_to_face,
+                              int *face, int *orientation)
+{
+  T8_ASSERT (face != NULL);
+  T8_ASSERT (orientation != NULL);
+  const int           F = t8_eclass_max_num_faces[dimension];
+
+  /* Performs the inverse operation to tree_to_face = orientation * F + face */
+  *face = tree_to_face % F;
+  *orientation = tree_to_face / F;
+}
+
 void
 t8_cmesh_trees_print (t8_cmesh_t cmesh, t8_cmesh_trees_t trees)
 {

--- a/src/t8_cmesh/t8_cmesh_trees.c
+++ b/src/t8_cmesh/t8_cmesh_trees.c
@@ -498,14 +498,47 @@ t8_cmesh_trees_get_tree_ext (t8_cmesh_trees_t trees, t8_locidx_t ltree_id,
 }
 
 t8_locidx_t
-t8_cmesh_trees_get_face_neighbor (t8_ctree_t tree, int face)
+t8_cmesh_trees_get_face_neighbor_ext (const t8_ctree_t tree, const int face,
+                                      int8_t * ttf)
 {
   t8_locidx_t        *face_neighbors;
 
   T8_ASSERT (tree != NULL);
   T8_ASSERT (0 <= face && face < t8_eclass_num_faces[tree->eclass]);
 
+  if (ttf != NULL) {
+    /* Get the ttf value */
+    *ttf = ((int8_t *) T8_TREE_TTF (tree))[face];
+  }
+
+  /* Gt the face neighbor array */
   face_neighbors = (t8_locidx_t *) T8_TREE_FACE (tree);
+  return face_neighbors[face];
+}
+
+t8_locidx_t
+t8_cmesh_trees_get_face_neighbor (const t8_ctree_t tree, const int face)
+{
+  /* We just pass this through to get_face_neighbor_ext without the ttf argument */
+  t8_cmesh_trees_get_face_neighbor_ext (tree, face, NULL);
+}
+
+t8_gloidx_t
+t8_cmesh_trees_get_ghost_face_neighbor_ext (const t8_cghost_t ghost,
+                                            const int face, int8_t * ttf)
+{
+  t8_locidx_t        *face_neighbors;
+
+  T8_ASSERT (ghost != NULL);
+  T8_ASSERT (0 <= face && face < t8_eclass_num_faces[ghost->eclass]);
+
+  if (ttf != NULL) {
+    /* Get the ttf value */
+    *ttf = ((int8_t *) T8_GHOST_TTF (ghost))[face];
+  }
+
+  /* Gt the face neighbor array */
+  face_neighbors = (t8_locidx_t *) T8_GHOST_FACE (ghost);
   return face_neighbors[face];
 }
 

--- a/src/t8_cmesh/t8_cmesh_trees.c
+++ b/src/t8_cmesh/t8_cmesh_trees.c
@@ -527,7 +527,7 @@ t8_gloidx_t
 t8_cmesh_trees_get_ghost_face_neighbor_ext (const t8_cghost_t ghost,
                                             const int face, int8_t * ttf)
 {
-  t8_locidx_t        *face_neighbors;
+  t8_gloidx_t        *face_neighbors;
 
   T8_ASSERT (ghost != NULL);
   T8_ASSERT (0 <= face && face < t8_eclass_num_faces[ghost->eclass]);
@@ -538,7 +538,7 @@ t8_cmesh_trees_get_ghost_face_neighbor_ext (const t8_cghost_t ghost,
   }
 
   /* Gt the face neighbor array */
-  face_neighbors = (t8_locidx_t *) T8_GHOST_FACE (ghost);
+  face_neighbors = (t8_gloidx_t *) T8_GHOST_FACE (ghost);
   return face_neighbors[face];
 }
 

--- a/src/t8_cmesh/t8_cmesh_trees.h
+++ b/src/t8_cmesh/t8_cmesh_trees.h
@@ -322,12 +322,49 @@ t8_ctree_t          t8_cmesh_trees_get_tree_ext (t8_cmesh_trees_t trees,
                                                  t8_locidx_t ** face_neigh,
                                                  int8_t ** ttf);
 
+/** Return the face neigbor of a tree at a given face and return the tree_to_face info
+ * \param [in]      trees The trees structure where the tree is to be looked up.
+ * \param [in]      ltreeid  The local id of the tree.
+ * \param [in]      face  A face of the tree.
+ * \param [out]     ttf   If not NULL the tree_to_face value of the face connection.
+ * \return          The face neighbor that is stored for this face
+ */
+t8_locidx_t         t8_cmesh_trees_get_face_info (t8_cmesh_trees_t trees,
+                                                  t8_locidx_t ltreeid,
+                                                  int face, int8_t * ttf);
+
 /** Given a coarse tree and a face number, return the local id of the neighbor tree.
  * \param [in]      tree.     The coarse tree.
  * \param [in]      face.     The face number.
  * \return                    The local id of the neighbor tree. */
-t8_locidx_t         t8_cmesh_trees_get_face_neighbor (t8_ctree_t tree,
-                                                      int face);
+t8_locidx_t         t8_cmesh_trees_get_face_neighbor (const t8_ctree_t tree,
+                                                      const int face);
+
+/** Given a coarse tree and a face number, return the local id of the neighbor tree
+ * together with its tree-to-face info.
+ * \param [in]   tree         The coarse tree.
+ * \param [in]   face         The face number.
+ * \param [out]  ttf          If not NULL it is filled with the tree-to-face value
+ *                            for this face.
+ * \return                    The local id of the neighbor tree. */
+t8_locidx_t         t8_cmesh_trees_get_face_neighbor_ext (const t8_ctree_t
+                                                          tree,
+                                                          const int face,
+                                                          int8_t * ttf);
+
+/** Given a coarse ghost and a face number, return the local id of the neighbor tree
+ * together with its tree-to-face info.
+ * \param [in]   ghost        The coarse ghost.
+ * \param [in]   face         The face number.
+ * \param [out]  ttf          If not NULL it is filled with the tree-to-face value
+ *                            for this face.
+ * \return                    The global id of the neighbor tree. */
+t8_gloidx_t         t8_cmesh_trees_get_ghost_face_neighbor_ext (const
+                                                                t8_cghost_t
+                                                                ghost,
+                                                                const int
+                                                                face,
+                                                                int8_t * ttf);
 
 /* TODO: This function return NULL if the ghost is not present.
  *       So far no error checking is done here. */

--- a/src/t8_cmesh/t8_cmesh_trees.h
+++ b/src/t8_cmesh/t8_cmesh_trees.h
@@ -309,7 +309,7 @@ t8_ctree_t          t8_cmesh_trees_get_tree (t8_cmesh_trees_t trees,
 
 /** Return a pointer to a specific tree in a trees struct plus pointers to
  * its face_neighbor and tree_to_face arrays.
- * \param [in]      trees The tress structure where the tree is to be looked up.
+ * \param [in]      trees The trees structure where the tree is to be looked up.
  * \param [in]      ltree_id  The local id of the tree.
  * \param [out]     face_neigh If not NULL a pointer to the trees face_neighbor
  *                             array is stored here on return.

--- a/src/t8_cmesh/t8_cmesh_trees.h
+++ b/src/t8_cmesh/t8_cmesh_trees.h
@@ -442,6 +442,33 @@ void                t8_cmesh_trees_add_attribute (t8_cmesh_trees_t trees,
  */
 size_t              t8_cmesh_trees_get_numproc (t8_cmesh_trees_t trees);
 
+/** Compute the tree-to-face information given a face and orientation value
+ *  of a face connection.
+ * \param [in]        dimension The dimension of the corresponding eclasses.
+ * \param [in]        face      A face number
+ * \param [in]        orientation A face-to-face orientation.
+ * \return            The tree-to-face entry corresponding to the face/orientation combination.
+ * It is computed as t8_eclass_max_num_faces[dimension] * orientation + face
+ */
+int8_t              t8_cmesh_tree_to_face_encode (const int dimension,
+                                                  const t8_locidx_t face,
+                                                  const int orientation);
+
+/** Given a tree-to-face value, get its encoded face number and orientation.
+ * \param [in]        dimension The dimension of the corresponding eclasses.
+ * \param [in]        tree_to_face A tree-to-face value
+ * \param [out]       face      On output filled with the stored face value.
+ * \param [out]       orientation On output filled with the stored orientation value.
+ * \note This function is the invers operation of \ref t8_cmesh_tree_to_face_encode
+ * If F = t8_eclass_max_num_faces[dimension], we get
+ *  orientation = tree_to_face / F
+ *  face = tree_to_face % F
+ */
+void                t8_cmesh_tree_to_face_decode (const int dimension,
+                                                  const int8_t tree_to_face,
+                                                  int *face,
+                                                  int *orientation);
+
 /* TODO: To fit to the interface a trees struct is given as parameter here,
  *       however we could just take the one associated to the cmesh given.*/
 /** Print the trees,ghosts and their neighbors in ASCII format t stdout.

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -14,9 +14,10 @@ t8code_test_programs = \
 	test/t8_test_forest_commit \
 	test/t8_test_transform \
 	test/t8_test_half_neighbors \
-  test/t8_test_element_count_leafs \
-  test/t8_test_search \
-    test/t8_test_find_parent
+	test/t8_test_element_count_leafs \
+	test/t8_test_search \
+	test/t8_test_find_parent \
+	test/t8_test_cmesh_face_is_boundary
 
 test_t8_test_eclass_SOURCES = test/t8_test_eclass.c
 test_t8_test_bcast_SOURCES = test/t8_test_bcast.c
@@ -32,6 +33,7 @@ test_t8_test_half_neighbors_SOURCES = test/t8_test_half_neighbors.cxx
 test_t8_test_element_count_leafs_SOURCES = test/t8_test_element_count_leafs.cxx
 test_t8_test_search_SOURCES = test/t8_test_search.cxx
 test_t8_test_find_parent_SOURCES = test/t8_test_find_parent.cpp
+test_t8_test_cmesh_face_is_boundary_SOURCES = test/t8_test_cmesh_face_is_boundary.cxx
 
 TESTS += $(t8code_test_programs)
 check_PROGRAMS += $(t8code_test_programs)

--- a/test/t8_test_cmesh_face_is_boundary.cxx
+++ b/test/t8_test_cmesh_face_is_boundary.cxx
@@ -26,7 +26,7 @@
 /* Createsa coarse mesh with one tree for each eclass, where each
  * face is a boundary face. */
 static void
-t8_test_face_is_boundary_one_tree (sc_MPI_Comm mpic)
+t8_test_face_is_boundary_one_tree (sc_MPI_Comm comm)
 {
   int                 eci;
   int                 num_faces, iface;
@@ -35,7 +35,7 @@ t8_test_face_is_boundary_one_tree (sc_MPI_Comm mpic)
   for (eci = T8_ECLASS_ZERO; eci < T8_ECLASS_COUNT; ++eci) {
     /* For each eclass create a cmesh consisting only of one tree.
      * We then check whether all faces of this tree are a boundary face. */
-    cmesh = t8_cmesh_new_from_class ((t8_eclass_t) eci, mpic);
+    cmesh = t8_cmesh_new_from_class ((t8_eclass_t) eci, comm);
     SC_CHECK_ABORT (t8_cmesh_is_committed (cmesh), "Cmesh commit failed.");
     /* We now check each face */
     num_faces = t8_eclass_num_faces[eci];

--- a/test/t8_test_cmesh_face_is_boundary.cxx
+++ b/test/t8_test_cmesh_face_is_boundary.cxx
@@ -1,0 +1,119 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element types in parallel.
+
+  Copyright (C) 2010 The University of Texas System
+  Written by Carsten Burstedde, Lucas C. Wilcox, and Tobin Isaac
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+#include <t8_cmesh.h>
+
+/* Createsa coarse mesh with one tree for each eclass, where each
+ * face is a boundary face. */
+static void
+t8_test_face_is_boundary_one_tree (sc_MPI_Comm mpic)
+{
+  int                 eci;
+  int                 num_faces, iface;
+  t8_cmesh_t          cmesh;
+
+  for (eci = T8_ECLASS_ZERO; eci < T8_ECLASS_COUNT; ++eci) {
+    /* For each eclass create a cmesh consisting only of one tree.
+     * We then check whether all faces of this tree are a boundary face. */
+    cmesh = t8_cmesh_new_from_class ((t8_eclass_t) eci, mpic);
+    SC_CHECK_ABORT (t8_cmesh_is_committed (cmesh), "Cmesh commit failed.");
+    /* We now check each face */
+    num_faces = t8_eclass_num_faces[eci];
+    for (iface = 0; iface < num_faces; ++iface) {
+      SC_CHECK_ABORT (t8_cmesh_tree_face_is_boundary (cmesh, 0, iface),
+                      "Face is not detected as a boundary.");
+    }
+
+    t8_cmesh_destroy (&cmesh);
+  }
+}
+
+/* Creates coarse meshes with two trees for each eclass,
+ * one for each face of the first tree as the connecting face.
+ * This, only the remaining trees should register as boundary trees. */
+static void
+t8_test_face_is_boundary_two_tree (sc_MPI_Comm mpic)
+{
+  int                 eci;
+  int                 num_faces, iface, checkface;
+  t8_cmesh_t          cmesh;
+
+  for (eci = T8_ECLASS_LINE; eci < T8_ECLASS_COUNT; ++eci) {
+    num_faces = t8_eclass_num_faces[eci];
+    for (iface = 0; iface < num_faces; ++iface) {
+      /* For each face of the eclass we construct one cmesh having
+       * this face as a connecting face. */
+      t8_cmesh_init (&cmesh);
+      t8_cmesh_set_tree_class (cmesh, 0, (t8_eclass_t) eci);
+      t8_cmesh_set_tree_class (cmesh, 1, (t8_eclass_t) eci);
+      /* Connect face iface of tree 0 with face iface of tree 1 with orientation 0 */
+      t8_cmesh_set_join (cmesh, 0, 1, iface, iface, 0);
+      t8_cmesh_commit (cmesh, mpic);
+      SC_CHECK_ABORT (t8_cmesh_is_committed (cmesh), "Cmesh commit failed.");
+      for (checkface = 0; checkface < num_faces; ++checkface) {
+        if (iface != checkface) {
+          SC_CHECK_ABORT (t8_cmesh_tree_face_is_boundary
+                          (cmesh, 0, checkface),
+                          "Face is not detected as a boundary.");
+          SC_CHECK_ABORT (t8_cmesh_tree_face_is_boundary
+                          (cmesh, 1, checkface),
+                          "Face is not detected as a boundary.");
+        }
+        else {
+          SC_CHECK_ABORT (!t8_cmesh_tree_face_is_boundary
+                          (cmesh, 0, checkface),
+                          "Face is wrongly detected as a boundary.");
+          SC_CHECK_ABORT (!t8_cmesh_tree_face_is_boundary
+                          (cmesh, 1, checkface),
+                          "Face is wrongly detected as a boundary.");
+        }
+      }
+      t8_cmesh_destroy (&cmesh);
+    }
+  }
+}
+
+int
+main (int argc, char **argv)
+{
+  int                 mpiret;
+  sc_MPI_Comm         mpic;
+
+  mpiret = sc_MPI_Init (&argc, &argv);
+  SC_CHECK_MPI (mpiret);
+
+  mpic = sc_MPI_COMM_WORLD;
+  sc_init (mpic, 1, 1, NULL, SC_LP_PRODUCTION);
+  p4est_init (NULL, SC_LP_ESSENTIAL);
+  t8_init (SC_LP_DEFAULT);
+
+  t8_test_face_is_boundary_one_tree (mpic);
+  t8_test_face_is_boundary_two_tree (mpic);
+
+  sc_finalize ();
+
+  mpiret = sc_MPI_Finalize ();
+  SC_CHECK_MPI (mpiret);
+
+  return 0;
+}

--- a/test/t8_test_cmesh_face_is_boundary.cxx
+++ b/test/t8_test_cmesh_face_is_boundary.cxx
@@ -48,16 +48,57 @@ t8_test_face_is_boundary_one_tree (sc_MPI_Comm comm)
   }
 }
 
+/* For a two tree cmesh, compute a parallel distribution of the trees.
+ * If we have more than 1 process, the first half of process (rank < size/2)
+ * gets tree 0, the other half gets tree 1. */
+static void
+t8_test_compute_parallel_bounds (sc_MPI_Comm comm, t8_gloidx_t * first_tree,
+                                 t8_gloidx_t * last_tree)
+{
+  int                 mpirank, mpisize, mpiret;
+  int                 num_lower_half, num_upper_half;
+  int                 first_tree_shared = 0;
+
+  mpiret = sc_MPI_Comm_rank (comm, &mpirank);
+  SC_CHECK_MPI (mpiret);
+  mpiret = sc_MPI_Comm_size (comm, &mpisize);
+  SC_CHECK_MPI (mpiret);
+
+  /* If only one process, it gets all trees */
+  if (mpisize == 1) {
+    *first_tree = 0;
+    *last_tree = 1;
+    return;
+  }
+  /* First half of processes gets tree 0, other half gets tree 1 */
+  if (mpirank < mpisize / 2) {
+    /* The first tree is shared if this rank is in the lower half, but not rank 0 */
+    first_tree_shared = mpirank > 0;
+    /* The first tree is 0 */
+    *first_tree = first_tree_shared ? -1 : 0;
+    *last_tree = 0;
+  }
+  else {
+    /* The first tree is shared if this process is not mpisize/2 */
+    first_tree_shared = mpirank > mpisize / 2;
+    /* The first tree is 1 */
+    *first_tree = first_tree_shared ? -2 : 1;
+    *last_tree = 1;
+  }
+}
+
 /* Creates coarse meshes with two trees for each eclass,
  * one for each face of the first tree as the connecting face.
  * This, only the remaining trees should register as boundary trees. */
 static void
-t8_test_face_is_boundary_two_tree (sc_MPI_Comm mpic)
+t8_test_face_is_boundary_two_tree (sc_MPI_Comm comm)
 {
   int                 eci;
   int                 num_faces, iface, checkface;
   t8_cmesh_t          cmesh;
+  t8_gloidx_t         first_tree, last_tree;
 
+  t8_test_compute_parallel_bounds (comm, &first_tree, &last_tree);
   for (eci = T8_ECLASS_LINE; eci < T8_ECLASS_COUNT; ++eci) {
     num_faces = t8_eclass_num_faces[eci];
     for (iface = 0; iface < num_faces; ++iface) {
@@ -68,7 +109,10 @@ t8_test_face_is_boundary_two_tree (sc_MPI_Comm mpic)
       t8_cmesh_set_tree_class (cmesh, 1, (t8_eclass_t) eci);
       /* Connect face iface of tree 0 with face iface of tree 1 with orientation 0 */
       t8_cmesh_set_join (cmesh, 0, 1, iface, iface, 0);
-      t8_cmesh_commit (cmesh, mpic);
+      /* Set the cmesh to be partitioned.
+       * We do it in such a way that each process has one local and one ghost tree. */
+      t8_cmesh_set_partition_range (cmesh, 3, first_tree, last_tree);
+      t8_cmesh_commit (cmesh, comm);
       SC_CHECK_ABORT (t8_cmesh_is_committed (cmesh), "Cmesh commit failed.");
       for (checkface = 0; checkface < num_faces; ++checkface) {
         if (iface != checkface) {
@@ -97,18 +141,18 @@ int
 main (int argc, char **argv)
 {
   int                 mpiret;
-  sc_MPI_Comm         mpic;
+  sc_MPI_Comm         comm;
 
   mpiret = sc_MPI_Init (&argc, &argv);
   SC_CHECK_MPI (mpiret);
 
-  mpic = sc_MPI_COMM_WORLD;
-  sc_init (mpic, 1, 1, NULL, SC_LP_PRODUCTION);
+  comm = sc_MPI_COMM_WORLD;
+  sc_init (comm, 1, 1, NULL, SC_LP_PRODUCTION);
   p4est_init (NULL, SC_LP_ESSENTIAL);
   t8_init (SC_LP_DEFAULT);
 
-  t8_test_face_is_boundary_one_tree (mpic);
-  t8_test_face_is_boundary_two_tree (mpic);
+  t8_test_face_is_boundary_one_tree (comm);
+  t8_test_face_is_boundary_two_tree (comm);
 
   sc_finalize ();
 


### PR DESCRIPTION
The cmesh gets a new function t8_cmesh_get_face_neighbor to gather face neighbor information from a local treeid.
We also add additional helper functions to check whether a local id is  a local tree or ghost.
We add tree_to_face encode and decode function to ease handling of the tree_to_face data (dual face and orientation).
We add  a test for the new t8_cmesh_get_face_neighbor function.
While testing we discovered an old bug in t8_cmesh_commit that computed wrong tree counts when the cmesh was build from stash with t8_cmesh_set_partition_range.
This bug is now fixed.