### PR TITLE
Enable netcdf linkage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,3 +97,17 @@ jobs:
       run: make check -j4 V=0
     - name: clean up
       run: make distclean
+# configure and test with MPI and netcdf
+    - name: Install netcdf
+      run: sudo apt-get install libnetcdf
+    - name: configure
+      run: ./configure --without-blas --with-netcdf --enable-mpi
+    - name: OnFailPrintLog
+      if: failure()
+      run: cat config.log
+    - name: make
+      run: make -j V=0
+    - name: make check
+      run: make check -j4 V=0
+    - name: clean up
+      run: make distclean

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,7 +99,7 @@ jobs:
       run: make distclean
 # configure and test with MPI and netcdf
     - name: Install netcdf
-      run: sudo apt-get install libnetcdf
+      run: sudo apt-get install libnetcdf-dev
     - name: configure
       run: ./configure --without-blas --with-netcdf --enable-mpi
     - name: OnFailPrintLog

--- a/Makefile.am
+++ b/Makefile.am
@@ -40,7 +40,9 @@ Makefile.t8.mk : Makefile.t8.pre
 
 # install T8 m4 macros in the correct directory
 t8aclocaldir = $(datadir)/aclocal
-dist_t8aclocal_DATA = config/t8_include.m4 config/t8_stdpp.m4
+dist_t8aclocal_DATA = config/t8_include.m4 \
+                      config/t8_stdpp.m4 \
+                      config/t8_netcdf.m4
 
 # install t8 data in the correct directory
 t8datadir = $(datadir)/data

--- a/Makefile.am
+++ b/Makefile.am
@@ -81,6 +81,7 @@ include example/gmsh/Makefile.am
 include example/cmesh/Makefile.am
 include example/common/Makefile.am
 include example/advect/Makefile.am
+include example/netcdf/Makefile.am
 #include example/cxx/Makefile.am
 #include example/ExtremeScaling/Makefile.am
 

--- a/config/t8_include.m4
+++ b/config/t8_include.m4
@@ -47,6 +47,7 @@ dnl link to T8 to add appropriate options to LIBS.
 dnl
 AC_DEFUN([T8_CHECK_LIBRARIES],
 [
+T8_CHECK_NETCDF([$1])
 T8_CHECK_CPPSTD([$1])
 ])
 

--- a/config/t8_netcdf.m4
+++ b/config/t8_netcdf.m4
@@ -1,0 +1,47 @@
+dnl T8_CHECK_NETCDF
+dnl Check for netcdf support and link a test program
+dnl
+dnl This macro tries to link to the netcdf library.
+dnl Use the LIBS variable on the configure line to specify a different library
+dnl or use --with-netcdf=<LIBRARY>
+dnl
+dnl Using --with-netcdf without any argument defaults to -lnetcdf.
+dnl
+AC_DEFUN([T8_CHECK_NETCDF], [
+
+dnl This link test changes the LIBS variable in place for posterity
+dnl SAVE_LIBS="$LIBS"
+dnl T8_CHECK_LIB([netcdf], [nc_open], [NETCDF])
+dnl LIBS="$SAVE_LIBS"
+dnl AC_MSG_CHECKING([for netcdf linkage])
+
+T8_ARG_WITH([netcdf],
+  [netcdf library (optionally use --with-netcdf=<NETCDF_LIBS>)],
+  [NETCDF])
+if test "x$T8_WITH_NETCDF" != xno ; then
+  T8_NETCDF_LIBS="-lnetcdf"
+  if test "x$T8_WITH_NETCDF" != xyes ; then
+    T8_NETCDF_LIBS="$T8_WITH_NETCDF"
+    dnl AC_MSG_ERROR([Please provide --with-netcdf without arguments])
+  fi
+  PRE_NETCDF_LIBS="$LIBS"
+  LIBS="$LIBS $T8_NETCDF_LIBS"
+  AC_LINK_IFELSE([AC_LANG_PROGRAM(
+[[
+]],[[
+  #include <netcdf.h>
+
+  int ncid;
+  nc_open (NULL, NC_NOWRITE, &ncid);
+]])],,
+                 [AC_MSG_ERROR([Unable to link with netcdf library])])
+dnl Keep the variables changed as done above
+dnl LIBS="$PRE_NETCDF_LIBS"
+
+  AC_MSG_RESULT([successful])
+else
+  AC_MSG_RESULT([not used])
+fi
+
+])
+

