### PR TITLE
t8_forest_num_element -> t8_forest_get_local_num_elements

### DIFF
--- a/example/advect/t8_advection.cxx
+++ b/example/advect/t8_advection.cxx
@@ -316,7 +316,7 @@ t8_advect_level_set_volume (const t8_advect_problem_t * problem)
   double              volume = 0, global_volume = 0;
   double              phi;
 
-  num_local_elements = t8_forest_get_num_element (problem->forest);
+  num_local_elements = t8_forest_get_local_num_elements (problem->forest);
 
   for (ielem = 0; ielem < num_local_elements; ielem++) {
     elem_data = (t8_advect_element_data_t *)
@@ -346,7 +346,7 @@ t8_advect_l_infty_rel (const t8_advect_problem_t * problem,
     -1, 0
   }, el_error, global_error[2];
 
-  num_local_elements = t8_forest_get_num_element (problem->forest);
+  num_local_elements = t8_forest_get_local_num_elements (problem->forest);
   for (ielem = 0; ielem < num_local_elements; ielem++) {
     elem_data = (t8_advect_element_data_t *)
       t8_sc_array_index_locidx (problem->element_data, ielem);
@@ -389,7 +389,7 @@ t8_advect_l_2_rel (const t8_advect_problem_t * problem,
     0, 0
   }, el_error, global_error[2];
 
-  num_local_elements = t8_forest_get_num_element (problem->forest);
+  num_local_elements = t8_forest_get_local_num_elements (problem->forest);
   for (ielem = 0; ielem < num_local_elements; ielem++) {
     elem_data = (t8_advect_element_data_t *)
       t8_sc_array_index_locidx (problem->element_data, ielem);
@@ -593,7 +593,8 @@ t8_advect_flux_upwind_hanging (const t8_advect_problem_t * problem,
     neigh_id = el_hang->neighs[face][i];
     neigh_data = (t8_advect_element_data_t *)
       t8_sc_array_index_locidx (problem->element_data, neigh_id);
-    neigh_is_ghost = neigh_id >= t8_forest_get_num_element (problem->forest);
+    neigh_is_ghost =
+      neigh_id >= t8_forest_get_local_num_elements (problem->forest);
     phi_minus = t8_advect_element_get_phi (problem, neigh_id);
     /* Compute the flux */
     el_hang->fluxes[face][i] =
@@ -898,7 +899,7 @@ t8_advect_problem_elements_destroy (t8_advect_problem_t * problem)
   int                 iface;
   t8_advect_element_data_t *elem_data;
 
-  num_local_elem = t8_forest_get_num_element (problem->forest);
+  num_local_elem = t8_forest_get_local_num_elements (problem->forest);
   T8_ASSERT (num_local_elem <=
              (t8_locidx_t) problem->element_data->elem_count);
   /* destroy all elements */
@@ -980,7 +981,7 @@ t8_advect_problem_adapt (t8_advect_problem_t * problem, int measure_time)
   }
 
   /* Allocate new memory for the element_data of the advected forest */
-  num_elems = t8_forest_get_num_element (problem->forest_adapt);
+  num_elems = t8_forest_get_local_num_elements (problem->forest_adapt);
   num_elems_p_ghosts = num_elems +
     t8_forest_get_num_ghosts (problem->forest_adapt);
   problem->element_data_adapt =
@@ -1059,8 +1060,9 @@ t8_advect_problem_partition (t8_advect_problem_t * problem, int measure_time)
     problem->stats[ADVECT_GHOST].count = 1;
   }
   /* Partition the data */
-  num_local_elements = t8_forest_get_num_element (problem->forest);
-  num_local_elements_new = t8_forest_get_num_element (forest_partition);
+  num_local_elements = t8_forest_get_local_num_elements (problem->forest);
+  num_local_elements_new =
+    t8_forest_get_local_num_elements (forest_partition);
   num_ghosts_new = t8_forest_get_num_ghosts (forest_partition);
   /* Create a view array of the entries for the local elements */
   sc_array_init_view (&data_view, problem->element_data, 0,
@@ -1214,13 +1216,13 @@ t8_advect_problem_init (t8_cmesh_t cmesh,
 
   problem->element_data =
     sc_array_new_count (sizeof (t8_advect_element_data_t),
-                        t8_forest_get_num_element (problem->forest));
+                        t8_forest_get_local_num_elements (problem->forest));
   problem->element_data_adapt = NULL;
 
   /* initialize the phi array */
   problem->phi_values =
     sc_array_new_count ((dummy_op ? 2 : 1) * sizeof (double),
-                        t8_forest_get_num_element (problem->forest) +
+                        t8_forest_get_local_num_elements (problem->forest) +
                         t8_forest_get_num_ghosts (problem->forest));
   problem->phi_values_adapt = NULL;
   return problem;
@@ -1235,7 +1237,7 @@ t8_advect_project_element_data (t8_advect_problem_t * problem)
   t8_advect_element_data_t *elem_data;
   int                 iface;
 
-  num_local_elements = t8_forest_get_num_element (problem->forest);
+  num_local_elements = t8_forest_get_local_num_elements (problem->forest);
   for (ielem = 0; ielem < num_local_elements; ielem++) {
     elem_data = (t8_advect_element_data_t *)
       t8_sc_array_index_locidx (problem->element_data, ielem);
@@ -1374,7 +1376,7 @@ t8_advect_write_vtk (t8_advect_problem_t * problem)
   double              phi;
 
   /* Allocate num_local_elements doubles to store u and phi values */
-  num_local_elements = t8_forest_get_num_element (problem->forest);
+  num_local_elements = t8_forest_get_local_num_elements (problem->forest);
   /* phi */
   u_and_phi_array[0] = T8_ALLOC_ZERO (double, num_local_elements);
   /* phi_0 */
@@ -1446,7 +1448,7 @@ t8_advect_print_phi (t8_advect_problem_t * problem)
   char                buffer[BUFSIZ] = "";
   double              phi;
 
-  num_local_els = t8_forest_get_num_element (problem->forest);
+  num_local_els = t8_forest_get_local_num_elements (problem->forest);
   for (ielement = 0;
        ielement <
        (t8_locidx_t) problem->element_data->elem_count; ielement++) {
@@ -1659,7 +1661,7 @@ t8_advect_solve (t8_cmesh_t cmesh, t8_flow_function_3d_fn u,
 
               neigh_index = elem_data->neighs[iface][0];
               neigh_is_ghost = neigh_index >=
-                t8_forest_get_num_element (problem->forest);
+                t8_forest_get_local_num_elements (problem->forest);
               hanging = elem_data->level != elem_data->neigh_level[iface];
             }
             else {

--- a/example/tetgen/t8_forest_from_tetgen.cxx
+++ b/example/tetgen/t8_forest_from_tetgen.cxx
@@ -73,7 +73,7 @@ t8_forest_from_cmesh (t8_cmesh_t cmesh, int level, const char *prefix)
   t8_forest_set_level (forest, level);
   t8_forest_commit (forest);
   t8_debugf ("Committed forest. Has %i elements.\n",
-             t8_forest_get_num_element (forest));
+             t8_forest_get_local_num_elements (forest));
   snprintf (fileprefix, BUFSIZ, "%s_t8_tetgen_forest", prefix);
   t8_forest_write_vtk (forest, fileprefix);
   t8_debugf ("Wrote to file %s\n", fileprefix);

--- a/example/tutorials/t8_step2_uniform_forest.cxx
+++ b/example/tutorials/t8_step2_uniform_forest.cxx
@@ -155,7 +155,7 @@ main (int argc, char **argv)
   /* Build the uniform forest, it is automatically partitioned among the processes. */
   forest = t8_step2_build_uniform_forest (comm, cmesh, level);
   /* Get the local number of elements. */
-  local_num_elements = t8_forest_get_num_element (forest);
+  local_num_elements = t8_forest_get_local_num_elements (forest);
   /* Get the global number of elements. */
   global_num_elements = t8_forest_get_global_num_elements (forest);
 

--- a/example/tutorials/t8_step3_adapt_forest.cxx
+++ b/example/tutorials/t8_step3_adapt_forest.cxx
@@ -184,7 +184,7 @@ t8_step3_print_forest_information (t8_forest_t forest)
   T8_ASSERT (t8_forest_is_committed (forest));
 
   /* Get the local number of elements. */
-  local_num_elements = t8_forest_get_num_element (forest);
+  local_num_elements = t8_forest_get_local_num_elements (forest);
   /* Get the global number of elements. */
   global_num_elements = t8_forest_get_global_num_elements (forest);
   t8_global_productionf (" [step3] Local number of elements:\t\t%i\n",

--- a/example/tutorials/t8_step5_element_data.cxx
+++ b/example/tutorials/t8_step5_element_data.cxx
@@ -82,7 +82,7 @@ t8_step5_create_element_data (t8_forest_t forest)
   T8_ASSERT (t8_forest_is_committed (forest));
 
   /* Get the number of local elements of forest. */
-  num_local_elements = t8_forest_get_num_element (forest);
+  num_local_elements = t8_forest_get_local_num_elements (forest);
   /* Get the number of ghost elements of forest. */
   num_ghost_elements = t8_forest_get_num_ghosts (forest);
 
@@ -164,7 +164,8 @@ t8_step5_exchange_ghost_data (t8_forest_t forest,
                               struct t8_step5_data_per_element *data)
 {
   sc_array           *sc_array_wrapper;
-  t8_locidx_t         num_elements = t8_forest_get_num_element (forest);
+  t8_locidx_t         num_elements =
+    t8_forest_get_local_num_elements (forest);
   t8_locidx_t         num_ghosts = t8_forest_get_num_ghosts (forest);
 
   /* t8_forest_ghost_exchange_data expects an sc_array (of length num_local_elements + num_ghosts).
@@ -194,7 +195,8 @@ t8_step5_output_data_to_vtu (t8_forest_t forest,
                              struct t8_step5_data_per_element *data,
                              const char *prefix)
 {
-  t8_locidx_t         num_elements = t8_forest_get_num_element (forest);
+  t8_locidx_t         num_elements =
+    t8_forest_get_local_num_elements (forest);
   t8_locidx_t         ielem;
   /* We need to allocate a new array to store the volumes on their own.
    * This array has one entry per local element. */
@@ -286,7 +288,7 @@ t8_step5_main (int argc, char **argv)
 
   t8_global_productionf
     (" [step5] Computed level and volume data for local elements.\n");
-  if (t8_forest_get_num_element (forest) > 0) {
+  if (t8_forest_get_local_num_elements (forest) > 0) {
     /* Output the stored data of the first local element (if it exists). */
     t8_global_productionf (" [step5] Element 0 has level %i and volume %e.\n",
                            data[0].level, data[0].volume);
@@ -301,7 +303,7 @@ t8_step5_main (int argc, char **argv)
   if (t8_forest_get_num_ghosts (forest) > 0) {
     /* output the data of the first ghost element (if it exists) */
     t8_locidx_t         first_ghost_index =
-      t8_forest_get_num_element (forest);
+      t8_forest_get_local_num_elements (forest);
     t8_global_productionf (" [step5] Ghost 0 has level %i and volume %e.\n",
                            data[first_ghost_index].level,
                            data[first_ghost_index].volume);

--- a/src/t8_forest.h
+++ b/src/t8_forest.h
@@ -396,7 +396,7 @@ void                t8_forest_commit (t8_forest_t forest);
  */
 int                 t8_forest_get_maxlevel (t8_forest_t forest);
 
-t8_locidx_t         t8_forest_get_num_element (t8_forest_t forest);
+t8_locidx_t         t8_forest_get_local_num_elements (t8_forest_t forest);
 
 t8_gloidx_t         t8_forest_get_global_num_elements (t8_forest_t forest);
 

--- a/src/t8_forest.h
+++ b/src/t8_forest.h
@@ -396,8 +396,18 @@ void                t8_forest_commit (t8_forest_t forest);
  */
 int                 t8_forest_get_maxlevel (t8_forest_t forest);
 
+/** Return the number of process local elements in the forest.
+  * \param [in]  forest    A forest.
+  * \return                The number of elements on this process in \a forest.
+ * \a forest must be committed before calling this function.
+  */
 t8_locidx_t         t8_forest_get_local_num_elements (t8_forest_t forest);
 
+/** Return the number of global elements in the forest.
+  * \param [in]  forest    A forest.
+  * \return                The number of elements (summed over all processes) in \a forest.
+ * \a forest must be committed before calling this function.
+  */
 t8_gloidx_t         t8_forest_get_global_num_elements (t8_forest_t forest);
 
 /** Return the number of ghost elements of a forest.

--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -630,7 +630,7 @@ t8_forest_commit (t8_forest_t forest)
 }
 
 t8_locidx_t
-t8_forest_get_num_element (t8_forest_t forest)
+t8_forest_get_local_num_elements (t8_forest_t forest)
 {
   T8_ASSERT (t8_forest_is_committed (forest));
 
@@ -868,7 +868,7 @@ t8_forest_get_element (t8_forest_t forest, t8_locidx_t lelement_id,
 
   T8_ASSERT (t8_forest_is_committed (forest));
   T8_ASSERT (lelement_id >= 0);
-  if (lelement_id >= t8_forest_get_num_element (forest)) {
+  if (lelement_id >= t8_forest_get_local_num_elements (forest)) {
     return NULL;
   }
   /* We optimized the binary search out by using sc_bsearch,

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -1921,7 +1921,7 @@ t8_forest_leaf_face_neighbors (t8_forest_t forest, t8_locidx_t ltreeid,
          * of local elements. */
         element_index +=
           t8_forest_ghost_get_tree_element_offset (forest, lghost_treeid);
-        element_index += t8_forest_get_num_element (forest);
+        element_index += t8_forest_get_local_num_elements (forest);
         T8_ASSERT (forest->local_num_elements <= element_index
                    && element_index <
                    forest->local_num_elements +
@@ -2065,7 +2065,7 @@ t8_forest_leaf_face_neighbors (t8_forest_t forest, t8_locidx_t ltreeid,
         element_indices[ineigh] +=
           t8_forest_ghost_get_tree_element_offset (forest, lghost_treeid);
         /* Add the number of all local elements to this index */
-        element_indices[ineigh] += t8_forest_get_num_element (forest);
+        element_indices[ineigh] += t8_forest_get_local_num_elements (forest);
       }
     }                           /* End for loop over neighbor leafs */
     T8_FREE (owners);
@@ -2102,7 +2102,7 @@ t8_forest_print_all_leaf_neighbors (t8_forest_t forest)
     allocate_el_offset = 1;
     t8_forest_partition_create_offsets (forest);
   }
-  for (ielem = 0; ielem < t8_forest_get_num_element (forest); ielem++) {
+  for (ielem = 0; ielem < t8_forest_get_local_num_elements (forest); ielem++) {
     /* Get a pointer to the ielem-th element, its eclass, treeid and scheme */
     leaf = t8_forest_get_element (forest, ielem, &ltree);
     eclass = t8_forest_get_tree_class (forest, ltree);

--- a/src/t8_forest/t8_forest_ghost.cxx
+++ b/src/t8_forest/t8_forest_ghost.cxx
@@ -1867,7 +1867,7 @@ t8_forest_ghost_create_ext (t8_forest_t forest, int unbalanced_version)
 
   T8_ASSERT (t8_forest_is_committed (forest));
   t8_global_productionf ("Into t8_forest_ghost with %i local elements.\n",
-                         t8_forest_get_num_element (forest));
+                         t8_forest_get_local_num_elements (forest));
 
   if (forest->profile != NULL) {
     /* If profiling is enabled, we measure the runtime of ghost_create */
@@ -1896,7 +1896,7 @@ t8_forest_ghost_create_ext (t8_forest_t forest, int unbalanced_version)
     t8_forest_partition_create_first_desc (forest);
   }
 
-  if (t8_forest_get_num_element (forest) > 0) {
+  if (t8_forest_get_local_num_elements (forest) > 0) {
     if (forest->ghost_type == T8_GHOST_NONE) {
       t8_debugf ("WARNING: Trying to construct ghosts with ghost_type NONE. "
                  "Ghost layer is not constructed.\n");
@@ -1963,7 +1963,7 @@ t8_forest_ghost_create_ext (t8_forest_t forest, int unbalanced_version)
 
   t8_global_productionf ("Done t8_forest_ghost with %i local elements and %i"
                          " ghost elements.\n",
-                         t8_forest_get_num_element (forest),
+                         t8_forest_get_local_num_elements (forest),
                          t8_forest_get_num_ghosts (forest));
 }
 
@@ -2178,7 +2178,7 @@ t8_forest_ghost_exchange_begin (t8_forest_t forest, sc_array_t * element_data)
   }
 
   /* The index in element_data at which the ghost elements start */
-  ghost_start = t8_forest_get_num_element (forest);
+  ghost_start = t8_forest_get_local_num_elements (forest);
   /* Receive the incoming messages */
 #if 0
   while (received_messages < data_exchange->num_remotes) {
@@ -2302,7 +2302,7 @@ t8_forest_ghost_exchange_data (t8_forest_t forest, sc_array_t * element_data)
   T8_ASSERT (forest->ghosts != NULL);
   T8_ASSERT (element_data != NULL);
   T8_ASSERT ((t8_locidx_t) element_data->elem_count ==
-             t8_forest_get_num_element (forest)
+             t8_forest_get_local_num_elements (forest)
              + t8_forest_get_num_ghosts (forest));
 
   data_exchange = t8_forest_ghost_exchange_begin (forest, element_data);

--- a/src/t8_forest/t8_forest_partition.cxx
+++ b/src/t8_forest/t8_forest_partition.cxx
@@ -256,7 +256,7 @@ t8_forest_partition_create_tree_offsets (t8_forest_t forest)
   tree_offset =
     t8_forest_first_tree_shared (forest) ?
         -forest->first_local_tree - 1 : forest->first_local_tree;
-  if (t8_forest_get_num_element(forest) <= 0) {
+  if (t8_forest_get_local_num_elements(forest) <= 0) {
     /* This forest is empty */
     is_empty = 1;
     /* Set the global number of trees as offset (temporarily) */
@@ -1153,7 +1153,7 @@ t8_forest_partition_given (t8_forest_t forest, const int send_data,
       - t8_shmem_array_get_gloidx (forest->element_offsets, forest->mpirank);
   }
   else {
-    num_new_elements = t8_forest_get_num_element (forest);
+    num_new_elements = t8_forest_get_local_num_elements (forest);
   }
 
   if (num_new_elements > 0) {

--- a/src/t8_forest/t8_forest_vtk.cxx
+++ b/src/t8_forest/t8_forest_vtk.cxx
@@ -1112,7 +1112,7 @@ t8_forest_vtk_write_file (t8_forest_t forest, const char *fileprefix,
   }
 
   /* The local number of elements */
-  num_elements = t8_forest_get_num_element (forest);
+  num_elements = t8_forest_get_local_num_elements (forest);
   if (write_ghosts) {
     num_elements += t8_forest_get_num_ghosts (forest);
   }

--- a/test/t8_test_element_general_function.cxx
+++ b/test/t8_test_element_general_function.cxx
@@ -65,7 +65,7 @@ test_element_general_function (sc_MPI_Comm comm)
         t8_forest_new_uniform (t8_cmesh_new_from_class
                                ((t8_eclass_t) (eclass), comm), ts, level, 0,
                                comm);
-      for (ielement = 0; ielement < t8_forest_get_num_element (forest);
+      for (ielement = 0; ielement < t8_forest_get_local_num_elements (forest);
            ++ielement) {
         int8_t              outdata = -1;
         int8_t              should_be = -1;

--- a/test/t8_test_ghost_exchange.cxx
+++ b/test/t8_test_ghost_exchange.cxx
@@ -76,7 +76,7 @@ t8_test_ghost_exchange_data_id (t8_forest_t forest)
   size_t              array_pos = 0;
   sc_array_t          element_data;
 
-  num_elements = t8_forest_get_num_element (forest);
+  num_elements = t8_forest_get_local_num_elements (forest);
   num_ghosts = t8_forest_get_num_ghosts (forest);
   /* Allocate a uin64_t as data for each element and each ghost */
   sc_array_init_size (&element_data, sizeof (t8_linearidx_t),
@@ -144,7 +144,7 @@ t8_test_ghost_exchange_data_int (t8_forest_t forest)
   t8_locidx_t         num_elements, ielem, num_ghosts;
   int                 ghost_int;
 
-  num_elements = t8_forest_get_num_element (forest);
+  num_elements = t8_forest_get_local_num_elements (forest);
   num_ghosts = t8_forest_get_num_ghosts (forest);
   /* Allocate an integer as data for each element and each ghost */
   sc_array_init_size (&element_data, sizeof (int), num_elements + num_ghosts);

--- a/test/t8_test_point_inside.cxx
+++ b/test/t8_test_point_inside.cxx
@@ -71,7 +71,7 @@ t8_test_point_inside_level0 (sc_MPI_Comm comm, t8_eclass_t eclass)
   /* Build a uniform level 0 forest */
   forest = t8_forest_new_uniform (cmesh, default_scheme, 0, 0, comm);
 
-  if (t8_forest_get_num_element (forest) > 0) { /* Skip empty forests (occur when executed in parallel) */
+  if (t8_forest_get_local_num_elements (forest) > 0) {  /* Skip empty forests (occur when executed in parallel) */
 
     /* Get a pointer to the single element */
     element = t8_forest_get_element (forest, 0, NULL);
@@ -226,7 +226,7 @@ t8_test_point_inside_specific_triangle ()
     t8_forest_new_uniform (cmesh, t8_scheme_new_default_cxx (), 0, 0,
                            sc_MPI_COMM_WORLD);
 
-  if (t8_forest_get_num_element (forest) <= 0) {        /* Skip empty forests (occur when executed in parallel) */
+  if (t8_forest_get_local_num_elements (forest) <= 0) { /* Skip empty forests (occur when executed in parallel) */
     t8_forest_unref (&forest);
     return;
   }

--- a/test/t8_test_search.cxx
+++ b/test/t8_test_search.cxx
@@ -138,7 +138,7 @@ t8_test_search_one_query_matches_all (sc_MPI_Comm comm, t8_eclass_t eclass,
   sc_array_init_size (&queries, sizeof (int), 1);
   *(int *) sc_array_index (&queries, 0) = query;
 
-  num_elements = t8_forest_get_num_element (forest);
+  num_elements = t8_forest_get_local_num_elements (forest);
   /* set up an array in which we flag whether an element was matched in the
    * search */
   sc_array_init_size (&matched_leafs, sizeof (int), num_elements);

--- a/test/t8_test_transform.cxx
+++ b/test/t8_test_transform.cxx
@@ -173,7 +173,8 @@ t8_test_transform (sc_MPI_Comm comm)
       t8_forest_set_scheme (forest, default_scheme);
       t8_forest_commit (forest);
 
-      for (ielem = 0; ielem < t8_forest_get_num_element (forest); ielem++) {
+      for (ielem = 0; ielem < t8_forest_get_local_num_elements (forest);
+           ielem++) {
         /* Get a pointer to the element */
         element = t8_forest_get_element (forest, ielem, NULL);
         /* perform the transform test */


### PR DESCRIPTION
The name of the function to query the local number
of elements was misleading.
We changed it to be consistent with the name of
the function getting the global number of elements.