### PR TITLE
Move installed t8code configuration files into subdirectory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,11 +27,12 @@ nodist_include_HEADERS =
 nobase_dist_include_HEADERS =
 noinst_HEADERS =
 noinst_PROGRAMS =
-sysconf_DATA =
+t8sysconf_DATA =
 dist_t8data_DATA =
 
 # use this if you want to link in T8 without autotools
-sysconf_DATA += Makefile.t8.mk
+t8sysconfdir = $(sysconfdir)/t8code
+t8sysconf_DATA += Makefile.t8.mk
 CLEANFILES += Makefile.t8.mk
 Makefile.t8.mk : Makefile.t8.pre
 	cat $< | \


### PR DESCRIPTION
Install configuration files into `<sysconfdir>/t8code` instead of `<sysconfdir>`. See #152.