### PR TITLE
extend_example_timesteps

### DIFF
--- a/example/common/t8_example_common.cxx
+++ b/example/common/t8_example_common.cxx
@@ -207,7 +207,15 @@ t8_common_adapt_level_set (t8_forest_t forest,
      * as argument, we coarsen to level base level */
     return -1;
   }
-  return 0;
+  else if (ts->t8_element_test_if_subelement (elements[0]) == 1) {
+    /* every subelement should be coarsened to its parent quadrant 
+     * such that there are no subelements left before entering the 
+     * remove_hanging_faces function */
+    return -1;
+  }
+  else {
+    return 0;
+  }
 }
 
 #if 0

--- a/example/common/t8_example_common.cxx
+++ b/example/common/t8_example_common.cxx
@@ -156,8 +156,10 @@ t8_common_adapt_level_set (t8_forest_t forest,
   int                 level;
   double             *tree_vertices;
 
+  /* TODO: check if this assertion makes sense */
   T8_ASSERT (num_elements == 1 || num_elements ==
-             ts->t8_element_num_siblings (elements[0]));
+             ts->t8_element_num_siblings (elements[0])
+             || num_elements == ts->t8_element_num_children (elements[0]));
 
   data = (t8_example_level_set_struct_t *) t8_forest_get_user_data (forest);
   level = ts->t8_element_level (elements[0]);
