### PR TITLE
Feature warning message in cmesh hypercube

### DIFF
--- a/src/t8_cmesh/t8_cmesh.c
+++ b/src/t8_cmesh/t8_cmesh.c
@@ -2107,9 +2107,8 @@ t8_cmesh_new_hypercube (t8_eclass_t eclass, sc_MPI_Comm comm, int do_bcast,
   SC_CHECK_ABORT (eclass != T8_ECLASS_PYRAMID || !periodic,
                   "The pyramid cube mesh cannot be periodic.\n");
 
-  SC_CHECK_ABORT (do_bcast
-                  && do_partition,
-                  "Broadcasting and partitioning the hypercube cmesh is currently not supported.\n");
+  SC_CHECK_ABORT (do_partition,
+                  "Partitioning the hypercube cmesh is currently not supported.\n");
 
   mpiret = sc_MPI_Comm_rank (comm, &mpirank);
   SC_CHECK_MPI (mpiret);

--- a/src/t8_cmesh/t8_cmesh.c
+++ b/src/t8_cmesh/t8_cmesh.c
@@ -2107,6 +2107,10 @@ t8_cmesh_new_hypercube (t8_eclass_t eclass, sc_MPI_Comm comm, int do_bcast,
   SC_CHECK_ABORT (eclass != T8_ECLASS_PYRAMID || !periodic,
                   "The pyramid cube mesh cannot be periodic.");
 
+  SC_CHECK_ABORT (do_bcast
+                  && do_partition,
+                  "Broadcasting and partitioning the hypercube cmesh is currently not supported.\n");
+
   mpiret = sc_MPI_Comm_rank (comm, &mpirank);
   SC_CHECK_MPI (mpiret);
   if (!do_bcast || mpirank == 0) {

--- a/src/t8_cmesh/t8_cmesh.c
+++ b/src/t8_cmesh/t8_cmesh.c
@@ -2105,7 +2105,7 @@ t8_cmesh_new_hypercube (t8_eclass_t eclass, sc_MPI_Comm comm, int do_bcast,
   };
 
   SC_CHECK_ABORT (eclass != T8_ECLASS_PYRAMID || !periodic,
-                  "The pyramid cube mesh cannot be periodic.");
+                  "The pyramid cube mesh cannot be periodic.\n");
 
   SC_CHECK_ABORT (do_bcast
                   && do_partition,

--- a/src/t8_cmesh/t8_cmesh.c
+++ b/src/t8_cmesh/t8_cmesh.c
@@ -2107,8 +2107,11 @@ t8_cmesh_new_hypercube (t8_eclass_t eclass, sc_MPI_Comm comm, int do_bcast,
   SC_CHECK_ABORT (eclass != T8_ECLASS_PYRAMID || !periodic,
                   "The pyramid cube mesh cannot be periodic.\n");
 
-  SC_CHECK_ABORT (do_partition,
-                  "Partitioning the hypercube cmesh is currently not supported.\n");
+  if (do_partition) {
+    t8_global_errorf
+      ("WARNING: Partitioning the hypercube cmesh is currently not supported.\n"
+       "Using this cmesh will crash when vertices are used. See also https://github.com/holke/t8code/issues/79\n");
+  }
 
   mpiret = sc_MPI_Comm_rank (comm, &mpirank);
   SC_CHECK_MPI (mpiret);


### PR DESCRIPTION
We have a bug in cmesh_new_hypercube when using it partitioned. See #79.
This commit introduces a warning message so that a user knows they should proceed with care.

See also #80 