### PR TITLE
Add a num_siblings element function.

### DIFF
--- a/src/t8_element_cxx.hxx
+++ b/src/t8_element_cxx.hxx
@@ -125,6 +125,15 @@ public:
   virtual void        t8_element_parent (const t8_element_t * elem,
                                          t8_element_t * parent) = 0;
 
+  /** Compute the number of siblings of an element. That is the number of 
+   * Children of its parent.
+   * \param [in] elem The element.
+   * \return          The number of siblings of \a element.
+   * Note that this number is >= 1, since we count the element itself as a sibling.
+   */
+  virtual int         t8_element_num_siblings (const t8_element_t *
+                                               elem) const = 0;
+
   /** Compute a specific sibling of a given element \b elem and store it in \b sibling.
    *  \b sibling needs to be an existing element. No memory is allocated by this function.
    *  \b elem and \b sibling can point to the same element, then the entries of

--- a/src/t8_schemes/t8_default/t8_default_common_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_common_cxx.cxx
@@ -138,6 +138,19 @@ t8_gloidx_t
   return count_leafs_from_level (element_level, level, dim);
 }
 
+/* Count the number of siblings.
+ * The number of children is 2^dim for each element, except for pyramids.
+ * TODO: For pyramids we will have to implement a standalone version in the pyramid scheme. */
+/* *INDENT-OFF* */
+/* Indent bug: indent adds an additional const */
+int
+t8_default_scheme_common_c::t8_element_num_siblings (const t8_element_t * elem) const
+/* *INDENT-ON* */
+{
+  const int           dim = t8_eclass_to_dimension[eclass];
+  return sc_intpow (2, dim);
+}
+
 t8_gloidx_t
   t8_default_scheme_common_c::t8_element_count_leafs_from_root (int level)
 {

--- a/src/t8_schemes/t8_default/t8_default_common_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_common_cxx.hxx
@@ -63,6 +63,9 @@ public:
   virtual t8_gloidx_t t8_element_count_leafs (const t8_element_t * t,
                                               int level);
 
+  virtual int         t8_element_num_siblings (const t8_element_t *
+                                               elem) const;
+
   /** Count how many leaf descendants of a given uniform level the root element will produce.
    * \param [in] level A refinement level.
    * \return The value of \ref t8_element_count_leafs if the input element


### PR DESCRIPTION
This function returns the number of siblings of
an element.
We add a default implementation that returns
2**dim. For pyramids we will have to implement
a standalone definition.