@@ -174,7 +176,7 @@ t8_common_adapt_level_set (t8_forest_t forest,
   if (level > data->max_level && num_elements > 1) {
     return -1;
   }
-  /* the following case is not reasonable if we use multiple timesteps */
+  /* The following case is somehow not reasonable and leads to problems for multiple timesteps */
 #if 0
   if (level >= data->max_level) {
     return 0;
@@ -194,7 +196,9 @@ t8_common_adapt_level_set (t8_forest_t forest,
     /* The element can be refined and lies inside the refinement region */
     return 1;
   }
-  else if (num_elements > 1 && level > data->min_level && !within_band) {
+  else if (num_elements > 1 
+           && (level > data->min_level || ts->t8_element_test_if_subelement (elements[0]) == 1 && level >= data->min_level) 
+           && !within_band) {
     /* If element lies out of the refinement region and a family was given
      * as argument, we coarsen to level base level */
     return -1;

--- a/example/common/t8_example_common.cxx
+++ b/example/common/t8_example_common.cxx
@@ -195,22 +195,9 @@ t8_common_adapt_level_set (t8_forest_t forest,
     /* The element can be refined and lies inside the refinement region */
     return 1;
   }
-  /* At this point a special condition for subelements is added. 
-   * Otherwise, subelements of the lowest level would never be coarsended back to their parent quadrant again,
-   * since their level is the same. */
-  else if (num_elements > 1
-           && (level > data->min_level
-               || (ts->t8_element_test_if_subelement (elements[0]) == 1
-                   && level >= data->min_level))
-           && !within_band) {
+  else if (num_elements > 1 && level > data->min_level && !within_band) {
     /* If element lies out of the refinement region and a family was given
      * as argument, we coarsen to level base level */
-    return -1;
-  }
-  else if (ts->t8_element_test_if_subelement (elements[0]) == 1) {
-    /* Every subelement should at least be coarsened to its parent quadrant, 
-     * if all other cases did not come into effect, such that there are no subelements left
-     * before entering the remove_hanging_faces function. */
     return -1;
   }
   else {

--- a/example/common/t8_example_common.cxx
+++ b/example/common/t8_example_common.cxx
@@ -156,10 +156,8 @@ t8_common_adapt_level_set (t8_forest_t forest,
   int                 level;
   double             *tree_vertices;
 
-  /* TODO: check if this assertion makes sense */
   T8_ASSERT (num_elements == 1 || num_elements ==
-             ts->t8_element_num_siblings (elements[0])
-             || num_elements == ts->t8_element_num_children (elements[0]));
+             ts->t8_element_num_siblings (elements[0]));
 
   data = (t8_example_level_set_struct_t *) t8_forest_get_user_data (forest);
   level = ts->t8_element_level (elements[0]);
@@ -176,7 +174,8 @@ t8_common_adapt_level_set (t8_forest_t forest,
   if (level > data->max_level && num_elements > 1) {
     return -1;
   }
-  /* The following case is somehow not reasonable and leads to problems for multiple timesteps */
+  /* The following case is not reasonable for multiple timesteps.
+   * Elements of the highest level will not be coarsended again. */
 #if 0
   if (level >= data->max_level) {
     return 0;
@@ -195,7 +194,10 @@ t8_common_adapt_level_set (t8_forest_t forest,
   if (within_band && level < data->max_level) {
     /* The element can be refined and lies inside the refinement region */
     return 1;
-  }
+  } 
+  /* At this point a special condition for subelements is added. 
+   * Otherwise, subelements of the lowest level would never be coarsended back to their parent quadrant again,
+   * since their level is the same. */
   else if (num_elements > 1
            && (level > data->min_level
                || (ts->t8_element_test_if_subelement (elements[0]) == 1

--- a/example/common/t8_example_common.cxx
+++ b/example/common/t8_example_common.cxx
@@ -199,7 +199,7 @@ t8_common_adapt_level_set (t8_forest_t forest,
   else if (num_elements > 1
            && (level > data->min_level
                || (ts->t8_element_test_if_subelement (elements[0]) == 1
-               && level >= data->min_level))
+                   && level >= data->min_level))
            && !within_band) {
     /* If element lies out of the refinement region and a family was given
      * as argument, we coarsen to level base level */

--- a/example/common/t8_example_common.cxx
+++ b/example/common/t8_example_common.cxx
@@ -169,17 +169,17 @@ t8_common_adapt_level_set (t8_forest_t forest,
 
   /* Get the minimum and maximum x-coordinate from the user data pointer of forest */
   data = (t8_example_level_set_struct_t *) t8_forest_get_user_data (forest);
-  
+
   /* If maxlevel is exceeded, coarsen or do not refine */
   if (level > data->max_level && num_elements > 1) {
     return -1;
   }
   /* the following case is not reasonable if we use multiple timesteps */
-  #if 0
+#if 0
   if (level >= data->max_level) {
     return 0;
   }
-  #endif
+#endif
   /* Refine at least until min level */
   if (level < data->min_level) {
     return 1;
@@ -189,7 +189,7 @@ t8_common_adapt_level_set (t8_forest_t forest,
     t8_common_within_levelset (forest_from, which_tree, elements[0],
                                ts, tree_vertices, data->L,
                                data->band_width / 2, data->t, data->udata);
-  
+
   if (within_band && level < data->max_level) {
     /* The element can be refined and lies inside the refinement region */
     return 1;

--- a/example/common/t8_example_common.cxx
+++ b/example/common/t8_example_common.cxx
@@ -196,8 +196,10 @@ t8_common_adapt_level_set (t8_forest_t forest,
     /* The element can be refined and lies inside the refinement region */
     return 1;
   }
-  else if (num_elements > 1 
-           && (level > data->min_level || ts->t8_element_test_if_subelement (elements[0]) == 1 && level >= data->min_level) 
+  else if (num_elements > 1
+           && (level > data->min_level
+               || (ts->t8_element_test_if_subelement (elements[0]) == 1
+               && level >= data->min_level))
            && !within_band) {
     /* If element lies out of the refinement region and a family was given
      * as argument, we coarsen to level base level */

--- a/example/common/t8_example_common.cxx
+++ b/example/common/t8_example_common.cxx
@@ -194,7 +194,7 @@ t8_common_adapt_level_set (t8_forest_t forest,
   if (within_band && level < data->max_level) {
     /* The element can be refined and lies inside the refinement region */
     return 1;
-  } 
+  }
   /* At this point a special condition for subelements is added. 
    * Otherwise, subelements of the lowest level would never be coarsended back to their parent quadrant again,
    * since their level is the same. */

--- a/example/common/t8_example_common.cxx
+++ b/example/common/t8_example_common.cxx
@@ -208,9 +208,9 @@ t8_common_adapt_level_set (t8_forest_t forest,
     return -1;
   }
   else if (ts->t8_element_test_if_subelement (elements[0]) == 1) {
-    /* every subelement should be coarsened to its parent quadrant 
-     * such that there are no subelements left before entering the 
-     * remove_hanging_faces function */
+    /* Every subelement should at least be coarsened to its parent quadrant, 
+     * if all other cases did not come into effect, such that there are no subelements left
+     * before entering the remove_hanging_faces function. */
     return -1;
   }
   else {

--- a/example/common/t8_example_common.cxx
+++ b/example/common/t8_example_common.cxx
@@ -45,7 +45,7 @@ t8_common_adapt_balance (t8_forest_t forest, t8_forest_t forest_from,
   int                 level;
   int                 maxlevel, child_id;
   T8_ASSERT (num_elements == 1 || num_elements ==
-             ts->t8_element_num_children (elements[0]));
+             ts->t8_element_num_siblings (elements[0]));
   level = ts->t8_element_level (elements[0]);
 
   /* we set a maximum refinement level as forest user data */
@@ -157,7 +157,7 @@ t8_common_adapt_level_set (t8_forest_t forest,
   double             *tree_vertices;
 
   T8_ASSERT (num_elements == 1 || num_elements ==
-             ts->t8_element_num_children (elements[0]));
+             ts->t8_element_num_siblings (elements[0]));
 
   data = (t8_example_level_set_struct_t *) t8_forest_get_user_data (forest);
   level = ts->t8_element_level (elements[0]);
@@ -174,9 +174,12 @@ t8_common_adapt_level_set (t8_forest_t forest,
   if (level > data->max_level && num_elements > 1) {
     return -1;
   }
+  /* the following case is not reasonable if we use multiple timesteps */
+  #if 0
   if (level >= data->max_level) {
     return 0;
   }
+  #endif
   /* Refine at least until min level */
   if (level < data->min_level) {
     return 1;

--- a/example/subelements/t8_quad_refinement_with_subelements.cxx
+++ b/example/subelements/t8_quad_refinement_with_subelements.cxx
@@ -65,10 +65,10 @@ t8_refine_with_subelements (t8_eclass_t eclass)
   /* Values for the mesh refinement */
   int                 initlevel = 3;    /* initial uniform refinement level */
   int                 minlevel = initlevel;     /* lowest level allowed for coarsening */
-  int                 maxlevel = 5;     /* highest level allowed for refining */
+  int                 maxlevel = 6;     /* highest level allowed for refining */
 
   /* Values for multiple timesteps */
-  int                 timesteps = 3;    /* Number of times, the mesh is refined */
+  int                 timesteps = 1;    /* Number of times, the mesh is refined */
   double              delta = 0.2;      /* The value, the radius increases after each timestep */
   int                 i;
 
@@ -97,7 +97,7 @@ t8_refine_with_subelements (t8_eclass_t eclass)
   sdata.mid_point[0] = 0.2;
   sdata.mid_point[1] = 0.4;
   sdata.mid_point[2] = 0;
-  sdata.radius = 0.2;
+  sdata.radius = 0.6;
 
   /* refinement parameter */
   ls_data.band_width = 1.5;
@@ -116,11 +116,11 @@ t8_refine_with_subelements (t8_eclass_t eclass)
     /* Adapt the mesh according to the user data */
     t8_forest_set_user_data (forest_adapt, &ls_data);
     t8_forest_set_adapt (forest_adapt, forest, t8_common_adapt_level_set, 1);
-    //t8_forest_set_balance (forest_adapt, forest, 0);
+    t8_forest_set_balance (forest_adapt, forest, 0);
 
     /* Analogue to the other set-functions, this function adds subelements to the from_method. 
      * The forest will therefore use subelements while adapting in order to remove hanging faces from the mesh. */
-    t8_forest_set_remove_hanging_faces (forest_adapt, NULL);
+    // t8_forest_set_remove_hanging_faces (forest_adapt, NULL);
 
     t8_forest_commit (forest_adapt);
 

--- a/example/subelements/t8_quad_refinement_with_subelements.cxx
+++ b/example/subelements/t8_quad_refinement_with_subelements.cxx
@@ -60,7 +60,9 @@ t8_refine_with_subelements (t8_eclass_t eclass)
   char                filename[BUFSIZ];
   int                 initlevel = 2;    /* initial uniform refinement level */
   int                 minlevel = 1;     /* lowest level allowed for coarsening */
-  int                 maxlevel = 3;     /* highest level allowed for refining */
+  int                 maxlevel = 5;     /* highest level allowed for refining */
+  int                 timesteps = 3;    /* Number of times, the mesh is refined */
+  int                 i;
 
   t8_forest_init (&forest);
   t8_forest_init (&forest_adapt);
@@ -81,10 +83,10 @@ t8_refine_with_subelements (t8_eclass_t eclass)
   t8_example_level_set_struct_t ls_data;
   t8_basic_sphere_data_t sdata;
 
-  sdata.mid_point[0] = 0.5;
-  sdata.mid_point[1] = 0.5;
+  sdata.mid_point[0] = -0.3;
+  sdata.mid_point[1] = -0.3;
   sdata.mid_point[2] = 0;
-  sdata.radius = 0.3;
+  sdata.radius = 0.5;
 
   ls_data.band_width = 1;
   ls_data.L = t8_basic_level_set_sphere;
@@ -92,51 +94,37 @@ t8_refine_with_subelements (t8_eclass_t eclass)
   ls_data.max_level = maxlevel;
   ls_data.udata = &sdata;
 
-  /* Adapt the mesh according to the user data. At the moment, balancing the adapted mesh afterwards is important for 
-   * the subelement functions to work. */
-  t8_forest_set_user_data (forest_adapt, &ls_data);
-  t8_forest_set_adapt (forest_adapt, forest, t8_common_adapt_level_set, 1);
+  for (i = 0; i < timesteps; i++) {
+    /* Set new user data for the second timestep */
+    sdata.mid_point[0] += 0.3 * i;
+    sdata.mid_point[1] += 0.3 * i;
 
-  /* This function is the point of entry for the subelements.
-   * Analogue to the other set-functions, we add subelements to the from_method and will therefore 
-   * use the corresponding functions later during the adaption. */
-  t8_forest_set_remove_hanging_faces (forest_adapt, NULL);
+    /* Adapt the mesh according to the user data. At the moment, balancing the adapted mesh afterwards is important for 
+    * the subelement functions to work. */
+    t8_forest_set_user_data (forest_adapt, &ls_data);
+    t8_forest_set_adapt (forest_adapt, forest, t8_common_adapt_level_set, 1);
 
-  t8_forest_commit (forest_adapt);
+    /* This function is the point of entry for the subelements.
+    * Analogue to the other set-functions, we add subelements to the from_method and will therefore 
+    * use the corresponding functions later during the adaption. */
+    t8_forest_set_remove_hanging_faces (forest_adapt, NULL);
 
-  /* print to vtk */
-  snprintf (filename, BUFSIZ, "forest_adapt_no_hanging_nodes_timestep1_%s",
-            t8_eclass_to_string[eclass]);
-  t8_forest_write_vtk (forest_adapt, filename);
+    t8_forest_commit (forest_adapt);
 
-  /* Set forest to the partitioned forest, so it gets adapted
-   * in the next time step. */
-  forest = forest_adapt;
-
-  /* Set new user data for the second timestep */
-  sdata.mid_point[0] = 0.5;
-  sdata.mid_point[1] = 0.5;
-  sdata.mid_point[2] = 0;
-  sdata.radius = 0.3;
-
-  ls_data.band_width = 1;
-  ls_data.L = t8_basic_level_set_sphere;
-  ls_data.min_level = minlevel;
-  ls_data.max_level = maxlevel;
-  ls_data.udata = &sdata;
-
-  /* set and adapt the forest */
-  t8_forest_init (&forest_adapt);
-  t8_forest_set_user_data (forest_adapt, &ls_data);
-  t8_forest_set_adapt (forest_adapt, forest, t8_common_adapt_level_set, 1);
-  t8_forest_set_remove_hanging_faces (forest_adapt, NULL);
-  t8_forest_commit (forest_adapt);
-
-  /* print to vtk */
-  snprintf (filename, BUFSIZ, "forest_adapt_no_hanging_nodes_timestep2_%s",
-            t8_eclass_to_string[eclass]);
-  t8_forest_write_vtk (forest_adapt, filename);
-
+    /* print to vtk */
+    snprintf (filename, BUFSIZ, "forest_adapt_no_hanging_nodes_timestep%i_%s",
+              i, t8_eclass_to_string[eclass]);
+    t8_forest_write_vtk (forest_adapt, filename);
+    
+    if (i == timesteps - 1) {
+      break;
+    }
+    /* Set forest to the partitioned forest, so it gets adapted
+      * in the next time step. */
+      forest = forest_adapt;
+      
+      t8_forest_init (&forest_adapt);
+  }
   t8_forest_unref (&forest_adapt);
 }
 

--- a/example/subelements/t8_quad_refinement_with_subelements.cxx
+++ b/example/subelements/t8_quad_refinement_with_subelements.cxx
@@ -100,13 +100,13 @@ t8_refine_with_subelements (t8_eclass_t eclass)
     sdata.mid_point[1] += 0.3 * i;
 
     /* Adapt the mesh according to the user data. At the moment, balancing the adapted mesh afterwards is important for 
-    * the subelement functions to work. */
+     * the subelement functions to work. */
     t8_forest_set_user_data (forest_adapt, &ls_data);
     t8_forest_set_adapt (forest_adapt, forest, t8_common_adapt_level_set, 1);
 
     /* This function is the point of entry for the subelements.
-    * Analogue to the other set-functions, we add subelements to the from_method and will therefore 
-    * use the corresponding functions later during the adaption. */
+     * Analogue to the other set-functions, we add subelements to the from_method and will therefore 
+     * use the corresponding functions later during the adaption. */
     t8_forest_set_remove_hanging_faces (forest_adapt, NULL);
 
     t8_forest_commit (forest_adapt);
@@ -115,15 +115,15 @@ t8_refine_with_subelements (t8_eclass_t eclass)
     snprintf (filename, BUFSIZ, "forest_adapt_no_hanging_nodes_timestep%i_%s",
               i, t8_eclass_to_string[eclass]);
     t8_forest_write_vtk (forest_adapt, filename);
-    
+
     if (i == timesteps - 1) {
       break;
     }
     /* Set forest to the partitioned forest, so it gets adapted
-      * in the next time step. */
-      forest = forest_adapt;
-      
-      t8_forest_init (&forest_adapt);
+     * in the next time step. */
+    forest = forest_adapt;
+
+    t8_forest_init (&forest_adapt);
   }
   t8_forest_unref (&forest_adapt);
 }

--- a/example/subelements/t8_quad_refinement_with_subelements.cxx
+++ b/example/subelements/t8_quad_refinement_with_subelements.cxx
@@ -104,7 +104,36 @@ t8_refine_with_subelements (t8_eclass_t eclass)
 
   t8_forest_commit (forest_adapt);
 
-  snprintf (filename, BUFSIZ, "forest_adapt_no_hanging_nodes_%s",
+  /* print to vtk */
+  snprintf (filename, BUFSIZ, "forest_adapt_no_hanging_nodes_timestep1_%s",
+            t8_eclass_to_string[eclass]);
+  t8_forest_write_vtk (forest_adapt, filename);
+
+  /* Set forest to the partitioned forest, so it gets adapted
+   * in the next time step. */
+  forest = forest_adapt;
+
+  /* Set new user data for the second timestep */
+  sdata.mid_point[0] = 0.5;
+  sdata.mid_point[1] = 0.5;
+  sdata.mid_point[2] = 0;
+  sdata.radius = 0.5;
+
+  ls_data.band_width = 1;
+  ls_data.L = t8_basic_level_set_sphere;
+  ls_data.min_level = minlevel;
+  ls_data.max_level = maxlevel;
+  ls_data.udata = &sdata;
+
+  /* set and adapt the forest */
+  t8_forest_init (&forest_adapt);
+  t8_forest_set_user_data (forest_adapt, &ls_data);
+  t8_forest_set_adapt (forest_adapt, forest, t8_common_adapt_level_set, 1);
+  t8_forest_set_remove_hanging_faces (forest_adapt, NULL);
+  t8_forest_commit (forest_adapt);
+
+  /* print to vtk */
+  snprintf (filename, BUFSIZ, "forest_adapt_no_hanging_nodes_timestep2_%s",
             t8_eclass_to_string[eclass]);
   t8_forest_write_vtk (forest_adapt, filename);
 

--- a/example/subelements/t8_quad_refinement_with_subelements.cxx
+++ b/example/subelements/t8_quad_refinement_with_subelements.cxx
@@ -68,7 +68,7 @@ t8_refine_with_subelements (t8_eclass_t eclass)
   int                 maxlevel = 6;     /* highest level allowed for refining */
 
   /* Values for multiple timesteps */
-  int                 timesteps = 1;    /* Number of times, the mesh is refined */
+  int                 timesteps = 4;    /* Number of times, the mesh is refined */
   double              delta = 0.2;      /* The value, the radius increases after each timestep */
   int                 i;
 
@@ -97,7 +97,7 @@ t8_refine_with_subelements (t8_eclass_t eclass)
   sdata.mid_point[0] = 0.2;
   sdata.mid_point[1] = 0.4;
   sdata.mid_point[2] = 0;
-  sdata.radius = 0.6;
+  sdata.radius = 0.2;
 
   /* refinement parameter */
   ls_data.band_width = 1.5;
@@ -105,6 +105,10 @@ t8_refine_with_subelements (t8_eclass_t eclass)
   ls_data.min_level = minlevel;
   ls_data.max_level = maxlevel;
   ls_data.udata = &sdata;
+
+  /* TODO: the time_forest examples use several refine_rounds within each time-loop. 
+   * This might resolve the problem with appearing artifacts during adaptation with multiple timesteps.
+   * This does not seem to be a problem of subelements but of the timestep scheme implemented in this example. */
 
   /* Adapting the mesh for different timesteps */
   for (i = 0; i < timesteps; i++) {
@@ -116,11 +120,11 @@ t8_refine_with_subelements (t8_eclass_t eclass)
     /* Adapt the mesh according to the user data */
     t8_forest_set_user_data (forest_adapt, &ls_data);
     t8_forest_set_adapt (forest_adapt, forest, t8_common_adapt_level_set, 1);
-    t8_forest_set_balance (forest_adapt, forest, 0);
+    // t8_forest_set_balance (forest_adapt, forest, 0);
 
     /* Analogue to the other set-functions, this function adds subelements to the from_method. 
      * The forest will therefore use subelements while adapting in order to remove hanging faces from the mesh. */
-    // t8_forest_set_remove_hanging_faces (forest_adapt, NULL);
+    t8_forest_set_remove_hanging_faces (forest_adapt, NULL);
 
     t8_forest_commit (forest_adapt);
 
@@ -141,9 +145,13 @@ t8_refine_with_subelements (t8_eclass_t eclass)
 
     /* Increasing the radius of the sphere for the next timestep */
     sdata.radius += delta;
-  }
+
+    t8_productionf
+      ("This is t8_refine_with_subelements. Done timestep %i of %i\n", i + 1,
+       timesteps);
+  } /* end of time-loop */
   t8_forest_unref (&forest_adapt);
-}
+} /* end of function */
 
 int
 main (int argc, char **argv)

--- a/example/subelements/t8_quad_refinement_with_subelements.cxx
+++ b/example/subelements/t8_quad_refinement_with_subelements.cxx
@@ -63,13 +63,13 @@ t8_refine_with_subelements (t8_eclass_t eclass)
   char                filename[BUFSIZ];
 
   /* init_level >= 3 is recommended for this example. It is also recommended to use min = init. */
-  int                 initlevel = 3;            /* initial uniform refinement level */
+  int                 initlevel = 3;    /* initial uniform refinement level */
   int                 minlevel = initlevel;     /* lowest level allowed for coarsening */
-  int                 maxlevel = 5;             /* highest level allowed for refining */
-  
+  int                 maxlevel = 5;     /* highest level allowed for refining */
+
   /* values for multiple timesteps */
-  int                 timesteps = 3;            /* Number of times, the mesh is refined */
-  double              delta = 0.2;             /* The value, the radius increases after each timestep */
+  int                 timesteps = 3;    /* Number of times, the mesh is refined */
+  double              delta = 0.2;      /* The value, the radius increases after each timestep */
   int                 i;
 
   t8_forest_init (&forest);
@@ -105,7 +105,9 @@ t8_refine_with_subelements (t8_eclass_t eclass)
   /* Iterate over different timesteps */
   for (i = 0; i < timesteps; i++) {
 
-    t8_productionf ("This is t8_refine_with_subelements. Into timestep %i of %i\n", i+1, timesteps);
+    t8_productionf
+      ("This is t8_refine_with_subelements. Into timestep %i of %i\n", i + 1,
+       timesteps);
 
     /* Adapt the mesh according to the user data. At the moment, balancing the adapted mesh afterwards is important for 
      * the subelement functions to work. */

--- a/example/subelements/t8_quad_refinement_with_subelements.cxx
+++ b/example/subelements/t8_quad_refinement_with_subelements.cxx
@@ -117,7 +117,7 @@ t8_refine_with_subelements (t8_eclass_t eclass)
   sdata.mid_point[0] = 0.5;
   sdata.mid_point[1] = 0.5;
   sdata.mid_point[2] = 0;
-  sdata.radius = 0.5;
+  sdata.radius = 0.3;
 
   ls_data.band_width = 1;
   ls_data.L = t8_basic_level_set_sphere;

--- a/example/subelements/t8_quad_refinement_with_subelements.cxx
+++ b/example/subelements/t8_quad_refinement_with_subelements.cxx
@@ -59,11 +59,11 @@ t8_refine_with_subelements (t8_eclass_t eclass)
   t8_cmesh_t          cmesh;
   char                filename[BUFSIZ];
   /* init_level >= 3 is recommended for this example. It is also recommended to use min = init. */
-  int                 initlevel = 3;            /* initial uniform refinement level */
+  int                 initlevel = 3;    /* initial uniform refinement level */
   int                 minlevel = initlevel;     /* lowest level allowed for coarsening */
-  int                 maxlevel = 6;             /* highest level allowed for refining */
+  int                 maxlevel = 6;     /* highest level allowed for refining */
 
-  int                 timesteps = 4;            /* Number of times, the mesh is refined */
+  int                 timesteps = 4;    /* Number of times, the mesh is refined */
   int                 i;
 
   t8_forest_init (&forest);

--- a/example/subelements/t8_quad_refinement_with_subelements.cxx
+++ b/example/subelements/t8_quad_refinement_with_subelements.cxx
@@ -58,10 +58,12 @@ t8_refine_with_subelements (t8_eclass_t eclass)
   t8_forest_t         forest_adapt;
   t8_cmesh_t          cmesh;
   char                filename[BUFSIZ];
-  int                 initlevel = 2;    /* initial uniform refinement level */
-  int                 minlevel = 1;     /* lowest level allowed for coarsening */
-  int                 maxlevel = 5;     /* highest level allowed for refining */
-  int                 timesteps = 3;    /* Number of times, the mesh is refined */
+  /* init_level >= 3 is recommended for this example. It is also recommended to use min = init. */
+  int                 initlevel = 3;            /* initial uniform refinement level */
+  int                 minlevel = initlevel;     /* lowest level allowed for coarsening */
+  int                 maxlevel = 6;             /* highest level allowed for refining */
+
+  int                 timesteps = 4;            /* Number of times, the mesh is refined */
   int                 i;
 
   t8_forest_init (&forest);
@@ -83,10 +85,10 @@ t8_refine_with_subelements (t8_eclass_t eclass)
   t8_example_level_set_struct_t ls_data;
   t8_basic_sphere_data_t sdata;
 
-  sdata.mid_point[0] = -0.3;
-  sdata.mid_point[1] = -0.3;
+  sdata.mid_point[0] = 0;
+  sdata.mid_point[1] = 0;
   sdata.mid_point[2] = 0;
-  sdata.radius = 0.5;
+  sdata.radius = 0.2;
 
   ls_data.band_width = 1;
   ls_data.L = t8_basic_level_set_sphere;
@@ -94,15 +96,14 @@ t8_refine_with_subelements (t8_eclass_t eclass)
   ls_data.max_level = maxlevel;
   ls_data.udata = &sdata;
 
+  /* Iterate over different timesteps */
   for (i = 0; i < timesteps; i++) {
-    /* Set new user data for the second timestep */
-    sdata.mid_point[0] += 0.3 * i;
-    sdata.mid_point[1] += 0.3 * i;
 
     /* Adapt the mesh according to the user data. At the moment, balancing the adapted mesh afterwards is important for 
      * the subelement functions to work. */
     t8_forest_set_user_data (forest_adapt, &ls_data);
     t8_forest_set_adapt (forest_adapt, forest, t8_common_adapt_level_set, 1);
+    //t8_forest_set_balance (forest_adapt, forest, 0);
 
     /* This function is the point of entry for the subelements.
      * Analogue to the other set-functions, we add subelements to the from_method and will therefore 
@@ -124,6 +125,9 @@ t8_refine_with_subelements (t8_eclass_t eclass)
     forest = forest_adapt;
 
     t8_forest_init (&forest_adapt);
+
+    /* Set new user data for the next timestep */
+    sdata.radius += 0.25;
   }
   t8_forest_unref (&forest_adapt);
 }

--- a/example/subelements/t8_quad_refinement_with_subelements.cxx
+++ b/example/subelements/t8_quad_refinement_with_subelements.cxx
@@ -149,9 +149,9 @@ t8_refine_with_subelements (t8_eclass_t eclass)
     t8_productionf
       ("This is t8_refine_with_subelements. Done timestep %i of %i\n", i + 1,
        timesteps);
-  } /* end of time-loop */
+  }                             /* end of time-loop */
   t8_forest_unref (&forest_adapt);
-} /* end of function */
+}                               /* end of function */
 
 int
 main (int argc, char **argv)

--- a/example/subelements/t8_test_subelement_functions.cxx
+++ b/example/subelements/t8_test_subelement_functions.cxx
@@ -74,6 +74,9 @@ t8_refine_quad_to_subelements ()
      type, num_subelements, num_subelements - 1);
   t8_productionf ("The coordinates of these subelements are:\n");
 
+  /* test the is_family function for subelements */
+  class_scheme->t8_element_is_family (element_subelements);
+
   /* Iterate through all subelements and determine their vertex coordinates */
   for (subelement_id = 0; subelement_id < num_subelements; ++subelement_id) {
 

--- a/src/t8_element_cxx.hxx
+++ b/src/t8_element_cxx.hxx
@@ -667,6 +667,16 @@ public:
                                                             t8_element_t *
                                                             elem) = 0;
 
+  /* TODO: comment */
+  virtual int                 t8_element_test_if_subelement (const 
+                                                             t8_element *
+                                                             elem) = 0;
+
+  /* TODO: comment */
+  virtual int                 t8_element_get_subelement_type (const 
+                                                              t8_element *
+                                                              elem) = 0;
+
 #ifdef T8_ENABLE_DEBUG
   /** Query whether a given element can be considered as 'valid' and it is
    *  safe to perform any of the above algorithms on it.

--- a/src/t8_element_cxx.hxx
+++ b/src/t8_element_cxx.hxx
@@ -668,14 +668,12 @@ public:
                                                             elem) = 0;
 
   /* TODO: comment */
-  virtual int                 t8_element_test_if_subelement (const 
-                                                             t8_element *
-                                                             elem) = 0;
+  virtual int         t8_element_test_if_subelement (const
+                                                     t8_element * elem) = 0;
 
   /* TODO: comment */
-  virtual int                 t8_element_get_subelement_type (const 
-                                                              t8_element *
-                                                              elem) = 0;
+  virtual int         t8_element_get_subelement_type (const
+                                                      t8_element * elem) = 0;
 
 #ifdef T8_ENABLE_DEBUG
   /** Query whether a given element can be considered as 'valid' and it is

--- a/src/t8_forest.h
+++ b/src/t8_forest.h
@@ -248,7 +248,7 @@ void                t8_forest_set_copy (t8_forest_t forest,
  */
 /* TODO: make recursive flag to int specifying the number of recursions? */
 void                t8_forest_set_adapt (t8_forest_t forest,
-                                         const t8_forest_t set_from,
+                                         t8_forest_t set_from,
                                          t8_forest_adapt_t adapt_fn,
                                          int recursive);
 

--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -252,7 +252,8 @@ t8_forest_set_remove_hanging_faces (t8_forest_t forest,
    * forest->from_method is unequal to one. If so, set balanced is not set yet. */
   if ((forest->from_method & (1 << 2)) >> 2 != 1) {
     t8_productionf
-      ("Forest was not balanced yet. The set_remove_hanging_faces function will set balance with repartition now.\n");
+      ("This is forest_set_remove_hanging_faces.\n"
+       "The forest might not be balanced and set_balance is not set yet. The set_remove_hanging_faces function will set balance with repartition now.\n");
     /* balance with repartition */
     t8_forest_set_balance (forest, NULL, 0);
   }
@@ -324,7 +325,8 @@ t8_forest_set_adapt (t8_forest_t forest, t8_forest_t set_from,
 
   if (set_from->set_subelements == 1) {
     t8_productionf
-      ("This is t8_forest_set_adapt. Remove possible subelements from the mesh for adapting.\n");
+      ("This is t8_forest_set_adapt.\n"
+       "There might be subelements in the forest. The set_adapt function will remove all subelements from the mesh now.\n");
     t8_forest_remove_subelements (set_from);
   }
 

--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -323,12 +323,14 @@ t8_forest_set_adapt (t8_forest_t forest, t8_forest_t set_from,
   forest->set_adapt_fn = adapt_fn;
   forest->set_adapt_recursive = recursive != 0;
 
+  #if 0 
   if (set_from->set_subelements == 1) {
     t8_productionf
       ("This is t8_forest_set_adapt.\n"
        "There might be subelements in the forest. The set_adapt function will remove all subelements from the mesh now.\n");
     t8_forest_remove_subelements (set_from);
   }
+  #endif
 
   if (set_from != NULL) {
     /* If set_from = NULL, we assume a previous forest_from was set */

--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -323,14 +323,14 @@ t8_forest_set_adapt (t8_forest_t forest, t8_forest_t set_from,
   forest->set_adapt_fn = adapt_fn;
   forest->set_adapt_recursive = recursive != 0;
 
-  #if 0 
+#if 0
   if (set_from->set_subelements == 1) {
     t8_productionf
       ("This is t8_forest_set_adapt.\n"
        "There might be subelements in the forest. The set_adapt function will remove all subelements from the mesh now.\n");
     t8_forest_remove_subelements (set_from);
   }
-  #endif
+#endif
 
   if (set_from != NULL) {
     /* If set_from = NULL, we assume a previous forest_from was set */

--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -323,7 +323,8 @@ t8_forest_set_adapt (t8_forest_t forest, t8_forest_t set_from,
   forest->set_adapt_recursive = recursive != 0;
 
   if (set_from->set_subelements == 1) {
-    t8_productionf ("This is t8_forest_set_adapt. Remove possible subelements from the mesh for adapting.\n");
+    t8_productionf
+      ("This is t8_forest_set_adapt. Remove possible subelements from the mesh for adapting.\n");
     t8_forest_remove_subelements (set_from);
   }
 

--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -56,6 +56,7 @@ t8_forest_init (t8_forest_t * pforest)
   forest->set_adapt_recursive = -1;
   forest->set_balance = -1;
   forest->maxlevel_existing = -1;
+  forest->set_subelements = 0;
 }
 
 int
@@ -269,6 +270,8 @@ t8_forest_set_remove_hanging_faces (t8_forest_t forest,
   else {
     forest->from_method |= T8_FOREST_FROM_SUBELEMENTS;
   }
+
+  forest->set_subelements = 1;
 }
 
 void
@@ -304,7 +307,7 @@ t8_forest_set_ghost (t8_forest_t forest, int do_ghost,
 }
 
 void
-t8_forest_set_adapt (t8_forest_t forest, const t8_forest_t set_from,
+t8_forest_set_adapt (t8_forest_t forest, t8_forest_t set_from,
                      t8_forest_adapt_t adapt_fn, int recursive)
 {
   T8_ASSERT (forest != NULL);
@@ -318,6 +321,11 @@ t8_forest_set_adapt (t8_forest_t forest, const t8_forest_t set_from,
 
   forest->set_adapt_fn = adapt_fn;
   forest->set_adapt_recursive = recursive != 0;
+
+  if (set_from->set_subelements == 1) {
+    t8_productionf ("This is t8_forest_set_adapt. Remove possible subelements from the mesh for adapting.\n");
+    t8_forest_remove_subelements (set_from);
+  }
 
   if (set_from != NULL) {
     /* If set_from = NULL, we assume a previous forest_from was set */

--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -323,15 +323,6 @@ t8_forest_set_adapt (t8_forest_t forest, t8_forest_t set_from,
   forest->set_adapt_fn = adapt_fn;
   forest->set_adapt_recursive = recursive != 0;
 
-#if 0
-  if (set_from->set_subelements == 1) {
-    t8_productionf
-      ("This is t8_forest_set_adapt.\n"
-       "There might be subelements in the forest. The set_adapt function will remove all subelements from the mesh now.\n");
-    t8_forest_remove_subelements (set_from);
-  }
-#endif
-
   if (set_from != NULL) {
     /* If set_from = NULL, we assume a previous forest_from was set */
     forest->set_from = set_from;

--- a/src/t8_forest/t8_forest_adapt.cxx
+++ b/src/t8_forest/t8_forest_adapt.cxx
@@ -352,7 +352,7 @@ t8_forest_adapt (t8_forest_t forest)
 
 #ifdef T8_ENABLE_DEBUG
       /* TODO: warning because of size_t instead of int */
-      
+
       /* output for debugging */
       t8_debugf
         ("el_considered: %i/%i  refine: %i  is_family: %i  num_siblings: %i\n",

--- a/src/t8_forest/t8_forest_adapt.cxx
+++ b/src/t8_forest/t8_forest_adapt.cxx
@@ -308,6 +308,9 @@ t8_forest_adapt (t8_forest_t forest)
         elements_from[zz] = t8_element_array_index_locidx (telements_from,
                                                            el_considered +
                                                            zz);
+ 
+        /* Dont use this check for noe since it might be problematic with removing subelements */
+        #if 0
         /* This is a quick check whether we build up a family here and could
          * abort early if not.
          * If the child id of the current element is not zz, then it cannot
@@ -317,6 +320,7 @@ t8_forest_adapt (t8_forest_t forest)
         if ((size_t) tscheme->t8_element_child_id (elements_from[zz]) != zz) {
           break;
         }
+        #endif
       }
 
       if (zz != num_siblings
@@ -445,7 +449,18 @@ t8_forest_adapt (t8_forest_t forest)
         T8_ASSERT (tscheme->t8_element_level (elements_from[0]) > 0);
         tscheme->t8_element_parent (elements_from[0], elements[0]);
         el_inserted++;
-        num_siblings = tscheme->t8_element_num_children (elements[0]);
+
+        if (tscheme->t8_element_test_if_subelement (current_element) == 1) {
+          int                 subelement_type =
+          tscheme->t8_element_get_subelement_type (current_element);
+          num_siblings =
+            tscheme->t8_element_get_number_of_subelements (subelement_type,
+                                                           current_element);   
+        }
+        else {
+          num_siblings = tscheme->t8_element_num_children (elements[0]);
+        }
+
         if (forest->set_adapt_recursive) {
           /* Adaptation is recursive.
            * We check whether the just generated parent is the last in its

--- a/src/t8_forest/t8_forest_adapt.cxx
+++ b/src/t8_forest/t8_forest_adapt.cxx
@@ -365,6 +365,9 @@ t8_forest_adapt (t8_forest_t forest)
                                      el_considered, tscheme,
                                      num_elements_to_adapt_fn, elements_from);
 
+      /* Some output for debugging */
+      t8_debugf ("el_considered: %i  refine: %i  is_family: %i  num_siblings: %i\n", el_considered, refine, is_family, num_siblings);
+
       T8_ASSERT (is_family || refine >= 0);
       if (refine > 0
           && tscheme->t8_element_level (elements_from[0]) >=

--- a/src/t8_forest/t8_forest_adapt.cxx
+++ b/src/t8_forest/t8_forest_adapt.cxx
@@ -480,8 +480,11 @@ t8_forest_adapt (t8_forest_t forest)
          * We copy the element to the new element array. */
         T8_ASSERT (refine == 0);
         elements[0] = t8_element_array_push (telements);
+        /* Note that it should not be allowed to copy a subelement at this point. 
+         * Subelements should always be coarsened to their parent quadrant or their parent quadrant 
+         * should be refined such that no subelements are left after calling the adapt function. */ 
+        T8_ASSERT (tscheme->t8_element_test_if_subelement (elements[0]) == -1);
         tscheme->t8_element_copy (elements_from[0], elements[0]);
-        num_siblings = tscheme->t8_element_num_siblings (elements[0]);
         el_inserted++;
         const int           child_id =
           tscheme->t8_element_child_id (elements[0]);

--- a/src/t8_forest/t8_forest_adapt.cxx
+++ b/src/t8_forest/t8_forest_adapt.cxx
@@ -328,10 +328,10 @@ t8_forest_adapt (t8_forest_t forest)
       /* Pass the element, or the family to the adapt callback.
        * The output will be 
        *
-       *      < 0 if we passed a family and it should get coarsened 
-       *      = 0 if the element should remain as is 
-       *      = 1 if the element should be refined (using the chosen recursive refinement scheme)
-       *      > 1 if we use subelements
+       *      = -1 if we passed a family and it should get coarsened 
+       *      =  0 if the element should remain as is 
+       *      =  1 if the element should be refined (using the chosen recursive refinement scheme)
+       *      >  1 if we use subelements
        * 
        * The values -1,0 and 1 will appear, if we use the standard refinement scheme of the given eclass.
        * 
@@ -350,6 +350,16 @@ t8_forest_adapt (t8_forest_t forest)
                                      el_considered, tscheme,
                                      num_elements_to_adapt_fn, elements_from);
 
+      /* We need to add a special condition for subelements that is independent of the refinement criteria:
+       * After the adapt procedure, no subelements should be left in order to ensure that following modifications 
+       * such as balance or remove_hanigng_faces work properly. 
+       * Therefore, all subelements that "survive" the adaptation will be coarsened back to their parent quadrant. 
+       * Note, that this is always valid for subelements in terms of the minimum level,
+       * since subelements have the same level as their parent quadrant. */
+      if (tscheme->t8_element_test_if_subelement (elements_from[0]) == 1 && refine == 0) {
+        refine = -1;
+      }
+      
 #ifdef T8_ENABLE_DEBUG
       /* TODO: warning because of size_t instead of int */
 

--- a/src/t8_forest/t8_forest_adapt.cxx
+++ b/src/t8_forest/t8_forest_adapt.cxx
@@ -482,8 +482,9 @@ t8_forest_adapt (t8_forest_t forest)
         elements[0] = t8_element_array_push (telements);
         /* Note that it should not be allowed to copy a subelement at this point. 
          * Subelements should always be coarsened to their parent quadrant or their parent quadrant 
-         * should be refined such that no subelements are left after calling the adapt function. */ 
-        T8_ASSERT (tscheme->t8_element_test_if_subelement (elements[0]) == -1);
+         * should be refined such that no subelements are left after calling the adapt function. */
+        T8_ASSERT (tscheme->t8_element_test_if_subelement (elements[0]) ==
+                   -1);
         tscheme->t8_element_copy (elements_from[0], elements[0]);
         el_inserted++;
         const int           child_id =

--- a/src/t8_forest/t8_forest_adapt.cxx
+++ b/src/t8_forest/t8_forest_adapt.cxx
@@ -286,7 +286,7 @@ t8_forest_adapt (t8_forest_t forest)
       t8_element_t       *current_element =
         t8_element_array_index_locidx (telements_from, el_considered);
 
-      int current_element_is_subelement = 0;
+      int                 current_element_is_subelement = 0;
       if (tscheme->t8_element_test_if_subelement (current_element) == 1) {
         current_element_is_subelement = 1;
         int                 subelement_type =

--- a/src/t8_forest/t8_forest_adapt.cxx
+++ b/src/t8_forest/t8_forest_adapt.cxx
@@ -366,7 +366,9 @@ t8_forest_adapt (t8_forest_t forest)
                                      num_elements_to_adapt_fn, elements_from);
 
       /* Some output for debugging */
-      t8_debugf ("el_considered: %i  refine: %i  is_family: %i  num_siblings: %i\n", el_considered, refine, is_family, num_siblings);
+      t8_debugf
+        ("el_considered: %i  refine: %i  is_family: %i  num_siblings: %i\n",
+         el_considered, refine, is_family, num_siblings);
 
       T8_ASSERT (is_family || refine >= 0);
       if (refine > 0

--- a/src/t8_forest/t8_forest_adapt.cxx
+++ b/src/t8_forest/t8_forest_adapt.cxx
@@ -286,7 +286,9 @@ t8_forest_adapt (t8_forest_t forest)
       t8_element_t       *current_element =
         t8_element_array_index_locidx (telements_from, el_considered);
 
+      int current_element_is_subelement = 0;
       if (tscheme->t8_element_test_if_subelement (current_element) == 1) {
+        current_element_is_subelement = 1;
         int                 subelement_type =
           tscheme->t8_element_get_subelement_type (current_element);
         num_siblings =
@@ -408,7 +410,12 @@ t8_forest_adapt (t8_forest_t forest)
                                         elements);
           el_inserted += num_children;
         }
-        el_considered++;
+        if (current_element_is_subelement == 1) {
+          el_considered += num_siblings;
+        }
+        else {
+          el_considered++;
+        }
       }
       else if (refine > 1) {    /* use subelements in this case */
         /* The subelement-callback function returns refine = subelement_type + 1 to avoid subelement_type = 1.

--- a/src/t8_forest/t8_forest_adapt.cxx
+++ b/src/t8_forest/t8_forest_adapt.cxx
@@ -310,7 +310,8 @@ t8_forest_adapt (t8_forest_t forest)
          * are 0, 1, 2, ... zz, ... num_siblings-1).
          * This check is however not sufficient - therefore, we call is_family later. */
         if ((size_t) tscheme->t8_element_child_id (elements_from[zz]) != zz
-            && tscheme->t8_element_test_if_subelement (elements_from[zz]) != 1) {
+            && tscheme->t8_element_test_if_subelement (elements_from[zz]) !=
+            1) {
           break;
         }
       }
@@ -359,7 +360,7 @@ t8_forest_adapt (t8_forest_t forest)
       /* Some output for debugging */
       t8_debugf
         ("el_considered: %i/%i  refine: %i  is_family: %i  num_siblings: %i\n",
-         el_considered, num_el_from ,refine, is_family, num_siblings);
+         el_considered, num_el_from, refine, is_family, num_siblings);
 #endif
 
       T8_ASSERT (is_family || refine >= 0);

--- a/src/t8_forest/t8_forest_adapt.cxx
+++ b/src/t8_forest/t8_forest_adapt.cxx
@@ -308,9 +308,9 @@ t8_forest_adapt (t8_forest_t forest)
         elements_from[zz] = t8_element_array_index_locidx (telements_from,
                                                            el_considered +
                                                            zz);
- 
+
         /* Dont use this check for noe since it might be problematic with removing subelements */
-        #if 0
+#if 0
         /* This is a quick check whether we build up a family here and could
          * abort early if not.
          * If the child id of the current element is not zz, then it cannot
@@ -320,7 +320,7 @@ t8_forest_adapt (t8_forest_t forest)
         if ((size_t) tscheme->t8_element_child_id (elements_from[zz]) != zz) {
           break;
         }
-        #endif
+#endif
       }
 
       if (zz != num_siblings
@@ -452,10 +452,10 @@ t8_forest_adapt (t8_forest_t forest)
 
         if (tscheme->t8_element_test_if_subelement (current_element) == 1) {
           int                 subelement_type =
-          tscheme->t8_element_get_subelement_type (current_element);
+            tscheme->t8_element_get_subelement_type (current_element);
           num_siblings =
             tscheme->t8_element_get_number_of_subelements (subelement_type,
-                                                           current_element);   
+                                                           current_element);
         }
         else {
           num_siblings = tscheme->t8_element_num_children (elements[0]);

--- a/src/t8_forest/t8_forest_adapt.cxx
+++ b/src/t8_forest/t8_forest_adapt.cxx
@@ -283,15 +283,18 @@ t8_forest_adapt (t8_forest_t forest)
        * a family.
        * At the end is_family will be true, if these elements form a family.
        */
-      t8_element_t * current_element = t8_element_array_index_locidx (telements_from, el_considered);
+      t8_element_t       *current_element =
+        t8_element_array_index_locidx (telements_from, el_considered);
 
       if (tscheme->t8_element_test_if_subelement (current_element) == 1) {
-        int subelement_type = tscheme->t8_element_get_subelement_type (current_element);
-        num_siblings = tscheme->t8_element_get_number_of_subelements (subelement_type, current_element);
+        int                 subelement_type =
+          tscheme->t8_element_get_subelement_type (current_element);
+        num_siblings =
+          tscheme->t8_element_get_number_of_subelements (subelement_type,
+                                                         current_element);
       }
       else {
-        num_siblings =
-        tscheme->t8_element_num_siblings (current_element);
+        num_siblings = tscheme->t8_element_num_siblings (current_element);
       }
 
       if (num_siblings > curr_num_siblings) {

--- a/src/t8_forest/t8_forest_adapt.cxx
+++ b/src/t8_forest/t8_forest_adapt.cxx
@@ -356,10 +356,11 @@ t8_forest_adapt (t8_forest_t forest)
        * Therefore, all subelements that "survive" the adaptation will be coarsened back to their parent quadrant. 
        * Note, that this is always valid for subelements in terms of the minimum level,
        * since subelements have the same level as their parent quadrant. */
-      if (tscheme->t8_element_test_if_subelement (elements_from[0]) == 1 && refine == 0) {
+      if (tscheme->t8_element_test_if_subelement (elements_from[0]) == 1
+          && refine == 0) {
         refine = -1;
       }
-      
+
 #ifdef T8_ENABLE_DEBUG
       /* TODO: warning because of size_t instead of int */
 

--- a/src/t8_forest/t8_forest_adapt.cxx
+++ b/src/t8_forest/t8_forest_adapt.cxx
@@ -283,10 +283,16 @@ t8_forest_adapt (t8_forest_t forest)
        * a family.
        * At the end is_family will be true, if these elements form a family.
        */
+      t8_element_t * current_element = t8_element_array_index_locidx (telements_from, el_considered);
 
-      num_siblings =
-        tscheme->t8_element_num_siblings (t8_element_array_index_locidx
-                                          (telements_from, el_considered));
+      if (tscheme->t8_element_test_if_subelement (current_element) == 1) {
+        int subelement_type = tscheme->t8_element_get_subelement_type (current_element);
+        num_siblings = tscheme->t8_element_get_number_of_subelements (subelement_type, current_element);
+      }
+      else {
+        num_siblings =
+        tscheme->t8_element_num_siblings (current_element);
+      }
 
       if (num_siblings > curr_num_siblings) {
         elements_from =

--- a/src/t8_forest/t8_forest_remove_hanging_faces.cxx
+++ b/src/t8_forest/t8_forest_remove_hanging_faces.cxx
@@ -114,10 +114,6 @@ t8_forest_remove_hanging_faces_adapt (t8_forest_t forest,
     }
   }
 
-  /* Print some useful output in debug mode */
-  t8_debugf ("element id: %i    subelement type: %i\n", lelement_id,
-             subelement_type);
-
   /* returning the right subelement types */
   if (subelement_type == 0) {   /* in this case, there are no hanging nodes and we do not need to do anything */
     return 0;

--- a/src/t8_forest/t8_forest_remove_hanging_faces.cxx
+++ b/src/t8_forest/t8_forest_remove_hanging_faces.cxx
@@ -165,7 +165,7 @@ t8_forest_remove_subelements_adapt (t8_forest_t forest,
     t8_forest_get_element_in_tree (forest_from, ltree_id, lelement_id);
 
   t8_quad_with_subelements *pquad_w_sub =
-      (t8_quad_with_subelements *) current_element;
+    (t8_quad_with_subelements *) current_element;
 
   if (pquad_w_sub->dummy_is_subelement == 1) {
     return -1;
@@ -175,8 +175,8 @@ t8_forest_remove_subelements_adapt (t8_forest_t forest,
   }
 }
 
-void 
-t8_forest_remove_subelements (t8_forest_t forest) 
+void
+t8_forest_remove_subelements (t8_forest_t forest)
 {
   t8_global_productionf ("Into t8_forest_remove_subelements.\n");
 

--- a/src/t8_forest/t8_forest_remove_hanging_faces.cxx
+++ b/src/t8_forest/t8_forest_remove_hanging_faces.cxx
@@ -150,44 +150,4 @@ t8_forest_hanging_faces_removed (t8_forest_t forest)
 }
 #endif
 
-int
-t8_forest_remove_subelements_adapt (t8_forest_t forest,
-                                    t8_forest_t forest_from,
-                                    t8_locidx_t ltree_id,
-                                    t8_locidx_t lelement_id,
-                                    t8_eclass_scheme_c * ts,
-                                    int num_elements,
-                                    t8_element_t * elements[])
-{
-  const t8_element_t *current_element;
-
-  current_element =
-    t8_forest_get_element_in_tree (forest_from, ltree_id, lelement_id);
-
-  t8_quad_with_subelements *pquad_w_sub =
-    (t8_quad_with_subelements *) current_element;
-
-  if (pquad_w_sub->dummy_is_subelement == 1) {
-    return -1;
-  }
-  else {
-    return 0;
-  }
-}
-
-void
-t8_forest_remove_subelements (t8_forest_t forest)
-{
-  t8_global_productionf ("Into t8_forest_remove_subelements.\n");
-
-  forest->set_from = forest;
-  forest->set_adapt_fn = t8_forest_remove_subelements_adapt;
-  forest->set_adapt_recursive = 0;
-  t8_forest_adapt (forest);
-
-  forest->set_subelements = 0;
-
-  t8_global_productionf ("Done t8_forest_remove_subelements.\n");
-}
-
 T8_EXTERN_C_END ();

--- a/src/t8_forest/t8_forest_remove_hanging_faces.cxx
+++ b/src/t8_forest/t8_forest_remove_hanging_faces.cxx
@@ -130,14 +130,14 @@ t8_forest_remove_hanging_faces_adapt (t8_forest_t forest,
 void
 t8_forest_remove_hanging_faces (t8_forest_t forest)
 {
-  t8_global_productionf ("Into t8_forest_subelements.\n");
+  t8_global_productionf ("Into t8_forest_remove_hanging_faces.\n");
 
   forest->set_adapt_fn = t8_forest_remove_hanging_faces_adapt;
   forest->set_adapt_recursive = 0;
   t8_forest_copy_trees (forest, forest->set_from, 0);
   t8_forest_adapt (forest);
 
-  t8_global_productionf ("Done t8_forest_subelements.\n");
+  t8_global_productionf ("Done t8_forest_hanging_faces.\n");
 }
 
 #if 0
@@ -149,5 +149,45 @@ t8_forest_hanging_faces_removed (t8_forest_t forest)
   return 0;
 }
 #endif
+
+int
+t8_forest_remove_subelements_adapt (t8_forest_t forest,
+                                    t8_forest_t forest_from,
+                                    t8_locidx_t ltree_id,
+                                    t8_locidx_t lelement_id,
+                                    t8_eclass_scheme_c * ts,
+                                    int num_elements,
+                                    t8_element_t * elements[])
+{
+  const t8_element_t *current_element;
+
+  current_element =
+    t8_forest_get_element_in_tree (forest_from, ltree_id, lelement_id);
+
+  t8_quad_with_subelements *pquad_w_sub =
+      (t8_quad_with_subelements *) current_element;
+
+  if (pquad_w_sub->dummy_is_subelement == 1) {
+    return -1;
+  }
+  else {
+    return 0;
+  }
+}
+
+void 
+t8_forest_remove_subelements (t8_forest_t forest) 
+{
+  t8_global_productionf ("Into t8_forest_remove_subelements.\n");
+
+  forest->set_from = forest;
+  forest->set_adapt_fn = t8_forest_remove_subelements_adapt;
+  forest->set_adapt_recursive = 0;
+  t8_forest_adapt (forest);
+
+  forest->set_subelements = 0;
+
+  t8_global_productionf ("Done t8_forest_remove_subelements.\n");
+}
 
 T8_EXTERN_C_END ();

--- a/src/t8_forest/t8_forest_remove_hanging_faces.h
+++ b/src/t8_forest/t8_forest_remove_hanging_faces.h
@@ -77,23 +77,6 @@ void                t8_forest_remove_hanging_faces (t8_forest_t forest);
  * This function is not implemented yet. */
 int                 t8_forest_hanging_faces_removed (t8_forest_t forest);
 
-/* TODO comment */
-int                 t8_forest_remove_subelements_adapt (t8_forest_t forest,
-                                                        t8_forest_t
-                                                        forest_from,
-                                                        t8_locidx_t
-                                                        ltree_id,
-                                                        t8_locidx_t
-                                                        lelement_id,
-                                                        t8_eclass_scheme_c *
-                                                        ts,
-                                                        int num_elements,
-                                                        t8_element_t *
-                                                        elements[]);
-
-/* TODO comment */
-void                t8_forest_remove_subelements (t8_forest_t forest);
-
 T8_EXTERN_C_END ();
 
 #endif /* !T8_FOREST_REMOVE_HANGING_FACES_H! */

--- a/src/t8_forest/t8_forest_remove_hanging_faces.h
+++ b/src/t8_forest/t8_forest_remove_hanging_faces.h
@@ -77,6 +77,24 @@ void                t8_forest_remove_hanging_faces (t8_forest_t forest);
  * This function is not implemented yet. */
 int                 t8_forest_hanging_faces_removed (t8_forest_t forest);
 
+/* TODO comment */
+int                 t8_forest_remove_subelements_adapt (t8_forest_t forest,
+                                                        t8_forest_t
+                                                        forest_from,
+                                                        t8_locidx_t
+                                                        ltree_id,
+                                                        t8_locidx_t
+                                                        lelement_id,
+                                                        t8_eclass_scheme_c *
+                                                        ts,
+                                                        int num_elements,
+                                                        t8_element_t *
+                                                        elements[]);
+
+/* TODO comment */
+void                t8_forest_remove_subelements (t8_forest_t 
+                                                  forest);
+
 T8_EXTERN_C_END ();
 
 #endif /* !T8_FOREST_REMOVE_HANGING_FACES_H! */

--- a/src/t8_forest/t8_forest_remove_hanging_faces.h
+++ b/src/t8_forest/t8_forest_remove_hanging_faces.h
@@ -92,8 +92,7 @@ int                 t8_forest_remove_subelements_adapt (t8_forest_t forest,
                                                         elements[]);
 
 /* TODO comment */
-void                t8_forest_remove_subelements (t8_forest_t 
-                                                  forest);
+void                t8_forest_remove_subelements (t8_forest_t forest);
 
 T8_EXTERN_C_END ();
 

--- a/src/t8_forest/t8_forest_types.h
+++ b/src/t8_forest/t8_forest_types.h
@@ -94,6 +94,7 @@ typedef struct t8_forest
                                              See \ref t8_forest_set_balance.
                                              If 0, no balance. If 1 balance with repartitioning, if 2 balance without
                                              repartitioning, \see t8_forest_balance */
+  int                 set_subelements;
   int                 do_ghost;         /**< If True, a ghost layer will be created when the forest is committed. */
   t8_ghost_type_t     ghost_type;       /**< If a ghost layer will be created, the type of neighbors that count as ghost. */
   int                 ghost_algorithm;  /**< Controls the algorithm used for ghost. 1 = balanced only. 2 = also unbalanced

--- a/src/t8_forest/t8_forest_types.h
+++ b/src/t8_forest/t8_forest_types.h
@@ -55,7 +55,7 @@ typedef int8_t      t8_forest_from_t;
 #define T8_FOREST_FROM_PARTITION 0x2
 #define T8_FOREST_FROM_BALANCE 0x4
 #define T8_FOREST_FROM_SUBELEMENTS 0x8
-#define T8_FOREST_FROM_NONE 0x10 /* A value that is not reached by adding up the other values. No from method used */
+#define T8_FOREST_FROM_NONE 0x10        /* A value that is not reached by adding up the other values. No from method used */
 #define T8_FOREST_FROM_LAST T8_FOREST_FROM_NONE
 
 #define T8_FOREST_BALANCE_REPART 1 /**< Value of forest->set_balance if balancing with repartitioning */

--- a/src/t8_schemes/t8_default/t8_default_common_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_common_cxx.cxx
@@ -206,4 +206,20 @@ t8_default_scheme_common_c::t8_element_get_number_of_subelements (int
   SC_ABORT ("This function is yet implemented for the given scheme.\n");
 }
 
+int                
+t8_default_scheme_common_c::t8_element_test_if_subelement (const 
+                                                           t8_element *
+                                                           elem)
+{
+  SC_ABORT ("This function is yet implemented for the given scheme.\n");
+}
+
+int                
+t8_default_scheme_common_c::t8_element_get_subelement_type (const 
+                                                            t8_element *
+                                                            elem)
+{
+  SC_ABORT ("This function is yet implemented for the given scheme.\n");
+}
+
 T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_common_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_common_cxx.cxx
@@ -206,18 +206,16 @@ t8_default_scheme_common_c::t8_element_get_number_of_subelements (int
   SC_ABORT ("This function is yet implemented for the given scheme.\n");
 }
 
-int                
-t8_default_scheme_common_c::t8_element_test_if_subelement (const 
-                                                           t8_element *
-                                                           elem)
+int
+t8_default_scheme_common_c::t8_element_test_if_subelement (const
+                                                           t8_element * elem)
 {
   SC_ABORT ("This function is yet implemented for the given scheme.\n");
 }
 
-int                
-t8_default_scheme_common_c::t8_element_get_subelement_type (const 
-                                                            t8_element *
-                                                            elem)
+int
+t8_default_scheme_common_c::t8_element_get_subelement_type (const
+                                                            t8_element * elem)
 {
   SC_ABORT ("This function is yet implemented for the given scheme.\n");
 }

--- a/src/t8_schemes/t8_default/t8_default_common_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_common_cxx.cxx
@@ -210,7 +210,8 @@ int
 t8_default_scheme_common_c::t8_element_test_if_subelement (const
                                                            t8_element * elem)
 {
-  SC_ABORT ("This function is not implemented for the given scheme.\n");
+  /* no subelements are implemented and therefore we return -1 meaning "is no subelement" */
+  return -1;
 }
 
 int

--- a/src/t8_schemes/t8_default/t8_default_common_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_common_cxx.cxx
@@ -203,21 +203,21 @@ t8_default_scheme_common_c::t8_element_get_number_of_subelements (int
                                                                   t8_element *
                                                                   elem)
 {
-  SC_ABORT ("This function is yet implemented for the given scheme.\n");
+  SC_ABORT ("This function is not implemented for the given scheme.\n");
 }
 
 int
 t8_default_scheme_common_c::t8_element_test_if_subelement (const
                                                            t8_element * elem)
 {
-  SC_ABORT ("This function is yet implemented for the given scheme.\n");
+  SC_ABORT ("This function is not implemented for the given scheme.\n");
 }
 
 int
 t8_default_scheme_common_c::t8_element_get_subelement_type (const
                                                             t8_element * elem)
 {
-  SC_ABORT ("This function is yet implemented for the given scheme.\n");
+  SC_ABORT ("This function is not implemented for the given scheme.\n");
 }
 
 T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_common_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_common_cxx.hxx
@@ -119,7 +119,6 @@ public:
   /* TODO: comment */
   virtual int         t8_element_get_subelement_type (const
                                                       t8_element * elem);
-
 };
 
 #endif /* !T8_DEFAULT_COMMON_CXX_HXX */

--- a/src/t8_schemes/t8_default/t8_default_common_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_common_cxx.hxx
@@ -113,6 +113,16 @@ public:
                                                             t8_element_t *
                                                             elem);
 
+  /* TODO: comment */
+  virtual int                 t8_element_test_if_subelement (const 
+                                                             t8_element *
+                                                             elem);
+
+  /* TODO: comment */
+  virtual int                 t8_element_get_subelement_type (const 
+                                                              t8_element *
+                                                              elem);
+
 };
 
 #endif /* !T8_DEFAULT_COMMON_CXX_HXX */

--- a/src/t8_schemes/t8_default/t8_default_common_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_common_cxx.hxx
@@ -114,14 +114,11 @@ public:
                                                             elem);
 
   /* TODO: comment */
-  virtual int                 t8_element_test_if_subelement (const 
-                                                             t8_element *
-                                                             elem);
+  virtual int         t8_element_test_if_subelement (const t8_element * elem);
 
   /* TODO: comment */
-  virtual int                 t8_element_get_subelement_type (const 
-                                                              t8_element *
-                                                              elem);
+  virtual int         t8_element_get_subelement_type (const
+                                                      t8_element * elem);
 
 };
 

--- a/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.cxx
+++ b/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.cxx
@@ -113,13 +113,13 @@ t8_subelement_scheme_quad_c::t8_element_compare (const t8_element_t * elem1,
   const p4est_quadrant_t *r = &pquad_w_sub_elem2->p4q;
 
   /* TODO: check */
-  #if 0
+#if 0
   /* at the moment, this function is not optimized for subelements */
   T8_ASSERT (pquad_w_sub_elem1->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
   T8_ASSERT (pquad_w_sub_elem2->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
-  #endif
+#endif
 
   T8_ASSERT (t8_element_is_valid (elem1));
   T8_ASSERT (t8_element_is_valid (elem2));
@@ -186,11 +186,11 @@ t8_subelement_scheme_quad_c::t8_element_num_faces (const t8_element_t * elem)
     (const t8_quad_with_subelements *) elem;
 
   /* TODO: check if an assertion is needed here */
-  #if 0
+#if 0
   /* at the moment, this function is only implemented for standard quad elements */
   T8_ASSERT (pquad_w_sub->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
-  #endif
+#endif
 
   T8_ASSERT (t8_element_is_valid (elem));
   return P4EST_FACES;
@@ -217,11 +217,11 @@ t8_subelement_scheme_quad_c::t8_element_num_children (const t8_element_t *
   const t8_quad_with_subelements *pquad_w_sub =
     (const t8_quad_with_subelements *) elem;
 
-  #if 0
+#if 0
   /* at the moment, this function is only implemented for standard quad elements */
   T8_ASSERT (pquad_w_sub->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
-  #endif
+#endif
 
   T8_ASSERT (t8_element_is_valid (elem));
   return P4EST_CHILDREN;
@@ -233,24 +233,25 @@ int
 t8_subelement_scheme_quad_c::t8_element_num_siblings (const t8_element_t *
                                                       elem) const
 /* *INDENT-ON* */
+
 {
   const t8_quad_with_subelements *pquad_w_sub =
     (const t8_quad_with_subelements *) elem;
 
   if (pquad_w_sub->dummy_is_subelement == T8_SUB_QUAD_IS_SUBELEMENT) {
-    int type = pquad_w_sub->subelement_type;
-    int num_hanging_faces = 0;
-    int num_siblings;
-    int i;
-    
+    int                 type = pquad_w_sub->subelement_type;
+    int                 num_hanging_faces = 0;
+    int                 num_siblings;
+    int                 i;
+
     /* TODO: use t8_element_get_number_of_subelements instead */
-    for (i = 0; i < P4EST_FACES; i++) {   /* Count the number of ones of the binary subelement type. This number equals the number of hanging faces. */
+    for (i = 0; i < P4EST_FACES; i++) { /* Count the number of ones of the binary subelement type. This number equals the number of hanging faces. */
       num_hanging_faces += (type & (1 << i)) >> i;
     }
 
-   /* The number of subelements equals the number of neighbours: */
-   num_siblings = P4EST_FACES + num_hanging_faces;
-   return num_siblings;
+    /* The number of subelements equals the number of neighbours: */
+    num_siblings = P4EST_FACES + num_hanging_faces;
+    return num_siblings;
   }
   else {
     return P4EST_CHILDREN;
@@ -263,13 +264,13 @@ t8_subelement_scheme_quad_c::t8_element_num_face_children (const t8_element_t
 {
   const t8_quad_with_subelements *pquad_w_sub =
     (const t8_quad_with_subelements *) elem;
-  
+
   /* TODO: check */
-  #if 0
+#if 0
   /* at the moment, this function is only implemented for standard quad elements */
   T8_ASSERT (pquad_w_sub->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
-  #endif
+#endif
 
   T8_ASSERT (t8_element_is_valid (elem));
   return 2;
@@ -337,11 +338,11 @@ t8_subelement_scheme_quad_c::t8_element_child (const t8_element_t * elem,
   const p4est_qcoord_t shift = P4EST_QUADRANT_LEN (q->level + 1);
 
   /* TODO: check */
-  #if 0
+#if 0
   /* at the moment, this function is only implemented for standard quad elements */
   T8_ASSERT (pquad_w_sub_elem->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
-  #endif
+#endif
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (child));
@@ -482,11 +483,11 @@ t8_linearidx_t
   p4est_quadrant_t   *q = &pquad_w_sub->p4q;
 
   /* TODO: check, if we need dont need an assertion here */
-  #if 0
+#if 0
   /* at the moment, this function is only implemented for standard quad elements */
   T8_ASSERT (pquad_w_sub->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
-  #endif
+#endif
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (0 <= level && level <= P4EST_QMAXLEVEL);
@@ -637,11 +638,11 @@ t8_subelement_scheme_quad_c::t8_element_children_at_face (const t8_element_t *
     (const t8_quad_with_subelements *) elem;
 
   /* TODO: check */
-  #if 0
+#if 0
   /* at the moment, this function is only implemented for standard quad elements */
   T8_ASSERT (pquad_w_sub->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
-  #endif
+#endif
 
   int                 first_child, second_child;
 
@@ -715,11 +716,11 @@ t8_subelement_scheme_quad_c::t8_element_face_child_face (const t8_element_t *
     (const t8_quad_with_subelements *) elem;
 
   /* TODO: check */
-  #if 0
+#if 0
   /* at the moment, this function is only implemented for standard quad elements */
   T8_ASSERT (pquad_w_sub->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
-  #endif
+#endif
 
   T8_ASSERT (t8_element_is_valid (elem));
   /* For quadrants the face enumeration of children is the same as for the parent. */
@@ -922,11 +923,11 @@ t8_subelement_scheme_quad_c::t8_element_tree_face (const t8_element_t * elem,
   t8_quad_with_subelements *pquad_w_sub = (t8_quad_with_subelements *) elem;
 
   /* TODO: check */
-  #if 0
+#if 0
   /* at the moment, this function is only implemented for standard quad elements */
   T8_ASSERT (pquad_w_sub->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
-  #endif
+#endif
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (0 <= face && face < P4EST_FACES);
@@ -1078,11 +1079,11 @@ t8_subelement_scheme_quad_c::t8_element_is_root_boundary (const t8_element_t *
   p4est_qcoord_t      coord;
 
   /* TODO: check this */
-  #if 0
+#if 0
   /* at the moment, this function is only implemented for standard quad elements */
   T8_ASSERT (pquad_w_sub->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
-  #endif
+#endif
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (0 <= face && face < P4EST_FACES);
@@ -1298,10 +1299,10 @@ t8_subelement_scheme_quad_c::t8_element_to_subelement (const t8_element_t *
   T8_ASSERT (type >= T8_SUB_QUAD_MIN_SUBELEMENT_TYPE
              && type <= T8_SUB_QUAD_MAX_SUBELEMENT_TYPE);
   /* TODO: check */
-  #if 0
+#if 0
   T8_ASSERT (pquad_w_sub_elem->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
-  #endif
+#endif
   T8_ASSERT (t8_element_is_valid (elem));
 #ifdef T8_ENABLE_DEBUG
   {

--- a/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.cxx
+++ b/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.cxx
@@ -1460,9 +1460,8 @@ t8_subelement_scheme_quad_c::t8_element_copy_subelement_values (const
 }
 
 int
-t8_subelement_scheme_quad_c::t8_element_test_if_subelement (const 
-                                                            t8_element *
-                                                            elem)
+t8_subelement_scheme_quad_c::t8_element_test_if_subelement (const
+                                                            t8_element * elem)
 {
   const t8_quad_with_subelements *pquad_w_sub =
     (const t8_quad_with_subelements *) elem;
@@ -1476,7 +1475,7 @@ t8_subelement_scheme_quad_c::t8_element_test_if_subelement (const
 }
 
 int
-t8_subelement_scheme_quad_c::t8_element_get_subelement_type (const 
+t8_subelement_scheme_quad_c::t8_element_get_subelement_type (const
                                                              t8_element *
                                                              elem)
 {

--- a/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.cxx
+++ b/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.cxx
@@ -264,7 +264,7 @@ t8_subelement_scheme_quad_c::t8_element_get_face_corner (const t8_element_t *
   /* at the moment, this function is only implemented for standard quad elements */
   T8_ASSERT (pquad_w_sub->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
-
+  /* TODO: check whether this enumeration of the faces is right. It might be f_3 and f_2 switched */
   /*
    *   2    f_2    3
    *     x -->-- x
@@ -314,7 +314,7 @@ t8_subelement_scheme_quad_c::t8_element_child (const t8_element_t * elem,
 
   const p4est_qcoord_t shift = P4EST_QUADRANT_LEN (q->level + 1);
 
-  /* at the moment, this function is only implemented for standard quad elements */
+  /* it should not be possible to construct a child of a subelement */
   T8_ASSERT (pquad_w_sub_elem->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
 

--- a/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.cxx
+++ b/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.cxx
@@ -447,9 +447,12 @@ t8_subelement_scheme_quad_c::t8_element_is_family (t8_element_t ** fam)
   if (pquad_w_sub_family[0]->dummy_is_subelement == T8_SUB_QUAD_IS_SUBELEMENT) {
     return 1;
   }
-  else if (pquad_w_sub_family[1]->dummy_is_subelement == T8_SUB_QUAD_IS_SUBELEMENT
-           || pquad_w_sub_family[2]->dummy_is_subelement == T8_SUB_QUAD_IS_SUBELEMENT
-           || pquad_w_sub_family[3]->dummy_is_subelement == T8_SUB_QUAD_IS_SUBELEMENT) {
+  else if (pquad_w_sub_family[1]->dummy_is_subelement ==
+           T8_SUB_QUAD_IS_SUBELEMENT
+           || pquad_w_sub_family[2]->dummy_is_subelement ==
+           T8_SUB_QUAD_IS_SUBELEMENT
+           || pquad_w_sub_family[3]->dummy_is_subelement ==
+           T8_SUB_QUAD_IS_SUBELEMENT) {
     return 0;
   }
   else {

--- a/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.cxx
+++ b/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.cxx
@@ -139,10 +139,16 @@ t8_subelement_scheme_quad_c::t8_element_parent (const t8_element_t * elem,
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (parent));
 
+  if (pquad_w_sub_elem->dummy_is_subelement == T8_SUB_QUAD_IS_SUBELEMENT) {
+    pquad_w_sub_parent->p4q = pquad_w_sub_elem->p4q;
+  }
+  else {
+    p4est_quadrant_parent (q, r);
+  }
+
   /* resetting the subelement infos and ensuring that a parent element can never be a subelement */
   t8_element_reset_subelement_values (parent);
-
-  p4est_quadrant_parent (q, r);
+  
   t8_element_copy_surround (q, r);
 }
 

--- a/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.cxx
+++ b/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.cxx
@@ -148,7 +148,7 @@ t8_subelement_scheme_quad_c::t8_element_parent (const t8_element_t * elem,
 
   /* resetting the subelement infos and ensuring that a parent element can never be a subelement */
   t8_element_reset_subelement_values (parent);
-  
+
   t8_element_copy_surround (q, r);
 }
 

--- a/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.cxx
+++ b/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.cxx
@@ -436,8 +436,8 @@ t8_subelement_scheme_quad_c::t8_element_is_family (t8_element_t ** fam)
         || pquad_w_sub_family[2]->dummy_is_subelement ==
         T8_SUB_QUAD_IS_SUBELEMENT
         || pquad_w_sub_family[3]->dummy_is_subelement ==
-        T8_SUB_QUAD_IS_SUBELEMENT) { 
-      return 0;    
+        T8_SUB_QUAD_IS_SUBELEMENT) {
+      return 0;
     }
     /* If all elements of fam are no subelements, then we can use the p4est check is_family */
     else {

--- a/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.cxx
+++ b/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.cxx
@@ -606,13 +606,17 @@ t8_subelement_scheme_quad_c::t8_element_nca (const t8_element_t * elem1,
   const p4est_quadrant_t *q1 = &pquad_w_sub_elem1->p4q;
   const p4est_quadrant_t *q2 = &pquad_w_sub_elem2->p4q;
   p4est_quadrant_t   *r = &pquad_w_sub_nca->p4q;
-
+  
+  /* In case of subelements, we use the parent quadrant and construct nca of the parent quadrant */
+  /* TODO: check this */
+  #if 0
   /* at the moment, this function is only implemented for standard quad elements */
   T8_ASSERT (pquad_w_sub_elem1->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
   T8_ASSERT (pquad_w_sub_elem2->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
-
+  #endif
+  
   T8_ASSERT (t8_element_is_valid (elem1));
   T8_ASSERT (t8_element_is_valid (elem2));
 #if 0

--- a/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.cxx
+++ b/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.cxx
@@ -606,17 +606,17 @@ t8_subelement_scheme_quad_c::t8_element_nca (const t8_element_t * elem1,
   const p4est_quadrant_t *q1 = &pquad_w_sub_elem1->p4q;
   const p4est_quadrant_t *q2 = &pquad_w_sub_elem2->p4q;
   p4est_quadrant_t   *r = &pquad_w_sub_nca->p4q;
-  
+
   /* In case of subelements, we use the parent quadrant and construct nca of the parent quadrant */
   /* TODO: check this */
-  #if 0
+#if 0
   /* at the moment, this function is only implemented for standard quad elements */
   T8_ASSERT (pquad_w_sub_elem1->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
   T8_ASSERT (pquad_w_sub_elem2->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
-  #endif
-  
+#endif
+
   T8_ASSERT (t8_element_is_valid (elem1));
   T8_ASSERT (t8_element_is_valid (elem2));
 #if 0

--- a/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.cxx
+++ b/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.cxx
@@ -358,11 +358,10 @@ t8_subelement_scheme_quad_c::t8_element_child_id (const t8_element_t * elem)
     (const t8_quad_with_subelements *) elem;
   const p4est_quadrant_t *q = &pquad_w_sub->p4q;
 
-  /* at the moment, this function is only implemented for standard quad elements */
-  T8_ASSERT (pquad_w_sub->dummy_is_subelement ==
-             T8_SUB_QUAD_IS_NO_SUBELEMENT);
-
   T8_ASSERT (t8_element_is_valid (elem));
+
+  /* Note that for all subelements of the same transition cell 
+   * the child_id stays the same. */
   return p4est_quadrant_child_id (q);
 }
 
@@ -389,18 +388,23 @@ t8_subelement_scheme_quad_c::t8_element_is_family (t8_element_t ** fam)
 
 #ifdef T8_ENABLE_DEBUG
   int                 i;
-  for (i = 0; i < P4EST_CHILDREN; i++) {
-    /* at the moment, this function is only implemented for standard quad elements */
-    T8_ASSERT (pquad_w_sub_family[i]->dummy_is_subelement ==
-               T8_SUB_QUAD_IS_NO_SUBELEMENT);
 
+  /* TODO: this loop goes from 0 to 3 but with subelements there can be more elements in fam */
+  for (i = 0; i < P4EST_CHILDREN; i++) {
     T8_ASSERT (t8_element_is_valid (fam[i]));
   }
 #endif
-  return p4est_quadrant_is_family (&pquad_w_sub_family[0]->p4q,
-                                   &pquad_w_sub_family[1]->p4q,
-                                   &pquad_w_sub_family[2]->p4q,
-                                   &pquad_w_sub_family[3]->p4q);
+
+  /* TODO: this is a test and no sufficient check */
+  if (pquad_w_sub_family[0]->dummy_is_subelement == T8_SUB_QUAD_IS_SUBELEMENT) {
+    return 1;
+  }
+  else {
+    return p4est_quadrant_is_family (&pquad_w_sub_family[0]->p4q,
+                                     &pquad_w_sub_family[1]->p4q,
+                                     &pquad_w_sub_family[2]->p4q,
+                                     &pquad_w_sub_family[3]->p4q);
+  }
 }
 
 void
@@ -1453,6 +1457,38 @@ t8_subelement_scheme_quad_c::t8_element_copy_subelement_values (const
     pquad_w_sub_source->dummy_is_subelement;
   pquad_w_sub_dest->subelement_type = pquad_w_sub_source->subelement_type;
   pquad_w_sub_dest->subelement_id = pquad_w_sub_source->subelement_id;
+}
+
+int
+t8_subelement_scheme_quad_c::t8_element_test_if_subelement (const 
+                                                            t8_element *
+                                                            elem)
+{
+  const t8_quad_with_subelements *pquad_w_sub =
+    (const t8_quad_with_subelements *) elem;
+
+  if (pquad_w_sub->dummy_is_subelement == T8_SUB_QUAD_IS_SUBELEMENT) {
+    return T8_SUB_QUAD_IS_SUBELEMENT;
+  }
+  else {
+    return T8_SUB_QUAD_IS_NO_SUBELEMENT;
+  }
+}
+
+int
+t8_subelement_scheme_quad_c::t8_element_get_subelement_type (const 
+                                                             t8_element *
+                                                             elem)
+{
+  const t8_quad_with_subelements *pquad_w_sub =
+    (const t8_quad_with_subelements *) elem;
+
+  if (pquad_w_sub->dummy_is_subelement == T8_SUB_QUAD_IS_NO_SUBELEMENT) {
+    return 0;
+  }
+  else {
+    return pquad_w_sub->subelement_type;
+  }
 }
 
 t8_element_shape_t

--- a/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.cxx
+++ b/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.cxx
@@ -112,11 +112,14 @@ t8_subelement_scheme_quad_c::t8_element_compare (const t8_element_t * elem1,
   const p4est_quadrant_t *q = &pquad_w_sub_elem1->p4q;
   const p4est_quadrant_t *r = &pquad_w_sub_elem2->p4q;
 
+  /* TODO: check */
+  #if 0
   /* at the moment, this function is not optimized for subelements */
   T8_ASSERT (pquad_w_sub_elem1->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
   T8_ASSERT (pquad_w_sub_elem2->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
+  #endif
 
   T8_ASSERT (t8_element_is_valid (elem1));
   T8_ASSERT (t8_element_is_valid (elem2));
@@ -182,9 +185,12 @@ t8_subelement_scheme_quad_c::t8_element_num_faces (const t8_element_t * elem)
   const t8_quad_with_subelements *pquad_w_sub =
     (const t8_quad_with_subelements *) elem;
 
+  /* TODO: check if an assertion is needed here */
+  #if 0
   /* at the moment, this function is only implemented for standard quad elements */
   T8_ASSERT (pquad_w_sub->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
+  #endif
 
   T8_ASSERT (t8_element_is_valid (elem));
   return P4EST_FACES;
@@ -211,12 +217,44 @@ t8_subelement_scheme_quad_c::t8_element_num_children (const t8_element_t *
   const t8_quad_with_subelements *pquad_w_sub =
     (const t8_quad_with_subelements *) elem;
 
+  #if 0
   /* at the moment, this function is only implemented for standard quad elements */
   T8_ASSERT (pquad_w_sub->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
+  #endif
 
   T8_ASSERT (t8_element_is_valid (elem));
   return P4EST_CHILDREN;
+}
+
+/* *INDENT-OFF* */
+/* indent bug, indent adds a second "const" modifier */
+int   
+t8_subelement_scheme_quad_c::t8_element_num_siblings (const t8_element_t *
+                                                      elem) const
+/* *INDENT-ON* */
+{
+  const t8_quad_with_subelements *pquad_w_sub =
+    (const t8_quad_with_subelements *) elem;
+
+  if (pquad_w_sub->dummy_is_subelement == T8_SUB_QUAD_IS_SUBELEMENT) {
+    int type = pquad_w_sub->subelement_type;
+    int num_hanging_faces = 0;
+    int num_siblings;
+    int i;
+    
+    /* TODO: use t8_element_get_number_of_subelements instead */
+    for (i = 0; i < P4EST_FACES; i++) {   /* Count the number of ones of the binary subelement type. This number equals the number of hanging faces. */
+      num_hanging_faces += (type & (1 << i)) >> i;
+    }
+
+   /* The number of subelements equals the number of neighbours: */
+   num_siblings = P4EST_FACES + num_hanging_faces;
+   return num_siblings;
+  }
+  else {
+    return P4EST_CHILDREN;
+  }
 }
 
 int
@@ -225,10 +263,13 @@ t8_subelement_scheme_quad_c::t8_element_num_face_children (const t8_element_t
 {
   const t8_quad_with_subelements *pquad_w_sub =
     (const t8_quad_with_subelements *) elem;
-
+  
+  /* TODO: check */
+  #if 0
   /* at the moment, this function is only implemented for standard quad elements */
   T8_ASSERT (pquad_w_sub->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
+  #endif
 
   T8_ASSERT (t8_element_is_valid (elem));
   return 2;
@@ -295,9 +336,12 @@ t8_subelement_scheme_quad_c::t8_element_child (const t8_element_t * elem,
 
   const p4est_qcoord_t shift = P4EST_QUADRANT_LEN (q->level + 1);
 
+  /* TODO: check */
+  #if 0
   /* at the moment, this function is only implemented for standard quad elements */
   T8_ASSERT (pquad_w_sub_elem->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
+  #endif
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (child));
@@ -321,6 +365,7 @@ t8_subelement_scheme_quad_c::t8_element_children (const t8_element_t * elem,
                                                   int length,
                                                   t8_element_t * c[])
 {
+  /* if elem is a subelement, then this function will construct the children of its parent p4est quadrant */
   const t8_quad_with_subelements *pquad_w_sub_elem =
     (const t8_quad_with_subelements *) elem;
   t8_quad_with_subelements **pquad_w_sub_children =
@@ -329,10 +374,6 @@ t8_subelement_scheme_quad_c::t8_element_children (const t8_element_t * elem,
   const p4est_quadrant_t *q = &pquad_w_sub_elem->p4q;
 
   int                 i;
-
-  /* at the moment, this function is only implemented for standard quad elements */
-  T8_ASSERT (pquad_w_sub_elem->dummy_is_subelement ==
-             T8_SUB_QUAD_IS_NO_SUBELEMENT);
 
   T8_ASSERT (t8_element_is_valid (elem));
 #ifdef T8_ENABLE_DEBUG
@@ -440,9 +481,12 @@ t8_linearidx_t
   t8_quad_with_subelements *pquad_w_sub = (t8_quad_with_subelements *) elem;
   p4est_quadrant_t   *q = &pquad_w_sub->p4q;
 
+  /* TODO: check, if we need dont need an assertion here */
+  #if 0
   /* at the moment, this function is only implemented for standard quad elements */
   T8_ASSERT (pquad_w_sub->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
+  #endif
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (0 <= level && level <= P4EST_QMAXLEVEL);
@@ -592,9 +636,12 @@ t8_subelement_scheme_quad_c::t8_element_children_at_face (const t8_element_t *
   const t8_quad_with_subelements *pquad_w_sub =
     (const t8_quad_with_subelements *) elem;
 
+  /* TODO: check */
+  #if 0
   /* at the moment, this function is only implemented for standard quad elements */
   T8_ASSERT (pquad_w_sub->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
+  #endif
 
   int                 first_child, second_child;
 
@@ -667,9 +714,12 @@ t8_subelement_scheme_quad_c::t8_element_face_child_face (const t8_element_t *
   const t8_quad_with_subelements *pquad_w_sub =
     (const t8_quad_with_subelements *) elem;
 
+  /* TODO: check */
+  #if 0
   /* at the moment, this function is only implemented for standard quad elements */
   T8_ASSERT (pquad_w_sub->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
+  #endif
 
   T8_ASSERT (t8_element_is_valid (elem));
   /* For quadrants the face enumeration of children is the same as for the parent. */
@@ -871,9 +921,12 @@ t8_subelement_scheme_quad_c::t8_element_tree_face (const t8_element_t * elem,
 {
   t8_quad_with_subelements *pquad_w_sub = (t8_quad_with_subelements *) elem;
 
+  /* TODO: check */
+  #if 0
   /* at the moment, this function is only implemented for standard quad elements */
   T8_ASSERT (pquad_w_sub->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
+  #endif
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (0 <= face && face < P4EST_FACES);
@@ -1024,9 +1077,12 @@ t8_subelement_scheme_quad_c::t8_element_is_root_boundary (const t8_element_t *
 
   p4est_qcoord_t      coord;
 
+  /* TODO: check this */
+  #if 0
   /* at the moment, this function is only implemented for standard quad elements */
   T8_ASSERT (pquad_w_sub->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
+  #endif
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (0 <= face && face < P4EST_FACES);
@@ -1241,8 +1297,11 @@ t8_subelement_scheme_quad_c::t8_element_to_subelement (const t8_element_t *
 
   T8_ASSERT (type >= T8_SUB_QUAD_MIN_SUBELEMENT_TYPE
              && type <= T8_SUB_QUAD_MAX_SUBELEMENT_TYPE);
+  /* TODO: check */
+  #if 0
   T8_ASSERT (pquad_w_sub_elem->dummy_is_subelement ==
              T8_SUB_QUAD_IS_NO_SUBELEMENT);
+  #endif
   T8_ASSERT (t8_element_is_valid (elem));
 #ifdef T8_ENABLE_DEBUG
   {

--- a/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.cxx
+++ b/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.cxx
@@ -443,9 +443,14 @@ t8_subelement_scheme_quad_c::t8_element_is_family (t8_element_t ** fam)
   }
 #endif
 
-  /* TODO: this is a test and no sufficient check */
+  /* TODO: this might not be a sufficient check */
   if (pquad_w_sub_family[0]->dummy_is_subelement == T8_SUB_QUAD_IS_SUBELEMENT) {
     return 1;
+  }
+  else if (pquad_w_sub_family[1]->dummy_is_subelement == T8_SUB_QUAD_IS_SUBELEMENT
+           || pquad_w_sub_family[2]->dummy_is_subelement == T8_SUB_QUAD_IS_SUBELEMENT
+           || pquad_w_sub_family[3]->dummy_is_subelement == T8_SUB_QUAD_IS_SUBELEMENT) {
+    return 0;
   }
   else {
     return p4est_quadrant_is_family (&pquad_w_sub_family[0]->p4q,

--- a/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.hxx
+++ b/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.hxx
@@ -402,12 +402,6 @@ protected:
                                                               t, int vertex,
                                                               int coords[]);
 
-  /** This function resets the subelement values of an element to the default value -1.
-   *  \param [in,out] elem A valid element, whose subelement values have been resetted. 
-   */
-  void                t8_element_reset_subelement_values (t8_element_t *
-                                                          elem);
-
   /** This function copies the subelement values from source to dest.
    *  \param [in] source A valid element 
    *  \param [in,out] dest A valid element, whose subelement values are equal to those of source
@@ -416,6 +410,12 @@ protected:
                                                          t8_element_t *
                                                          source,
                                                          t8_element_t * dest);
+
+  /** This function resets the subelement values of an element to the default value -1.
+   *  \param [in,out] elem A valid element, whose subelement values have been resetted. 
+   */
+  void                t8_element_reset_subelement_values (t8_element_t *
+                                                          elem);
 
   /** Query whether an elements subelement values are valid
    *  \param [in] source A element

--- a/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.hxx
+++ b/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.hxx
@@ -179,6 +179,9 @@ public:
   /** Return the number of children of an element when it is refined. */
   virtual int         t8_element_num_children (const t8_element_t * elem);
 
+  /** Return the number of siblings of an element */
+  virtual int         t8_element_num_siblings (const t8_element_t * elem) const;
+
   /** Return the number of children of an element's face when the element is refined. */
   virtual int         t8_element_num_face_children (const t8_element_t *
                                                     elem, int face);

--- a/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.hxx
+++ b/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.hxx
@@ -354,14 +354,11 @@ public:
                                                             elem);
 
 /** TODO: comment */
-  virtual int                 t8_element_test_if_subelement (const 
-                                                             t8_element *
-                                                             elem);
+  virtual int         t8_element_test_if_subelement (const t8_element * elem);
 
 /** TODO: comment */
-  virtual int                 t8_element_get_subelement_type (const 
-                                                              t8_element *
-                                                              elem);
+  virtual int         t8_element_get_subelement_type (const
+                                                      t8_element * elem);
 
 /** Get the shape of a given element. Subelements are triangles */
   virtual t8_element_shape_t t8_element_shape (const t8_element_t * elem);

--- a/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.hxx
+++ b/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.hxx
@@ -353,6 +353,16 @@ public:
                                                             t8_element *
                                                             elem);
 
+/** TODO: comment */
+  virtual int                 t8_element_test_if_subelement (const 
+                                                             t8_element *
+                                                             elem);
+
+/** TODO: comment */
+  virtual int                 t8_element_get_subelement_type (const 
+                                                              t8_element *
+                                                              elem);
+
 /** Get the shape of a given element. Subelements are triangles */
   virtual t8_element_shape_t t8_element_shape (const t8_element_t * elem);
 

--- a/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.hxx
+++ b/src/t8_schemes/t8_quads_w_rectangular_subelements/t8_subelements/t8_subelements_quad_cxx.hxx
@@ -180,7 +180,8 @@ public:
   virtual int         t8_element_num_children (const t8_element_t * elem);
 
   /** Return the number of siblings of an element */
-  virtual int         t8_element_num_siblings (const t8_element_t * elem) const;
+  virtual int         t8_element_num_siblings (const t8_element_t *
+                                               elem) const;
 
   /** Return the number of children of an element's face when the element is refined. */
   virtual int         t8_element_num_face_children (const t8_element_t *


### PR DESCRIPTION
Hey, this is the pull request for the new feature of multiple timesteps in the refinement example with subelements. 

This version might not work perfectly. We can observe "refinement artifacts" when using multiple timesteps. But it seems that this is no subelement specific problem (because these artifacts can also be observed without using subelements) but rather a problem of my timestep implementation. 

The time_forest examples use multiple refinement rounds in each time step which might solve this problem. But I could not find a simple way of transferring this code into my example for now (memory issues, forest is committed assertions etc.).

Since everything else seems to work fine, I might come back to this problem after the more important aspects like neighbors are working. 