### PR TITLE
Feature notification wrong gmsh version

### DIFF
--- a/doc/author_boeing.txt
+++ b/doc/author_boeing.txt
@@ -1,0 +1,1 @@
+I place my contributions to t8code under the FreeBSD license. Niklas Böing (niklas.boeing@gmx.de)

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -11,7 +11,7 @@
 
 # This is the indent script in the project's directory
 
-INDENT=./t8indent
+INDENT=./p4estindent
 
 if git rev-parse --verify HEAD >/dev/null 2>&1
 then

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -10,7 +10,6 @@
 #
 
 # This is the indent script in the project's directory
-
 INDENT=./p4estindent
 
 if git rev-parse --verify HEAD >/dev/null 2>&1

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -10,7 +10,8 @@
 #
 
 # This is the indent script in the project's directory
-INDENT=./p4estindent
+
+INDENT=./t8indent
 
 if git rev-parse --verify HEAD >/dev/null 2>&1
 then

--- a/src/t8_cmesh/t8_cmesh_readmshfile.c
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.c
@@ -174,17 +174,17 @@ t8_msh_file_node_compare (const void *node_a, const void *node_b,
 }
 
 /* Read an open msh-file and checks whether the MeshFormat-Version is supported by t8code or not. */
-static void
+static int
 t8_cmesh_check_version_of_msh_file (FILE * fp)
 {
-
   char               *line = (char *) malloc (1024);
   char                first_word[2048] = "\0";
-  T8_ASSERT (fp != NULL);
   size_t              linen = 1024;
   int                 retval;
-  int                 max_version_supported = 2;
   int                 version_number, sub_version_number;
+  int                 check_format;
+
+  T8_ASSERT (fp != NULL);
 
   /* Go to the beginning of the file. */
   fseek (fp, 0, SEEK_SET);
@@ -198,36 +198,53 @@ t8_cmesh_check_version_of_msh_file (FILE * fp)
     if (retval != 1) {
       t8_global_errorf
         ("Reading the msh-file in order to check the MeshFormat-number failed.\n");
-      t8_debugf ("The line is %s", line);
+      goto die_format;
     }
   }
 
   /* Got to the next line containing the MeshFormat. */
   (void) t8_cmesh_msh_read_next_line (&line, &linen, fp);
   /* Get the MeshFormat number of the file */
-  retval = sscanf (line, "%d.%d", &version_number, &sub_version_number);
+  retval =
+    sscanf (line, "%d.%d %d", &version_number, &sub_version_number,
+            &check_format);
 
   /*Checking for read/write error. */