--- a/example/README
+++ b/example/README
@@ -17,3 +17,6 @@ A brief description of the folders and programs:
              It works in 2D and 3D with all supported element types and
              hybrid meshes.
              Call './t8_advection -h' for usage details
+ netcdf   -- Eventually writing out meshes to netcdf format.
+	     Currently, only a test program that prints a message whether or
+	     not t8code was succesfully linked with netcdf.

--- a/example/netcdf/Makefile.am
+++ b/example/netcdf/Makefile.am
@@ -1,0 +1,9 @@
+# This file is part of t8code
+# Non-recursive Makefile.am in example/netcdf
+# Included from toplevel directory
+
+bin_PROGRAMS += \
+	example/netcdf/t8_netcdf_compilation_status
+
+example_netcdf_t8_netcdf_compilation_status_SOURCES = \
+	example/netcdf/t8_netcdf_status.c

--- a/example/netcdf/t8_netcdf_status.c
+++ b/example/netcdf/t8_netcdf_status.c
@@ -46,7 +46,7 @@ main (int argc, char **argv)
 
   /* Initialize sc */
   sc_init (sc_MPI_COMM_WORLD, 1, 1, NULL, SC_LP_ESSENTIAL);
-  /* Initliaze t8code */
+  /* Initialize t8code */
   t8_init (SC_LP_PRODUCTION);
 
   /* Check netcdf compilation */

--- a/example/netcdf/t8_netcdf_status.c
+++ b/example/netcdf/t8_netcdf_status.c
@@ -1,0 +1,63 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element types in parallel.
+
+  Copyright (C) 2015 the developers
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+#include <t8.h>
+
+/* This code prints a global message describing the netcdf compilation status. */
+static void
+t8_check_netcdf_compilation ()
+{
+#ifdef T8_WITH_NETCDF
+  t8_global_productionf
+    ("This version of t8code is compiled with netcdf support.\n");
+#else
+  t8_global_productionf
+    ("This version of t8code is not compiled with netcdf support.\n");
+#endif
+}
+
+int
+main (int argc, char **argv)
+{
+  int                 mpiret;
+
+  /* Initialize MPI */
+  mpiret = sc_MPI_Init (&argc, &argv);
+  SC_CHECK_MPI (mpiret);
+
+  /* Initialize sc */
+  sc_init (sc_MPI_COMM_WORLD, 1, 1, NULL, SC_LP_ESSENTIAL);
+  /* Initliaze t8code */
+  t8_init (SC_LP_PRODUCTION);
+
+  /* Check netcdf compilation */
+  t8_check_netcdf_compilation ();
+
+  /* Finalize sc */
+  sc_finalize ();
+
+  /* Finalize MPI */
+  mpiret = sc_MPI_Finalize ();
+  SC_CHECK_MPI (mpiret);
+
+  return 0;
+}

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -18,7 +18,8 @@ t8code_test_programs = \
 	test/t8_test_search \
 	test/t8_test_find_parent \
 	test/t8_test_cmesh_face_is_boundary \
-	test/t8_test_element_general_function
+	test/t8_test_element_general_function \
+	test/t8_test_netcdf_linkage
 
 test_t8_test_eclass_SOURCES = test/t8_test_eclass.c
 test_t8_test_bcast_SOURCES = test/t8_test_bcast.c
@@ -36,6 +37,7 @@ test_t8_test_search_SOURCES = test/t8_test_search.cxx
 test_t8_test_find_parent_SOURCES = test/t8_test_find_parent.cpp
 test_t8_test_cmesh_face_is_boundary_SOURCES = test/t8_test_cmesh_face_is_boundary.cxx
 test_t8_test_element_general_function_SOURCES = test/t8_test_element_general_function.cxx
+test_t8_test_netfdf_linkage_SOURCES = test/t8_test_netcdf_linkage.c
 
 TESTS += $(t8code_test_programs)
 check_PROGRAMS += $(t8code_test_programs)

--- a/test/t8_test_netcdf_linkage.c
+++ b/test/t8_test_netcdf_linkage.c
@@ -51,7 +51,7 @@ t8_test_netcdf_linkage ()
   nc_error = nc_close (ncid);
   /* Check for error */
   SC_CHECK_ABORTF (nc_error == NC_NOERR,
-                   "netcdf error when closing in memory " "file: %s\n",
+                   "netcdf error when closing in memory file: %s\n",
                    nc_strerror (nc_error));
 
   t8_global_productionf

--- a/test/t8_test_netcdf_linkage.c
+++ b/test/t8_test_netcdf_linkage.c
@@ -1,0 +1,90 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element types in parallel.
+
+  Copyright (C) 2015 the developers
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+/* In this test we create a netcdf in memory file and close it.
+ * The purpose of this test is to check whether t8code successfully links
+ * against netcdf.
+ * If t8code was not configured with --with-netcdf then this test
+ * does nothing and is always passed.
+ */
+
+#include <t8.h>
+#if T8_WITH_NETCDF
+#include <netcdf.h>
+#endif
+
+static void
+t8_test_netcdf_linkage ()
+{
+#if T8_WITH_NETCDF
+
+/* Create an in-memory netcdf file. This file will not be stored on
+ * the disk. */
+  int                 ncid;
+  int                 nc_error = nc_create ("FileName", NC_DISKLESS, &ncid);
+
+  /* Check for error */
+  SC_CHECK_ABORTF (nc_error == NC_NOERR,
+                   "netcdf error when creating in memory " "file: %s\n",
+                   nc_strerror (nc_error));
+
+  /* Close the file */
+  nc_error = nc_close (ncid);
+  /* Check for error */
+  SC_CHECK_ABORTF (nc_error == NC_NOERR,
+                   "netcdf error when closing in memory " "file: %s\n",
+                   nc_strerror (nc_error));
+
+  t8_global_productionf
+    ("Successfully created and closed in memory netcdf file.\n");
+#else
+  t8_global_productionf
+    ("This version of t8code is not compiled with netcdf support.\n");
+#endif
+}
+
+int
+main (int argc, char **argv)
+{
+  int                 mpiret;
+
+  /* Initialize MPI */
+  mpiret = sc_MPI_Init (&argc, &argv);
+  SC_CHECK_MPI (mpiret);
+
+  /* Initialize sc */
+  sc_init (sc_MPI_COMM_WORLD, 1, 1, NULL, SC_LP_ESSENTIAL);
+  /* Initliaze t8code */
+  t8_init (SC_LP_PRODUCTION);
+
+  /* Check netcdf linkage */
+  t8_test_netcdf_linkage ();
+
+  /* Finalize sc */
+  sc_finalize ();
+
+  /* Finalize MPI */
+  mpiret = sc_MPI_Finalize ();
+  SC_CHECK_MPI (mpiret);
+
+  return 0;
+}

--- a/test/t8_test_netcdf_linkage.c
+++ b/test/t8_test_netcdf_linkage.c
@@ -73,7 +73,7 @@ main (int argc, char **argv)
 
   /* Initialize sc */
   sc_init (sc_MPI_COMM_WORLD, 1, 1, NULL, SC_LP_ESSENTIAL);
-  /* Initliaze t8code */
+  /* Initialize t8code */
   t8_init (SC_LP_PRODUCTION);
 
   /* Check netcdf linkage */


### PR DESCRIPTION
t8code can now be configured to link against netcdf.
Usage: configure --with-netcdf

Added example/netcdf/t8_netcdf_compilation_status.
This programs prints a message telling us whether t8code was linked against
netcdf or not.

Added test/t8_test_netcdf_linkage. If t8code was linked against netcdf this test
checks whether we are able to compile and execute netcdf code.


﻿- Add possibility to link against netcdf
- netcdf m4 file for configuring with netcdf
- Added a netcdf example that prints the compilation status.
- Add a test for netcdf linkage
- Add a with-netcdf variant to the github test workflow