-  if (retval != 2) {
-    t8_global_errorf ("The MeshFormat-number was not read correctly.\n");
+  if (retval != 3) {
     t8_debugf ("Reading of the MeshFormat-number failed.\n");
+    goto die_format;
+  }
+
+  /* Checks if the file is of Binary-type. */
+  if (check_format) {
+    t8_global_errorf
+      ("Incompatible file-type. t8code works with ASCII-type msh-files of version %d.\n",
+       T8_CMESH_MAX_SUPPORTED_FILE_VERSION);
+    goto die_format;
   }
 
   /* Check if MeshFormat-number is compatible. */
-  if (version_number <= max_version_supported) {
-    t8_debugf ("Succesfully read the MeshFormat-Number.\n");
+  if (version_number <= T8_CMESH_MAX_SUPPORTED_FILE_VERSION) {
     t8_debugf ("This version of msh-file (%d.%d) is supported.\n",
                version_number, sub_version_number);
-
+    free (line);
+    return 1;
   }
   else {
-    t8_debugf
-      ("This version of msh-file is currently not supported by t8code.\n");
     t8_global_errorf
-      ("This version of msh-file (%d.%d) is currently not supported by t8code, please provide a msh-file of version %d.X or lower.\n",
-       version_number, sub_version_number, max_version_supported);
+      ("This version of msh-file (%d.%d) is currently not supported by t8code, please provide an ASCII-type msh-file of version %d.X or lower.\n",
+       version_number, sub_version_number,
+       T8_CMESH_MAX_SUPPORTED_FILE_VERSION);
+    free (line);
+    return 0;
   }
 
+/* Will be executed, if reading the MeshFormat failed. */
+die_format:
+  /* Free memory. */
+  free (line);
+  /* Returning as error code. */
+  return -1;
 }
 
 /* Read an open .msh file and parse the nodes into a hash table.
@@ -834,7 +851,13 @@ t8_cmesh_from_msh_file (const char *fileprefix, int partition,
       return NULL;
     }
     /* Check if msh-file version is compatible. */
-    t8_cmesh_check_version_of_msh_file (file);
+    if (t8_cmesh_check_version_of_msh_file (file) != 1) {
+      /* If reading the MeshFormat-number failed or the version is incompatible, close the file */
+      fclose (file);
+      t8_debugf
+        ("The reading process of the msh-file has failed and the file has been closed.\n");
+      return NULL;
+    }
     /* read nodes from the file */
     vertices = t8_msh_file_read_nodes (file, &num_vertices, &node_mempool);
     t8_cmesh_msh_file_read_eles (cmesh, file, vertices, &vertex_indices, dim);

--- a/src/t8_cmesh/t8_cmesh_readmshfile.c
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.c
@@ -173,7 +173,7 @@ t8_msh_file_node_compare (const void *node_a, const void *node_b,
   return Node_a->index == Node_b->index;
 }
 
-/* Read an open msh-file and checks whether the MeshFormat-Version is supported by t8code or not. */
+/* Reads an open msh-file and checks whether the MeshFormat-Version is supported by t8code or not. */
 static int
 t8_cmesh_check_version_of_msh_file (FILE * fp)
 {
@@ -848,6 +848,7 @@ t8_cmesh_from_msh_file (const char *fileprefix, int partition,
     file = fopen (current_file, "r");
     if (file == NULL) {
       t8_global_errorf ("Could not open file %s\n", current_file);
+      t8_cmesh_destroy (&cmesh);
       return NULL;
     }
     /* Check if msh-file version is compatible. */
@@ -856,6 +857,7 @@ t8_cmesh_from_msh_file (const char *fileprefix, int partition,
       fclose (file);
       t8_debugf
         ("The reading process of the msh-file has failed and the file has been closed.\n");
+      t8_cmesh_destroy (&cmesh);
       return NULL;
     }
     /* read nodes from the file */

--- a/src/t8_cmesh_readmshfile.h
+++ b/src/t8_cmesh_readmshfile.h
@@ -32,6 +32,9 @@
 #include <t8_eclass.h>
 #include <t8_cmesh.h>
 
+/* The maximum supported .msh file version.
+ * Currently, we support gmsh's file version 2 in ASCII format.
+ */
 #define T8_CMESH_MAX_SUPPORTED_FILE_VERSION 2
 
 /* put typedefs here */

--- a/src/t8_cmesh_readmshfile.h
+++ b/src/t8_cmesh_readmshfile.h
@@ -27,11 +27,12 @@
 
 #ifndef T8_CMESH_READMSHFILE_H
 #define T8_CMESH_READMSHFILE_H
-#define T8_CMESH_MAX_SUPPORTED_FILE_VERSION 2
 
 #include <t8.h>
 #include <t8_eclass.h>
 #include <t8_cmesh.h>
+
+#define T8_CMESH_MAX_SUPPORTED_FILE_VERSION 2
 
 /* put typedefs here */
 

--- a/src/t8_cmesh_readmshfile.h
+++ b/src/t8_cmesh_readmshfile.h
@@ -27,6 +27,7 @@
 
 #ifndef T8_CMESH_READMSHFILE_H
 #define T8_CMESH_READMSHFILE_H
+#define T8_CMESH_MAX_SUPPORTED_FILE_VERSION 2
 
 #include <t8.h>
 #include <t8_eclass.h>


### PR DESCRIPTION
An error message will be thrown, if the provided msh-file has an incompatible MeshFormat number and therefore cannot be read by "t8_cmesh_readmshfile.c". Currently supported are msh-files of version 2 or lower.