### PR TITLE
Feature init shared mem

### DIFF
--- a/example/cmesh/t8_cmesh_partition.cxx
+++ b/example/cmesh/t8_cmesh_partition.cxx
@@ -176,7 +176,6 @@ test_ghost_send ()
                           &dummy_arg, sizeof (dummy_arg), 1);
   t8_cmesh_set_attribute (cmesh, 2, t8_get_package_id (), 0,
                           &dummy_arg, sizeof (dummy_arg), 1);
-  sc_shmem_set_type (sc_MPI_COMM_WORLD, T8_SHMEM_BEST_TYPE);
   switch (mpirank) {
   case 0:
     t8_cmesh_set_partition_range (cmesh, 3, 0, -1);

--- a/src/t8_cmesh/t8_cmesh_commit.c
+++ b/src/t8_cmesh/t8_cmesh_commit.c
@@ -240,7 +240,7 @@ t8_cmesh_commit_partitioned_new (t8_cmesh_t cmesh, sc_MPI_Comm comm)
 #endif
 
   if (cmesh->tree_offsets != NULL) {
-    t8_gloidx_t        *tree_offsets = (t8_gloidx_t *)
+    const t8_gloidx_t  *tree_offsets = (t8_gloidx_t *)
       t8_shmem_array_get_gloidx_array (cmesh->tree_offsets);
     /* We partition using tree offsets */
     /* Get the first tree and whether it is shared */

--- a/src/t8_cmesh/t8_cmesh_commit.c
+++ b/src/t8_cmesh/t8_cmesh_commit.c
@@ -229,6 +229,7 @@ t8_cmesh_commit_partitioned_new (t8_cmesh_t cmesh, sc_MPI_Comm comm)
     /* TODO: reset cmesh */
     return;
   }
+  t8_shmem_init (comm);
   t8_cmesh_set_shmem_type (comm);       /* TODO: do we actually need the shared array? */
   t8_stash_attribute_sort (cmesh->stash);
 

--- a/src/t8_cmesh/t8_cmesh_offset.c
+++ b/src/t8_cmesh/t8_cmesh_offset.c
@@ -37,7 +37,7 @@ t8_glo_kl0 (t8_gloidx_t A)
 
 /* The first tree of a given process in a partition */
 t8_gloidx_t
-t8_offset_first (int proc, t8_gloidx_t * offset)
+t8_offset_first (int proc, const t8_gloidx_t * offset)
 {
   T8_ASSERT (proc >= 0);
   T8_ASSERT (offset != NULL);
@@ -57,7 +57,7 @@ t8_offset_first_tree_to_entry (t8_gloidx_t first_tree, int shared)
 
 /* The number of trees of a given process in a partition */
 t8_gloidx_t
-t8_offset_num_trees (int proc, t8_gloidx_t * offset)
+t8_offset_num_trees (int proc, const t8_gloidx_t * offset)
 {
   t8_gloidx_t         num_global_trees;
   T8_ASSERT (proc >= 0);
@@ -71,7 +71,7 @@ t8_offset_num_trees (int proc, t8_gloidx_t * offset)
 
 /* The last local tree of a given process in a partition */
 t8_gloidx_t
-t8_offset_last (int proc, t8_gloidx_t * offset)
+t8_offset_last (int proc, const t8_gloidx_t * offset)
 {
   T8_ASSERT (proc >= -1);
   T8_ASSERT (offset != NULL);
@@ -82,7 +82,8 @@ t8_offset_last (int proc, t8_gloidx_t * offset)
 #ifdef T8_ENABLE_DEBUG
 /* Query whether a given global tree is in a valid range of a partition */
 static int
-t8_offset_valid_tree (t8_gloidx_t gtree, int mpisize, t8_gloidx_t * offset)
+t8_offset_valid_tree (t8_gloidx_t gtree, int mpisize,
+                      const t8_gloidx_t * offset)
 {
   T8_ASSERT (offset != NULL);
 
@@ -93,7 +94,7 @@ t8_offset_valid_tree (t8_gloidx_t gtree, int mpisize, t8_gloidx_t * offset)
 /* Return 1 if the process has no trees in the partition.
  * Return 0 if the process has at least one tree */
 int
-t8_offset_empty (int proc, t8_gloidx_t * offset)
+t8_offset_empty (int proc, const t8_gloidx_t * offset)
 {
   /* TODO: Why dont we just compute the number of local trees? */
   T8_ASSERT (proc >= 0);
@@ -108,7 +109,8 @@ t8_offset_empty (int proc, t8_gloidx_t * offset)
 /* Find the next higher rank that is not empty.
  * returns mpisize if this rank does not exist. */
 int
-t8_offset_next_nonempty_rank (int rank, int mpisize, t8_gloidx_t * offset)
+t8_offset_next_nonempty_rank (int rank, int mpisize,
+                              const t8_gloidx_t * offset)
 {
   int                 next_nonempty = rank + 1;
 
@@ -122,7 +124,7 @@ t8_offset_next_nonempty_rank (int rank, int mpisize, t8_gloidx_t * offset)
 /* Check whether a given offset array represents a valid
  * partition. */
 int
-t8_offset_consistent (int mpisize, t8_gloidx_t * offset,
+t8_offset_consistent (int mpisize, const t8_gloidx_t * offset,
                       t8_gloidx_t num_trees)
 {
   int                 i, ret = 1;
@@ -158,7 +160,7 @@ t8_offset_consistent (int mpisize, t8_gloidx_t * offset,
 
 /* Determine whether a given global tree id is in the range of a given process */
 int
-t8_offset_in_range (t8_gloidx_t tree_id, int proc, t8_gloidx_t * offset)
+t8_offset_in_range (t8_gloidx_t tree_id, int proc, const t8_gloidx_t * offset)
 {
   return t8_offset_first (proc, offset) <= tree_id
     && tree_id <= t8_offset_last (proc, offset);
@@ -170,7 +172,7 @@ t8_offset_in_range (t8_gloidx_t tree_id, int proc, t8_gloidx_t * offset)
  */
 int
 t8_offset_any_owner_of_tree (int mpisize, t8_gloidx_t gtree,
-                             t8_gloidx_t * offset)
+                             const t8_gloidx_t * offset)
 {
   int                 proc, range[2], found;
 
@@ -199,7 +201,7 @@ t8_offset_any_owner_of_tree (int mpisize, t8_gloidx_t gtree,
  * already owns the tree. Otherwise (some_owner < 0), the function will compute one. */
 int
 t8_offset_first_owner_of_tree (int mpisize, t8_gloidx_t gtree,
-                               t8_gloidx_t * offset, int *some_owner)
+                               const t8_gloidx_t * offset, int *some_owner)
 {
   int                 proc, proc_temp;
 
@@ -240,8 +242,8 @@ t8_offset_first_owner_of_tree (int mpisize, t8_gloidx_t gtree,
 
 static int
 t8_offset_next_prev_owner_of_tree (int mpisize, t8_gloidx_t gtree,
-                                   t8_gloidx_t * offset, int current_owner,
-                                   int search_dir)
+                                   const t8_gloidx_t * offset,
+                                   int current_owner, int search_dir)
 {
   int                 proc;
 
@@ -268,7 +270,7 @@ t8_offset_next_prev_owner_of_tree (int mpisize, t8_gloidx_t gtree,
  */
 int
 t8_offset_next_owner_of_tree (int mpisize, t8_gloidx_t gtree,
-                              t8_gloidx_t * offset, int current_owner)
+                              const t8_gloidx_t * offset, int current_owner)
 {
   return t8_offset_next_prev_owner_of_tree (mpisize, gtree, offset,
                                             current_owner, +1);
@@ -280,7 +282,7 @@ t8_offset_next_owner_of_tree (int mpisize, t8_gloidx_t gtree,
  */
 int
 t8_offset_prev_owner_of_tree (int mpisize, t8_gloidx_t gtree,
-                              t8_gloidx_t * offset, int current_owner)
+                              const t8_gloidx_t * offset, int current_owner)
 {
   return t8_offset_next_prev_owner_of_tree (mpisize, gtree, offset,
                                             current_owner, -1);
@@ -291,7 +293,7 @@ t8_offset_prev_owner_of_tree (int mpisize, t8_gloidx_t gtree,
  * already owns the tree. Otherwise (some_owner < 0), the function will compute one. */
 int
 t8_offset_last_owner_of_tree (int mpisize, t8_gloidx_t gtree,
-                              t8_gloidx_t * offset, int *some_owner)
+                              const t8_gloidx_t * offset, int *some_owner)
 {
   int                 proc, proc_temp;
 
@@ -335,7 +337,7 @@ t8_offset_last_owner_of_tree (int mpisize, t8_gloidx_t gtree,
  * element count 0 */
 void
 t8_offset_all_owners_of_tree (int mpisize, t8_gloidx_t gtree,
-                              t8_gloidx_t * offset, sc_array_t * owners)
+                              const t8_gloidx_t * offset, sc_array_t * owners)
 {
   int                 proc;
   int                *entry;
@@ -367,8 +369,8 @@ t8_offset_all_owners_of_tree (int mpisize, t8_gloidx_t gtree,
 /* Return 1 if the process will not send any trees, that is if it is
  * empty or has only one shared tree. */
 int
-t8_offset_nosend (int proc, int mpisize, t8_gloidx_t * offset_from,
-                  t8_gloidx_t * offset_to)
+t8_offset_nosend (int proc, int mpisize, const t8_gloidx_t * offset_from,
+                  const t8_gloidx_t * offset_to)
 {
   t8_gloidx_t         num_trees;
 
@@ -440,8 +442,8 @@ t8_offset_nosend (int proc, int mpisize, t8_gloidx_t * offset_from,
 /* Return one if proca sends trees to procb when partitioning from
  * offset_from to offset_to */
 int
-t8_offset_sendsto (int proca, int procb, t8_gloidx_t * t8_offset_from,
-                   t8_gloidx_t * t8_offset_to)
+t8_offset_sendsto (int proca, int procb, const t8_gloidx_t * t8_offset_from,
+                   const t8_gloidx_t * t8_offset_to)
 {
   t8_gloidx_t         proca_first, proca_last;
   t8_gloidx_t         procb_first, procb_last;
@@ -492,7 +494,8 @@ t8_offset_sendsto (int proca, int procb, t8_gloidx_t * t8_offset_from,
  */
 int
 t8_offset_sendstree (int proc_send, int proc_to, t8_gloidx_t gtree,
-                     t8_gloidx_t * offset_from, t8_gloidx_t * offset_to)
+                     const t8_gloidx_t * offset_from,
+                     const t8_gloidx_t * offset_to)
 {
   /* If the tree is not the last tree on proc_send it is send if
    * first_tree <= tree <= last_tree on the new partition for process proc_to.
@@ -531,7 +534,8 @@ t8_offset_sendstree (int proc_send, int proc_to, t8_gloidx_t gtree,
  * A process counts as sending if it has at least one non-shared local tree */
 int
 t8_offset_range_send (int start, int end, int mpirank,
-                      t8_gloidx_t * offset_from, t8_gloidx_t * offset_to)
+                      const t8_gloidx_t * offset_from,
+                      const t8_gloidx_t * offset_to)
 {
   int                 count = 0, i;
 

--- a/src/t8_cmesh/t8_cmesh_offset.c
+++ b/src/t8_cmesh/t8_cmesh_offset.c
@@ -124,11 +124,14 @@ t8_offset_next_nonempty_rank (int rank, int mpisize,
 /* Check whether a given offset array represents a valid
  * partition. */
 int
-t8_offset_consistent (int mpisize, const t8_gloidx_t * offset,
+t8_offset_consistent (int mpisize, const t8_shmem_array_t offset_shmem,
                       t8_gloidx_t num_trees)
 {
   int                 i, ret = 1;
   t8_gloidx_t         last_tree;
+  T8_ASSERT (t8_shmem_array_is_initialized (offset_shmem));
+
+  const t8_gloidx_t  *offset = t8_shmem_array_get_gloidx_array (offset_shmem);
 
   ret = offset[0] == 0;
   last_tree = t8_offset_last (0, offset);       /* stores the last tree of process i-1 */

--- a/src/t8_cmesh/t8_cmesh_offset.h
+++ b/src/t8_cmesh/t8_cmesh_offset.h
@@ -113,7 +113,7 @@ int                 t8_offset_next_nonempty_rank (int rank, int mpisize,
  *                        0 if not.
  */
 int                 t8_offset_consistent (int mpisize,
-                                          const t8_gloidx_t * offset,
+                                          const t8_shmem_array_t offset_shmem,
                                           t8_gloidx_t num_trees);
 #endif
 

--- a/src/t8_cmesh/t8_cmesh_offset.h
+++ b/src/t8_cmesh/t8_cmesh_offset.h
@@ -43,7 +43,7 @@ T8_EXTERN_C_BEGIN ();
  * \return              The global id of the first local tree
  *                      of \a proc in the partition \a offset.
  */
-t8_gloidx_t         t8_offset_first (int proc, t8_gloidx_t * offset);
+t8_gloidx_t         t8_offset_first (int proc, const t8_gloidx_t * offset);
 
 /** Given the global tree id of the first local tree of a process and
  * the flag whether it is shared or not, compute the entry in the offset array.
@@ -65,7 +65,8 @@ t8_gloidx_t
  * \return              The number of local trees of \a proc
  *                      in the partition \a offset.
  */
-t8_gloidx_t         t8_offset_num_trees (int proc, t8_gloidx_t * offset);
+t8_gloidx_t         t8_offset_num_trees (int proc,
+                                         const t8_gloidx_t * offset);
 
 /** Return the last local tree of a given process in a partition.
  * \param [in] proc     A mpi rank.
@@ -73,7 +74,7 @@ t8_gloidx_t         t8_offset_num_trees (int proc, t8_gloidx_t * offset);
  * \return              The global tree id of the last local tree of
  *                      \a proc in \a offset.
  */
-t8_gloidx_t         t8_offset_last (int proc, t8_gloidx_t * offset);
+t8_gloidx_t         t8_offset_last (int proc, const t8_gloidx_t * offset);
 
 /** Check whether a given process has no local trees in a given partition.
  * \param [in] proc     A mpi rank.
@@ -81,7 +82,7 @@ t8_gloidx_t         t8_offset_last (int proc, t8_gloidx_t * offset);
  * \return              nonzero if \a proc does not have local trees in \a offset.
  *                      0 otherwise.
  */
-int                 t8_offset_empty (int proc, t8_gloidx_t * offset);
+int                 t8_offset_empty (int proc, const t8_gloidx_t * offset);
 
 /** Find the next higher rank that is not empty.
  * returns mpisize if this rank does not exist.
@@ -95,7 +96,7 @@ int                 t8_offset_empty (int proc, t8_gloidx_t * offset);
  *                      If no such \a q exists, \a mpisize is returned.
  */
 int                 t8_offset_next_nonempty_rank (int rank, int mpisize,
-                                                  t8_gloidx_t * offset);
+                                                  const t8_gloidx_t * offset);
 
 #if T8_ENABLE_DEBUG
 /** Check whether a given offset array represents a valid
@@ -111,7 +112,8 @@ int                 t8_offset_next_nonempty_rank (int rank, int mpisize,
  * \return                nonzero if the partition is valid,
  *                        0 if not.
  */
-int                 t8_offset_consistent (int mpisize, t8_gloidx_t * offset,
+int                 t8_offset_consistent (int mpisize,
+                                          const t8_gloidx_t * offset,
                                           t8_gloidx_t num_trees);
 #endif
 
@@ -124,7 +126,7 @@ int                 t8_offset_consistent (int mpisize, t8_gloidx_t * offset,
  *                      0 if it is not.
  */
 int                 t8_offset_in_range (t8_gloidx_t tree_id, int proc,
-                                        t8_gloidx_t * offset);
+                                        const t8_gloidx_t * offset);
 
 /** Find any process that has a given tree as local tree.
  * \param [in] mpisize    The number of MPI ranks, also the number of entries in \a offset minus 1.
@@ -134,7 +136,7 @@ int                 t8_offset_in_range (t8_gloidx_t tree_id, int proc,
  */
 int                 t8_offset_any_owner_of_tree (int mpisize,
                                                  t8_gloidx_t gtree,
-                                                 t8_gloidx_t * offset);
+                                                 const t8_gloidx_t * offset);
 
 /** Find the smallest process that has a given tree as local tree.
  * To increase the runtime, an arbitrary process having this tree as local tree
@@ -151,7 +153,7 @@ int                 t8_offset_any_owner_of_tree (int mpisize,
  */
 int                 t8_offset_first_owner_of_tree (int mpisize,
                                                    t8_gloidx_t gtree,
-                                                   t8_gloidx_t * offset,
+                                                   const t8_gloidx_t * offset,
                                                    int *some_owner);
 
 /** Find the biggest process that has a given tree as local tree.
@@ -169,7 +171,7 @@ int                 t8_offset_first_owner_of_tree (int mpisize,
  */
 int                 t8_offset_last_owner_of_tree (int mpisize,
                                                   t8_gloidx_t gtree,
-                                                  t8_gloidx_t * offset,
+                                                  const t8_gloidx_t * offset,
                                                   int *some_owner);
 
 /** Given a process current_owner that has the tree gtree as local tree,
@@ -184,7 +186,7 @@ int                 t8_offset_last_owner_of_tree (int mpisize,
  */
 int                 t8_offset_next_owner_of_tree (int mpisize,
                                                   t8_gloidx_t gtree,
-                                                  t8_gloidx_t * offset,
+                                                  const t8_gloidx_t * offset,
                                                   int current_owner);
 
 /** Given a process current_owner that has the tree gtree as local tree,
@@ -199,7 +201,7 @@ int                 t8_offset_next_owner_of_tree (int mpisize,
  */
 int                 t8_offset_prev_owner_of_tree (int mpisize,
                                                   t8_gloidx_t gtree,
-                                                  t8_gloidx_t * offset,
+                                                  const t8_gloidx_t * offset,
                                                   int current_owner);
 
 /** Compute a list of all processes that own a specific tree.n \a offset minus 1.
@@ -212,7 +214,7 @@ int                 t8_offset_prev_owner_of_tree (int mpisize,
  */
 void                t8_offset_all_owners_of_tree (int mpisize,
                                                   t8_gloidx_t gtree,
-                                                  t8_gloidx_t * offset,
+                                                  const t8_gloidx_t * offset,
                                                   sc_array_t * owners);
 
 /** Query whether in a repartition setting a given process
@@ -226,8 +228,8 @@ void                t8_offset_all_owners_of_tree (int mpisize,
  *                      0 if it does send local trees.
  */
 int                 t8_offset_nosend (int proc, int mpisize,
-                                      t8_gloidx_t * offset_from,
-                                      t8_gloidx_t * offset_to);
+                                      const t8_gloidx_t * offset_from,
+                                      const t8_gloidx_t * offset_to);
 
 /** Query whether in a repartitioning setting, a given process sends local trees (and then possibly ghosts) to a
  * given other process.
@@ -240,8 +242,8 @@ int                 t8_offset_nosend (int proc, int mpisize,
  *                      0 else.
  */
 int                 t8_offset_sendsto (int proca, int procb,
-                                       t8_gloidx_t * t8_offset_from,
-                                       t8_gloidx_t * t8_offset_to);
+                                       const t8_gloidx_t * t8_offset_from,
+                                       const t8_gloidx_t * t8_offset_to);
 
 /** Query whether in a repartitioning setting, a given process sends a given
  * tree to a second process.
@@ -258,8 +260,8 @@ int                 t8_offset_sendsto (int proca, int procb,
  */
 int                 t8_offset_sendstree (int proc_send, int proc_to,
                                          t8_gloidx_t gtree,
-                                         t8_gloidx_t * offset_from,
-                                         t8_gloidx_t * offset_to);
+                                         const t8_gloidx_t * offset_from,
+                                         const t8_gloidx_t * offset_to);
 
 /** Count the number of processes in a given range [a,b] that send to
  * a given other process in a repartitioning setting.
@@ -273,8 +275,8 @@ int                 t8_offset_sendstree (int proc_send, int proc_to,
  *                      to \a mpirank.
  */
 int                 t8_offset_range_send (int start, int end, int mpirank,
-                                          t8_gloidx_t * offset_from,
-                                          t8_gloidx_t * offset_to);
+                                          const t8_gloidx_t * offset_from,
+                                          const t8_gloidx_t * offset_to);
 
 /** Print an offset array. Useful for debugging.
  * \param [in] offset    The offset to print

--- a/src/t8_cmesh/t8_cmesh_partition.c
+++ b/src/t8_cmesh/t8_cmesh_partition.c
@@ -2666,9 +2666,7 @@ t8_cmesh_offset_print (t8_cmesh_t cmesh, sc_MPI_Comm comm)
       offset_isnew = 1;
     }
     t8_offset_print (cmesh->tree_offsets, comm);
-    T8_ASSERT (t8_offset_consistent (cmesh->mpisize,
-                                     t8_shmem_array_get_gloidx_array
-                                     (cmesh->tree_offsets),
+    T8_ASSERT (t8_offset_consistent (cmesh->mpisize, cmesh->tree_offsets,
                                      cmesh->num_trees));
     if (offset_isnew == 1) {
       t8_shmem_array_destroy (&cmesh->tree_offsets);
@@ -2721,7 +2719,7 @@ t8_cmesh_offset_concentrate (int proc, sc_MPI_Comm comm,
   }
   t8_shmem_array_end_writing (shmem_array);
 
-  T8_ASSERT (t8_offset_consistent (mpisize, offsets, num_trees));
+  T8_ASSERT (t8_offset_consistent (mpisize, shmem_array, num_trees));
   return shmem_array;
 }
 
@@ -2806,7 +2804,7 @@ t8_cmesh_offset_random (sc_MPI_Comm comm, t8_gloidx_t num_trees, int shared,
   }
   t8_shmem_array_end_writing (shmem_array);
 
-  T8_ASSERT (t8_offset_consistent (mpisize, offsets, num_trees));
+  T8_ASSERT (t8_offset_consistent (mpisize, shmem_array, num_trees));
   return shmem_array;
 }
 
@@ -2873,9 +2871,7 @@ t8_cmesh_offset_percent (t8_cmesh_t cmesh, sc_MPI_Comm comm, int percent)
      * again. */
     t8_shmem_array_destroy (&cmesh->tree_offsets);
   }
-  T8_ASSERT (t8_offset_consistent (mpisize,
-                                   t8_shmem_array_get_gloidx_array
-                                   (partition_array),
+  T8_ASSERT (t8_offset_consistent (mpisize, partition_array,
                                    t8_cmesh_get_num_trees (cmesh)));
   return partition_array;
 }

--- a/src/t8_cmesh/t8_cmesh_partition.c
+++ b/src/t8_cmesh/t8_cmesh_partition.c
@@ -221,6 +221,7 @@ t8_cmesh_gather_treecount_ext (t8_cmesh_t cmesh, sc_MPI_Comm comm,
   tree_offset = cmesh->first_tree_shared ? -cmesh->first_tree - 1 :
     cmesh->first_tree;
   if (cmesh->tree_offsets == NULL) {
+    t8_shmem_init (comm);
     t8_shmem_set_type (comm, T8_SHMEM_BEST_TYPE);
     /* Only allocate the shmem array, if it is not already allocated */
     cmesh->tree_offsets = t8_cmesh_alloc_offsets (cmesh->mpisize, comm);

--- a/src/t8_cmesh/t8_cmesh_partition.h
+++ b/src/t8_cmesh/t8_cmesh_partition.h
@@ -87,6 +87,7 @@ void                t8_cmesh_offset_print (t8_cmesh_t cmesh,
  * \param[in]        num_trees The number of global trees in the partition.
  * \return                   A valid partition table for a cmesh with \a num_trees trees
  *                           and communicator \a comm, where each tree is on process \a proc.
+ * \note This function is MPI collective.
  */
 t8_shmem_array_t    t8_cmesh_offset_concentrate (int proc, sc_MPI_Comm comm,
                                                  t8_gloidx_t num_trees);
@@ -101,6 +102,7 @@ t8_shmem_array_t    t8_cmesh_offset_concentrate (int proc, sc_MPI_Comm comm,
  * \return                   A valid partition table for a cmesh with \a num_trees trees
  *                           and communicator \a comm, where each processor gets a random number
  *                           of trees. The number of trees per processor is roughly uniformly distributed.
+ * \note This function is MPI collective. 
  */
 t8_shmem_array_t    t8_cmesh_offset_random (sc_MPI_Comm comm,
                                             t8_gloidx_t num_trees,
@@ -112,6 +114,7 @@ t8_shmem_array_t    t8_cmesh_offset_random (sc_MPI_Comm comm,
  * \param [in]      comm    A valid MPI communicator for cmesh.
  * \return                  A shared memory offset array storing the new offsets.
  *                          Its associated communicator is \a comm.
+ * \note This function is MPI collective.
  */
 t8_shmem_array_t    t8_cmesh_offset_half (t8_cmesh_t cmesh, sc_MPI_Comm comm);
 
@@ -124,6 +127,7 @@ t8_shmem_array_t    t8_cmesh_offset_half (t8_cmesh_t cmesh, sc_MPI_Comm comm);
  *                          be the same on each process.
  * \return                  A shared memory offset array storing the new offsets.
  *                          Its associated communicator is \a comm.
+ * \note This function is MPI collective.
  */
 t8_shmem_array_t    t8_cmesh_offset_percent (t8_cmesh_t cmesh,
                                              sc_MPI_Comm comm, int percent);

--- a/src/t8_cmesh/t8_cmesh_save.c
+++ b/src/t8_cmesh/t8_cmesh_save.c
@@ -886,6 +886,7 @@ t8_cmesh_load_and_distribute (const char *fileprefix, int num_files,
   T8_ASSERT (mpisize >= num_files);
 
   /* Try to set the comm type */
+  t8_shmem_init (comm);
   t8_shmem_set_type (comm, T8_SHMEM_BEST_TYPE);
 
   /* Use cmesh_bcast, if only one process loads the cmesh: */

--- a/src/t8_data/t8_shmem.c
+++ b/src/t8_data/t8_shmem.c
@@ -50,8 +50,9 @@ t8_shmem_array_is_writing_possible (const t8_shmem_array_t array)
   return array->writing_possible;
 }
 
+#if T8_ENABLE_DEBUG
 /* Check whether a shared memory array is initialized. */
-static int
+int
 t8_shmem_array_is_initialized (const t8_shmem_array_t array)
 {
   return (array != NULL &&
@@ -59,6 +60,7 @@ t8_shmem_array_is_initialized (const t8_shmem_array_t array)
           array->elem_count >= 0 &&
           array->array != NULL && array->comm != sc_MPI_COMM_NULL);
 }
+#endif
 
 void
 t8_shmem_init (sc_MPI_Comm comm)

--- a/src/t8_data/t8_shmem.c
+++ b/src/t8_data/t8_shmem.c
@@ -29,16 +29,36 @@
 
 /* TODO: Think about whether we include a reference counter */
 
+/** Shared memory array structure.
+ * The array uses sc_shmem shared memory.*/
 typedef struct t8_shmem_array
 {
-  void               *array;
-  size_t              elem_size;
-  size_t              elem_count;
-  sc_MPI_Comm         comm;
+  void               *array;    /*< Pointer to the actual memory. */
+  size_t              elem_size;        /*< Size of one entry in byte. */
+  size_t              elem_count;       /*< Total count of entries. */
+  sc_MPI_Comm         comm;     /*< MPI communicator. */
+  int                 writing_possible; /*< True if we can currently write into this array. False if not. */
+  int                 write_start_called;       /*< True if t8_shmem_array_start_writing was called and no call to t8_shmem_array_end_writing happened yet. */
 #ifdef T8_ENABLE_DEBUG
-  sc_shmem_type_t     shmem_type;
+  sc_shmem_type_t     shmem_type;       /*< Shared memory type of the communicator (at time of initializing the array). */
 #endif
 } t8_shmem_array_struct_t;
+
+static int
+t8_shmem_array_is_writing_possible (const t8_shmem_array_t array)
+{
+  return array->writing_possible;
+}
+
+/* Check whether a shared memory array is initialized. */
+static int
+t8_shmem_array_is_initialized (const t8_shmem_array_t array)
+{
+  return (array != NULL &&
+          array->elem_size > 0 &&
+          array->elem_count >= 0 &&
+          array->array != NULL && array->comm != sc_MPI_COMM_NULL);
+}
 
 void
 t8_shmem_init (sc_MPI_Comm comm)
@@ -47,6 +67,8 @@ t8_shmem_init (sc_MPI_Comm comm)
    * for the current communicator. */
   sc_MPI_Comm         intranode;
   sc_MPI_Comm         internode;
+  SC_CHECK_ABORT (comm != sc_MPI_COMM_NULL,
+                  "Trying to initialize shared memory for NULL communicator.");
 
   sc_mpi_comm_get_node_comms (comm, &intranode, &internode);
   if (intranode == sc_MPI_COMM_NULL || internode == sc_MPI_COMM_NULL) {
@@ -98,6 +120,8 @@ t8_shmem_array_init (t8_shmem_array_t * parray, size_t elem_size,
    * for the current communicator. */
   sc_MPI_Comm         intranode;
   sc_MPI_Comm         internode;
+  SC_CHECK_ABORT (comm != sc_MPI_COMM_NULL,
+                  "Trying to initialize shared memory array with NULL communicator.");
 
   sc_mpi_comm_get_node_comms (comm, &intranode, &internode);
   if (intranode == sc_MPI_COMM_NULL || internode == sc_MPI_COMM_NULL) {
@@ -119,15 +143,47 @@ t8_shmem_array_init (t8_shmem_array_t * parray, size_t elem_size,
   array->comm = comm;
   array->elem_count = elem_count;
   array->elem_size = elem_size;
+  array->writing_possible = 0;
+  array->write_start_called = 0;
 #ifdef T8_ENABLE_DEBUG
   array->shmem_type = T8_SHMEM_BEST_TYPE;
 #endif
+}
+
+int
+t8_shmem_array_start_writing (t8_shmem_array_t array)
+{
+  T8_ASSERT (t8_shmem_array_is_initialized (array));
+
+  if (sc_shmem_write_start (array->array, array->comm)) {
+    array->writing_possible = 1;
+  }
+  else {
+    array->writing_possible = 0;
+  }
+  array->write_start_called = 1;
+  return array->writing_possible;
+}
+
+void
+t8_shmem_array_end_writing (t8_shmem_array_t array)
+{
+  T8_ASSERT (t8_shmem_array_is_initialized (array));
+
+  SC_CHECK_ABORT (array->write_start_called,
+                  "End writing to shared array is only possible when t8_shmem_start_writing was called before.");
+  sc_shmem_write_end (array->array, array->comm);
+  array->write_start_called = 0;
+  array->writing_possible = 0;
 }
 
 void
 t8_shmem_array_copy (t8_shmem_array_t dest, t8_shmem_array_t source)
 {
   size_t              bytes;
+  T8_ASSERT (t8_shmem_array_is_initialized (dest));
+  T8_ASSERT (t8_shmem_array_is_initialized (source));
+  T8_ASSERT (!t8_shmem_array_is_writing_possible (dest));
   SC_CHECK_ABORT (t8_shmem_array_get_elem_size (dest) ==
                   t8_shmem_array_get_elem_size (source),
                   "Try to copy shared memory arrays of different element size.\n");
@@ -150,8 +206,8 @@ t8_shmem_array_allgather (const void *sendbuf, int sendcount,
                           t8_shmem_array_t recvarray, int recvcount,
                           sc_MPI_Datatype recvtype)
 {
-  T8_ASSERT (recvarray != NULL);
-  T8_ASSERT (recvarray->array != NULL);
+  T8_ASSERT (t8_shmem_array_is_initialized (recvarray));
+  T8_ASSERT (!t8_shmem_array_is_writing_possible (recvarray));
 
   sc_shmem_allgather ((void *) sendbuf, sendcount, sendtype, recvarray->array,
                       recvcount, recvtype, recvarray->comm);
@@ -160,37 +216,48 @@ t8_shmem_array_allgather (const void *sendbuf, int sendcount,
 sc_MPI_Comm
 t8_shmem_array_get_comm (t8_shmem_array_t array)
 {
-  T8_ASSERT (array != NULL);
+  T8_ASSERT (t8_shmem_array_is_initialized (array));
   return array->comm;
 }
 
 size_t
 t8_shmem_array_get_elem_size (t8_shmem_array_t array)
 {
-  T8_ASSERT (array != NULL);
+  T8_ASSERT (t8_shmem_array_is_initialized (array));
   return array->elem_size;
 }
 
 size_t
 t8_shmem_array_get_elem_count (t8_shmem_array_t array)
 {
-  T8_ASSERT (array != NULL);
+  T8_ASSERT (t8_shmem_array_is_initialized (array));
   return array->elem_count;
 }
 
 const t8_gloidx_t  *
 t8_shmem_array_get_gloidx_array (t8_shmem_array_t array)
 {
-  T8_ASSERT (array != NULL);
+  T8_ASSERT (t8_shmem_array_is_initialized (array));
   T8_ASSERT (array->elem_size == sizeof (t8_gloidx_t));
+  T8_ASSERT (!t8_shmem_array_is_writing_possible (array));
+  return (const t8_gloidx_t *) array->array;
+}
+
+t8_gloidx_t        *
+t8_shmem_array_get_gloidx_array_for_writing (t8_shmem_array_t array)
+{
+  T8_ASSERT (t8_shmem_array_is_initialized (array));
+  T8_ASSERT (array->elem_size == sizeof (t8_gloidx_t));
+  SC_CHECK_ABORT (t8_shmem_array_is_writing_possible (array),
+                  "Writing not enabled for shmem array.");
   return (t8_gloidx_t *) array->array;
 }
 
 t8_gloidx_t
 t8_shmem_array_get_gloidx (t8_shmem_array_t array, int index)
 {
-  T8_ASSERT (array != NULL);
-  T8_ASSERT (array->array != NULL);
+  T8_ASSERT (t8_shmem_array_is_initialized (array));
+  T8_ASSERT (!t8_shmem_array_is_writing_possible (array));
   T8_ASSERT (array->elem_size == sizeof (t8_gloidx_t));
   T8_ASSERT (0 <= index && (size_t) index < array->elem_count);
 
@@ -201,10 +268,11 @@ void
 t8_shmem_array_set_gloidx (t8_shmem_array_t array, int index,
                            t8_gloidx_t value)
 {
-  T8_ASSERT (array != NULL);
-  T8_ASSERT (array->array != NULL);
+  T8_ASSERT (t8_shmem_array_is_initialized (array));
   T8_ASSERT (array->elem_size == sizeof (t8_gloidx_t));
   T8_ASSERT (0 <= index && (size_t) index < array->elem_count);
+  SC_CHECK_ABORT (t8_shmem_array_is_writing_possible (array),
+                  "Unauthorized write in shmem array. See t8_shmem_array_start_writing.");
 
   ((t8_gloidx_t *) array->array)[index] = value;
 }
@@ -212,14 +280,16 @@ t8_shmem_array_set_gloidx (t8_shmem_array_t array, int index,
 const void         *
 t8_shmem_array_get_array (t8_shmem_array_t array)
 {
-  T8_ASSERT (array != NULL);
+  T8_ASSERT (t8_shmem_array_is_initialized (array));
+  T8_ASSERT (!t8_shmem_array_is_writing_possible (array));
   return array->array;
 }
 
 const void         *
 t8_shmem_array_index (t8_shmem_array_t array, size_t index)
 {
-  T8_ASSERT (array != NULL);
+  T8_ASSERT (t8_shmem_array_is_initialized (array));
+  T8_ASSERT (!t8_shmem_array_is_writing_possible (array));
   T8_ASSERT (0 <= index && index < array->elem_count);
 
   return ((char *) array->array) + index * array->elem_size;
@@ -230,6 +300,10 @@ int
 t8_shmem_array_is_equal (t8_shmem_array_t array_a, t8_shmem_array_t array_b)
 {
   int                 retval;
+  T8_ASSERT (t8_shmem_array_is_initialized (array_a));
+  T8_ASSERT (t8_shmem_array_is_initialized (array_b));
+  T8_ASSERT (!t8_shmem_array_is_writing_possible (array_a));
+  T8_ASSERT (!t8_shmem_array_is_writing_possible (array_b));
 
   /* check if direct equality holds */
   if (array_a == array_b) {
@@ -260,7 +334,10 @@ void
 t8_shmem_array_destroy (t8_shmem_array_t * parray)
 {
   t8_shmem_array_t    array;
-  T8_ASSERT (parray != NULL && *parray != NULL);
+  T8_ASSERT (parray != NULL);
+  T8_ASSERT (t8_shmem_array_is_initialized (*parray));
+  T8_ASSERT (!t8_shmem_array_is_writing_possible (*parray));
+
   array = *parray;
   sc_shmem_free (t8_get_package_id (), array->array, array->comm);
   T8_FREE (array);

--- a/src/t8_data/t8_shmem.c
+++ b/src/t8_data/t8_shmem.c
@@ -70,7 +70,7 @@ t8_shmem_finalize (sc_MPI_Comm comm)
   }
 }
 
-int
+void
 t8_shmem_set_type (sc_MPI_Comm comm, sc_shmem_type_t type)
 {
   /* Check whether intranode and internode comms are set
@@ -86,15 +86,7 @@ t8_shmem_set_type (sc_MPI_Comm comm, sc_shmem_type_t type)
        " You should call t8_shmem_init before setting the shmem type.\n");
   }
 
-  if (sc_shmem_get_type (comm) == SC_SHMEM_NOT_SET) {
-    /* This communicator does not have a shmem type, so we set it */
-    sc_shmem_set_type (comm, type);
-    return 1;
-  }
-  else {
-    /* There was already a type set, we do not change it */
-    return 0;
-  }
+  sc_shmem_set_type (comm, type);
 }
 
 void

--- a/src/t8_data/t8_shmem.c
+++ b/src/t8_data/t8_shmem.c
@@ -73,6 +73,19 @@ t8_shmem_finalize (sc_MPI_Comm comm)
 int
 t8_shmem_set_type (sc_MPI_Comm comm, sc_shmem_type_t type)
 {
+  /* Check whether intranode and internode comms are set
+   * for the current communicator. */
+  sc_MPI_Comm         intranode;
+  sc_MPI_Comm         internode;
+
+  sc_mpi_comm_get_node_comms (comm, &intranode, &internode);
+  if (intranode == sc_MPI_COMM_NULL || internode == sc_MPI_COMM_NULL) {
+    t8_global_errorf
+      ("WARNING: Trying to used shared memory but intranode and internode"
+       " communicators are not set."
+       " You should call t8_shmem_init before setting the shmem type.\n");
+  }
+
   if (sc_shmem_get_type (comm) == SC_SHMEM_NOT_SET) {
     /* This communicator does not have a shmem type, so we set it */
     sc_shmem_set_type (comm, type);
@@ -89,6 +102,18 @@ t8_shmem_array_init (t8_shmem_array_t * parray, size_t elem_size,
                      size_t elem_count, sc_MPI_Comm comm)
 {
   t8_shmem_array_t    array;
+  /* Check whether intranode and internode comms are set
+   * for the current communicator. */
+  sc_MPI_Comm         intranode;
+  sc_MPI_Comm         internode;
+
+  sc_mpi_comm_get_node_comms (comm, &intranode, &internode);
+  if (intranode == sc_MPI_COMM_NULL || internode == sc_MPI_COMM_NULL) {
+    t8_global_errorf
+      ("WARNING: Trying to used shared memory but intranode and internode"
+       " communicators are not set."
+       " You should call t8_shmem_init before initializing a shared memory array.\n");
+  }
 
   T8_ASSERT (parray != NULL);
 

--- a/src/t8_data/t8_shmem.c
+++ b/src/t8_data/t8_shmem.c
@@ -40,6 +40,36 @@ typedef struct t8_shmem_array
 #endif
 } t8_shmem_array_struct_t;
 
+void
+t8_shmem_init (sc_MPI_Comm comm)
+{
+  /* Check whether intranode and internode comms are set
+   * for the current communicator. */
+  sc_MPI_Comm         intranode;
+  sc_MPI_Comm         internode;
+
+  sc_mpi_comm_get_node_comms (comm, &intranode, &internode);
+  if (intranode == sc_MPI_COMM_NULL || internode == sc_MPI_COMM_NULL) {
+    /* The inter/intra comms are not set. We need to set them to 
+     * initialize shared memory usage. */
+    sc_mpi_comm_get_and_attach (comm);
+  }
+}
+
+void
+t8_shmem_finalize (sc_MPI_Comm comm)
+{
+  /* Check whether intranode and internode comms are set
+   * for the current communicator. */
+  sc_MPI_Comm         intranode;
+  sc_MPI_Comm         internode;
+
+  sc_mpi_comm_get_node_comms (comm, &intranode, &internode);
+  if (intranode != sc_MPI_COMM_NULL || internode != sc_MPI_COMM_NULL) {
+    sc_mpi_comm_detach_node_comms (comm);
+  }
+}
+
 int
 t8_shmem_set_type (sc_MPI_Comm comm, sc_shmem_type_t type)
 {

--- a/src/t8_data/t8_shmem.c
+++ b/src/t8_data/t8_shmem.c
@@ -300,6 +300,16 @@ t8_shmem_array_index (t8_shmem_array_t array, size_t index)
   return ((char *) array->array) + index * array->elem_size;
 }
 
+void               *
+t8_shmem_array_index_for_writing (t8_shmem_array_t array, size_t index)
+{
+  T8_ASSERT (t8_shmem_array_is_initialized (array));
+  T8_ASSERT (t8_shmem_array_is_writing_possible (array));
+  T8_ASSERT (0 <= index && index < array->elem_count);
+
+  return ((char *) array->array) + index * array->elem_size;
+}
+
 /* TODO: implement */
 int
 t8_shmem_array_is_equal (t8_shmem_array_t array_a, t8_shmem_array_t array_b)

--- a/src/t8_data/t8_shmem.c
+++ b/src/t8_data/t8_shmem.c
@@ -153,7 +153,7 @@ t8_shmem_array_copy (t8_shmem_array_t dest, t8_shmem_array_t source)
 }
 
 void
-t8_shmem_array_allgather (void *sendbuf, int sendcount,
+t8_shmem_array_allgather (const void *sendbuf, int sendcount,
                           sc_MPI_Datatype sendtype,
                           t8_shmem_array_t recvarray, int recvcount,
                           sc_MPI_Datatype recvtype)
@@ -161,7 +161,7 @@ t8_shmem_array_allgather (void *sendbuf, int sendcount,
   T8_ASSERT (recvarray != NULL);
   T8_ASSERT (recvarray->array != NULL);
 
-  sc_shmem_allgather (sendbuf, sendcount, sendtype, recvarray->array,
+  sc_shmem_allgather ((void *) sendbuf, sendcount, sendtype, recvarray->array,
                       recvcount, recvtype, recvarray->comm);
 }
 
@@ -186,7 +186,7 @@ t8_shmem_array_get_elem_count (t8_shmem_array_t array)
   return array->elem_count;
 }
 
-t8_gloidx_t        *
+const t8_gloidx_t  *
 t8_shmem_array_get_gloidx_array (t8_shmem_array_t array)
 {
   T8_ASSERT (array != NULL);
@@ -217,14 +217,14 @@ t8_shmem_array_set_gloidx (t8_shmem_array_t array, int index,
   ((t8_gloidx_t *) array->array)[index] = value;
 }
 
-void *
+const void         *
 t8_shmem_array_get_array (t8_shmem_array_t array)
 {
   T8_ASSERT (array != NULL);
   return array->array;
 }
 
-void *
+const void         *
 t8_shmem_array_index (t8_shmem_array_t array, size_t index)
 {
   T8_ASSERT (array != NULL);

--- a/src/t8_data/t8_shmem.c
+++ b/src/t8_data/t8_shmem.c
@@ -103,13 +103,14 @@ t8_shmem_set_type (sc_MPI_Comm comm, sc_shmem_type_t type)
   sc_MPI_Comm         internode;
 
   sc_mpi_comm_get_node_comms (comm, &intranode, &internode);
+#if T8_ENABLE_MPI
   if (intranode == sc_MPI_COMM_NULL || internode == sc_MPI_COMM_NULL) {
     t8_global_errorf
       ("WARNING: Trying to used shared memory but intranode and internode"
        " communicators are not set."
        " You should call t8_shmem_init before setting the shmem type.\n");
   }
-
+#endif
   sc_shmem_set_type (comm, type);
 }
 
@@ -126,12 +127,14 @@ t8_shmem_array_init (t8_shmem_array_t * parray, size_t elem_size,
                   "Trying to initialize shared memory array with NULL communicator.");
 
   sc_mpi_comm_get_node_comms (comm, &intranode, &internode);
+#if T8_ENABLE_MPI
   if (intranode == sc_MPI_COMM_NULL || internode == sc_MPI_COMM_NULL) {
     t8_global_errorf
       ("WARNING: Trying to used shared memory but intranode and internode"
        " communicators are not set."
        " You should call t8_shmem_init before initializing a shared memory array.\n");
   }
+#endif
 
   T8_ASSERT (parray != NULL);
 

--- a/src/t8_data/t8_shmem.h
+++ b/src/t8_data/t8_shmem.h
@@ -58,6 +58,17 @@ T8_EXTERN_C_BEGIN ();
  */
 void                t8_shmem_init (sc_MPI_Comm comm);
 
+#if T8_ENABLE_DEBUG
+/* If you need this function outside of debugging mode, feel free
+ * to remove the macro protection. */
+/** Check whether a shared memory array was properly initialized.
+ * \param [in]          array   A shared memory array.
+ * \return non-zero if \a array is initialized correctly.
+ */
+int                 t8_shmem_array_is_initialized (const t8_shmem_array_t
+                                                   array);
+#endif
+
 /** Finalize shared memory usage for a communicator.
  *  This destroys the intra- and internode communicators.
  * \param [in]          comm    The MPI Communicator.

--- a/src/t8_data/t8_shmem.h
+++ b/src/t8_data/t8_shmem.h
@@ -46,12 +46,26 @@ typedef struct t8_shmem_array *t8_shmem_array_t;
 #define T8_SHMEM_BEST_TYPE SC_SHMEM_BASIC
 #endif
 #endif
-#if 0
-/* For testing we only use basic shmem type */
-#define T8_SHMEM_BEST_TYPE SC_SHMEM_BASIC
-#endif
 
 T8_EXTERN_C_BEGIN ();
+
+/** Initialize shared memory usage for a communicator.
+ *  This sets up the intra- and internode communicators.
+ * \param [in]          comm    The MPI Communicator.
+ * \note This function needs to be called to enable shared memory usage for a communicator.
+ * \note Calling this function multiple times with the same communicator is safe and does
+ *  not change the behaviour.
+ */
+void                t8_shmem_init (sc_MPI_Comm comm);
+
+/** Finalize shared memory usage for a communicator.
+ *  This destroys the intra- and internode communicators.
+ * \param [in]          comm    The MPI Communicator.
+ * \note This function needs to be called before t8code is finalized if \ref t8_shmem_init was called for a communicator. 
+ * \note Calling this function multiple times with the same communicator is safe and does
+ *  not change the behaviour.
+ */
+void                t8_shmem_finalize (sc_MPI_Comm comm);
 
 /** Try to set a shared memory type of a communicator.
  * If the type was set, returns true, otherwise false.

--- a/src/t8_data/t8_shmem.h
+++ b/src/t8_data/t8_shmem.h
@@ -61,7 +61,8 @@ void                t8_shmem_init (sc_MPI_Comm comm);
 /** Finalize shared memory usage for a communicator.
  *  This destroys the intra- and internode communicators.
  * \param [in]          comm    The MPI Communicator.
- * \note This function needs to be called before t8code is finalized if \ref t8_shmem_init was called for a communicator. 
+ * \note Call this function if you initialized the communicator for shared memory usage
+ *  and you are sure that you will not use it for shared memory again.
  * \note Calling this function multiple times with the same communicator is safe and does
  *  not change the behaviour.
  */

--- a/src/t8_data/t8_shmem.h
+++ b/src/t8_data/t8_shmem.h
@@ -68,15 +68,12 @@ void                t8_shmem_init (sc_MPI_Comm comm);
  */
 void                t8_shmem_finalize (sc_MPI_Comm comm);
 
-/** Try to set a shared memory type of a communicator.
- * If the type was set, returns true, otherwise false.
- * This will not set the type, if ther already was a type set
- * on this communicator. \see sc_shmem_set_type
+/** Set a shared memory type of a communicator.
+ * If the type was already set it is overwritten.
  * \param [in,out]      comm    The MPI Communicator
  * \param [in]          type    A shared memory type.
- * \return                      Non-zero if the type was set. Zero if it wasn't.
  */
-int                 t8_shmem_set_type (sc_MPI_Comm comm,
+void                t8_shmem_set_type (sc_MPI_Comm comm,
                                        sc_shmem_type_t type);
 
 /** Initialize and allocate a shared memory array structure.

--- a/src/t8_data/t8_shmem.h
+++ b/src/t8_data/t8_shmem.h
@@ -82,8 +82,7 @@ void                t8_shmem_set_type (sc_MPI_Comm comm,
  * \param [in]          elem_size The size in bytes of an array element.
  * \param [in]          elem_count The total number of elements to allocate.
  * \param [in]          comm      The MPI communicator to be associated with the shmem_array.
- *                                The shared memory type must have been set. Best practice would be
- *                                calling \ref sc_shmem_set_type (comm, T8_SHMEM_BEST_TYPE).
+ *                                If not set, the shared memory type will be set to T8_SHMEM_BEST_TYPE.
  */
 void                t8_shmem_array_init (t8_shmem_array_t * parray,
                                          size_t elem_size,

--- a/src/t8_data/t8_shmem.h
+++ b/src/t8_data/t8_shmem.h
@@ -117,7 +117,8 @@ void                t8_shmem_array_copy (t8_shmem_array_t dest,
  * \param[in] recvcount       the number of items to allgather
  * \param[in] recvtype        the type of items to allgather
  */
-void                t8_shmem_array_allgather (void *sendbuf, int sendcount,
+void                t8_shmem_array_allgather (const void *sendbuf,
+                                              int sendcount,
                                               sc_MPI_Datatype sendtype,
                                               t8_shmem_array_t recvarray,
                                               int recvcount,
@@ -146,7 +147,7 @@ size_t              t8_shmem_array_get_elem_count (t8_shmem_array_t array);
  * \param [in]          array   The t8_shmem_array
  * \return              The data of \a array as t8_gloidx_t pointer.
  */
-t8_gloidx_t        *t8_shmem_array_get_gloidx_array (t8_shmem_array_t array);
+const t8_gloidx_t  *t8_shmem_array_get_gloidx_array (t8_shmem_array_t array);
 
 /** Return an entry of a shared memory array that stores t8_gloidx_t.
  * \param [in]          array   The t8_shmem_array
@@ -160,14 +161,14 @@ t8_gloidx_t         t8_shmem_array_get_gloidx (t8_shmem_array_t array,
  * \param [in]          array The t8_shmem_array.
  * \return                    A pointer to the data array of \a array.
  */
-void               *t8_shmem_array_get_array (t8_shmem_array_t array);
+const void         *t8_shmem_array_get_array (t8_shmem_array_t array);
 
 /** Return a pointer to an element in a t8_shmem_array.
  * \param [in]          array The t8_shmem_array.
  * \param [in]          index The index of an element.
  * \return              A pointer to the element at \a index in \a array.
  */
-void               *t8_shmem_array_index (t8_shmem_array_t array,
+const void         *t8_shmem_array_index (t8_shmem_array_t array,
                                           size_t index);
 
 /* TODO: implement and comment */

--- a/src/t8_data/t8_shmem.h
+++ b/src/t8_data/t8_shmem.h
@@ -200,7 +200,7 @@ t8_gloidx_t         t8_shmem_array_get_gloidx (t8_shmem_array_t array,
  */
 const void         *t8_shmem_array_get_array (t8_shmem_array_t array);
 
-/** Return a pointer to an element in a t8_shmem_array.
+/** Return a read-only pointer to an element in a t8_shmem_array.
  * \param [in]          array The t8_shmem_array.
  * \param [in]          index The index of an element.
  * \return              A pointer to the element at \a index in \a array.
@@ -209,6 +209,16 @@ const void         *t8_shmem_array_get_array (t8_shmem_array_t array);
  */
 const void         *t8_shmem_array_index (t8_shmem_array_t array,
                                           size_t index);
+
+/** Return a pointer to an element in a t8_shmem_array in writing mode.
+ * \param [in]          array The t8_shmem_array.
+ * \param [in]          index The index of an element.
+ * \return              A pointer to the element at \a index in \a array.
+ * \note You can modify the value before the next call to \ref t8_shmem_array_end_writing.
+ * \note Writing mode must be enabled for \a array.
+ */
+void               *t8_shmem_array_index_for_writing (t8_shmem_array_t array,
+                                                      size_t index);
 
 /* TODO: implement and comment */
 /* returns true if arrays are equal 

--- a/src/t8_data/t8_shmem.h
+++ b/src/t8_data/t8_shmem.h
@@ -88,7 +88,23 @@ void                t8_shmem_array_init (t8_shmem_array_t * parray,
                                          size_t elem_size,
                                          size_t elem_count, sc_MPI_Comm comm);
 
+/** Enable writing mode for a shmem array. Only some processes may be allowed
+ *  to write into the array, which is indicated by the return value being non-zero.
+ * \param [in,out]      array Initialized array. Writing will be enabled on certain processes.
+ * \return                    True if the calling process can write into the array.
+ * \note This function is MPI collective.
+ */
+int                 t8_shmem_array_start_writing (t8_shmem_array_t array);
+
+/** Disable writing mode for a shmem array.
+ * \param [in,out]      array Initialized with writing mode enabled.
+ * \see t8_shmem_array_start_writing.
+ * \note This function is MPI collective.
+ */
+void                t8_shmem_array_end_writing (t8_shmem_array_t array);
+
 /** Set an entry of a t8_shmem array that is used to store t8_gloidx_t.
+ * The array must have writing mode enabled \ref t8_shmem_array_start_writing.
  * \param [in,out]      array   The array to be mofified.
  * \param [in]          index   The array entry to be modified.
  * \param [in]          value   The new value to be set.
@@ -97,9 +113,10 @@ void                t8_shmem_array_set_gloidx (t8_shmem_array_t array,
                                                int index, t8_gloidx_t value);
 
 /** Copy the contents of one t8_shmem array into another.
- * \param [in,out]      dest    The array in which should be copied.
+ * \param [in,out]      dest    The array in which \a source should be copied.
  * \param [in]          source  The array to copy.
- * \note \a dest must match in element size and element count to \a source.
+ * \note \a dest must be initialized and match in element size and element count to \a source.
+ * \note \a dest must have writing mode disabled.
  */
 void                t8_shmem_array_copy (t8_shmem_array_t dest,
                                          t8_shmem_array_t source);
@@ -112,6 +129,7 @@ void                t8_shmem_array_copy (t8_shmem_array_t dest,
  * \param[in,out] recvbuf     the destination shmem array
  * \param[in] recvcount       the number of items to allgather
  * \param[in] recvtype        the type of items to allgather
+ * \note Writing mode must be disabled for \a recvarray.
  */
 void                t8_shmem_array_allgather (const void *sendbuf,
                                               int sendcount,
@@ -138,17 +156,28 @@ size_t              t8_shmem_array_get_elem_size (t8_shmem_array_t array);
  */
 size_t              t8_shmem_array_get_elem_count (t8_shmem_array_t array);
 
-/** Return a pointer to the data of a shared memory array interpreted as
+/** Return a read-only pointer to the data of a shared memory array interpreted as
  * an t8_gloidx_t array.
  * \param [in]          array   The t8_shmem_array
  * \return              The data of \a array as t8_gloidx_t pointer.
+ * \note Writing mode must be disabled for \a array.
  */
 const t8_gloidx_t  *t8_shmem_array_get_gloidx_array (t8_shmem_array_t array);
+
+/** Return a pointer to the data of a shared memory array interpreted as
+ * an t8_gloidx_t array. The array must have writing enabled \ref t8_shmem_array_start_writing
+ * and you should not write into the memory after \ref t8_shmem_array_end_writing was called.
+ * \param [in]          array   The t8_shmem_array
+ * \return              The data of \a array as t8_gloidx_t pointer.
+ */
+t8_gloidx_t
+  * t8_shmem_array_get_gloidx_array_for_writing (t8_shmem_array_t array);
 
 /** Return an entry of a shared memory array that stores t8_gloidx_t.
  * \param [in]          array   The t8_shmem_array
  * \param [in]          index   The index of the entry to be queried.
  * \return              The \a index-th entry of \a array as t8_gloidx_t.
+ * \note Writing mode must be disabled for \a array.
  */
 t8_gloidx_t         t8_shmem_array_get_gloidx (t8_shmem_array_t array,
                                                int index);
@@ -156,6 +185,7 @@ t8_gloidx_t         t8_shmem_array_get_gloidx (t8_shmem_array_t array,
 /** Return a pointer to the data array of a t8_shmem_array.
  * \param [in]          array The t8_shmem_array.
  * \return                    A pointer to the data array of \a array.
+ * \note Writing mode must be disabled for \a array.
  */
 const void         *t8_shmem_array_get_array (t8_shmem_array_t array);
 
@@ -163,12 +193,16 @@ const void         *t8_shmem_array_get_array (t8_shmem_array_t array);
  * \param [in]          array The t8_shmem_array.
  * \param [in]          index The index of an element.
  * \return              A pointer to the element at \a index in \a array.
+ * \note You should not modify the value.
+ * \note Writing mode must be disabled for \a array.
  */
 const void         *t8_shmem_array_index (t8_shmem_array_t array,
                                           size_t index);
 
 /* TODO: implement and comment */
-/* returns true if arrays are equal */
+/* returns true if arrays are equal 
+ * \note Writing mode must be disabled for \a array_a and \a array_b.
+ */
 int                 t8_shmem_array_is_equal (t8_shmem_array_t array_a,
                                              t8_shmem_array_t array_b);
 

--- a/src/t8_forest/t8_forest_cxx.cxx
+++ b/src/t8_forest/t8_forest_cxx.cxx
@@ -2032,7 +2032,6 @@ t8_forest_element_check_owner (t8_forest_t forest,
 {
   t8_element_t       *first_desc;
   t8_eclass_scheme_c *ts;
-  t8_gloidx_t        *first_global_trees;
   t8_linearidx_t      rfirst_desc_id, rnext_desc_id = -1, first_desc_id;
   int                 is_first, is_last, check_next;
   int                 next_nonempty;
@@ -2043,7 +2042,8 @@ t8_forest_element_check_owner (t8_forest_t forest,
              && gtreeid < t8_forest_get_num_global_trees (forest));
 
   /* Get a pointer to the first_global_trees array of forest */
-  first_global_trees = t8_shmem_array_get_gloidx_array (forest->tree_offsets);
+  const t8_gloidx_t  *first_global_trees =
+    t8_shmem_array_get_gloidx_array (forest->tree_offsets);
 
   if (t8_offset_in_range (gtreeid, rank, first_global_trees)) {
     /* The process has elements of that tree */
@@ -2170,7 +2170,6 @@ t8_forest_element_find_owner_ext (t8_forest_t forest,
 {
   t8_element_t       *first_desc;
   t8_eclass_scheme_c *ts;
-  t8_gloidx_t        *first_trees, *element_offsets;
   t8_gloidx_t         current_first_tree;
   t8_linearidx_t      current_id, element_desc_id;
   t8_linearidx_t     *first_descs;
@@ -2207,7 +2206,8 @@ t8_forest_element_find_owner_ext (t8_forest_t forest,
   T8_ASSERT (forest->global_first_desc != NULL);
 
   /* Get pointers to the arrays of first local trees and first local descendants */
-  first_trees = t8_shmem_array_get_gloidx_array (forest->tree_offsets);
+  const t8_gloidx_t  *first_trees =
+    t8_shmem_array_get_gloidx_array (forest->tree_offsets);
   first_descs =
     (t8_linearidx_t *) t8_shmem_array_get_array (forest->global_first_desc);
   /* Compute the linear id of the element's first descendant */
@@ -2215,7 +2215,8 @@ t8_forest_element_find_owner_ext (t8_forest_t forest,
     ts->t8_element_get_linear_id (first_desc,
                                   ts->t8_element_level (first_desc));
   /* Get a pointer to the element offset array */
-  element_offsets = t8_shmem_array_get_gloidx_array (forest->element_offsets);
+  const t8_gloidx_t  *element_offsets =
+    t8_shmem_array_get_gloidx_array (forest->element_offsets);
 
   /* binary search for the owner process using the first descendant and first tree array */
   while (!found) {

--- a/src/t8_forest/t8_forest_partition.cxx
+++ b/src/t8_forest/t8_forest_partition.cxx
@@ -104,6 +104,7 @@ t8_forest_partition_create_offsets (t8_forest_t forest)
   t8_debugf ("Building offsets for forest %p\n", (void *) forest);
   comm = forest->mpicomm;
   /* Set the shmem array type of comm */
+  t8_shmem_init (comm);
   t8_shmem_set_type (comm, T8_SHMEM_BEST_TYPE);
   /* Initialize the offset array as a shmem array
    * holding mpisize+1 many t8_gloidx_t */
@@ -176,6 +177,7 @@ t8_forest_partition_create_first_desc (t8_forest_t forest)
 
   if (forest->global_first_desc == NULL) {
     /* Set the shmem array type of comm */
+    t8_shmem_init (comm);
     t8_shmem_set_type (comm, T8_SHMEM_BEST_TYPE);
     /* Initialize the offset array as a shmem array
      * holding mpisize+1 many t8_linearidx_t to store the elements linear ids */
@@ -268,6 +270,7 @@ t8_forest_partition_create_tree_offsets (t8_forest_t forest)
   /* *INDENT-ON* */
   if (forest->tree_offsets == NULL) {
     /* Set the shmem array type of comm */
+    t8_shmem_init (comm);
     t8_shmem_set_type (comm, T8_SHMEM_BEST_TYPE);
     /* Only allocate the shmem array, if it is not already allocated */
     t8_shmem_array_init (&forest->tree_offsets, sizeof (t8_gloidx_t),
@@ -337,6 +340,7 @@ t8_forest_partition_compute_new_offset (t8_forest_t forest)
 
   T8_ASSERT (forest->element_offsets == NULL);
   /* Set the shmem array type to comm */
+  t8_shmem_init (comm);
   t8_shmem_set_type (comm, T8_SHMEM_BEST_TYPE);
   /* Initialize the shmem array */
   t8_shmem_array_init (&forest->element_offsets, sizeof (t8_gloidx_t),

--- a/src/t8_geometry/t8_geometry.cxx
+++ b/src/t8_geometry/t8_geometry.cxx
@@ -196,7 +196,7 @@ void
 t8_geom_handler_register_geometry (t8_geometry_handler_t * geom_handler,
                                    const t8_geometry_c * geometry)
 {
-  t8_debugf ("Registring geometry %s\n", geometry->t8_geom_get_name ());
+  t8_debugf ("Registering geometry %s\n", geometry->t8_geom_get_name ());
   T8_ASSERT (t8_geom_handler_is_initialized (geom_handler));
   /* Must not be committed */
   T8_ASSERT (!t8_geom_handler_is_committed (geom_handler));

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -24,6 +24,7 @@ t8code_test_programs = \
 	test/t8_test_cmesh_readmshfile \
 	test/t8_test_netcdf_linkage \
 	test/t8_test_vtk_linkage \
+	test/t8_test_shmem \
 	test/t8_test_user_data
 
 test_t8_test_eclass_SOURCES = test/t8_test_eclass.c
@@ -47,6 +48,7 @@ test_t8_test_element_general_function_SOURCES = test/t8_test_element_general_fun
 test_t8_test_cmesh_readmshfile_SOURCES = test/t8_test_cmesh_readmshfile.c
 test_t8_test_netcdf_linkage_SOURCES = test/t8_test_netcdf_linkage.c
 test_t8_test_vtk_linkage_SOURCES = test/t8_test_vtk_linkage.cxx
+test_t8_test_shmem_SOURCES = test/t8_test_shmem.cxx
 test_t8_test_user_data_SOURCES = test/t8_test_user_data.cxx
 
 TESTS += $(t8code_test_programs)

--- a/test/t8_test_shmem.cxx
+++ b/test/t8_test_shmem.cxx
@@ -1,0 +1,245 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element classes in parallel.
+
+  Copyright (C) 2015 the developers
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+#include <t8_data/t8_shmem.h>
+
+static void
+t8_test_shmem_init_finalize (sc_MPI_Comm mpic)
+{
+  t8_global_productionf ("Starting shmem init test.\n");
+  sc_MPI_Comm         intranode, internode;
+  int                 intrarank, interrank;
+  int                 intrasize, intersize;
+  int                 mpiret;
+
+  /* setup shared memory usage */
+  t8_shmem_init (mpic);
+
+  /* Get intranode and internode comm */
+  sc_mpi_comm_get_node_comms (mpic, &intranode, &internode);
+
+  /* Check that they are not NULL */
+  SC_CHECK_ABORT (intranode != sc_MPI_COMM_NULL,
+                  "intra node communicator not set.");
+  SC_CHECK_ABORT (internode != sc_MPI_COMM_NULL,
+                  "inter node communicator not set.");
+
+  /* Compute ranks and size and print them */
+  mpiret = sc_MPI_Comm_size (intranode, &intrasize);
+  SC_CHECK_MPI (mpiret);
+  mpiret = sc_MPI_Comm_rank (intranode, &intrarank);
+  SC_CHECK_MPI (mpiret);
+  mpiret = sc_MPI_Comm_size (internode, &intersize);
+  SC_CHECK_MPI (mpiret);
+  mpiret = sc_MPI_Comm_rank (internode, &interrank);
+  SC_CHECK_MPI (mpiret);
+
+  t8_productionf ("On intranode comm i am rank %i of %i\n", intrarank,
+                  intrasize);
+  t8_productionf ("On internode comm i am rank %i of %i\n", interrank,
+                  intersize);
+
+  /* finalize shared mem usage */
+  t8_shmem_finalize (mpic);
+
+  /* Get intranode and internode comm */
+  sc_mpi_comm_get_node_comms (mpic, &intranode, &internode);
+  /* Check that they are NULL */
+  SC_CHECK_ABORT (intranode == sc_MPI_COMM_NULL,
+                  "intra node communicator not set.");
+  SC_CHECK_ABORT (internode == sc_MPI_COMM_NULL,
+                  "inter node communicator not set.");
+
+}
+
+static void
+t8_test_shmem_array (sc_MPI_Comm comm)
+{
+  t8_global_productionf ("Starting shmem array test.\n");
+  const int           array_length = 100;
+  const int           element_size = sizeof (int);
+  int                 mpirank, mpisize;
+  int                 mpiret;
+  sc_MPI_Comm         intranode, internode;
+
+  mpiret = sc_MPI_Comm_rank (comm, &mpirank);
+  SC_CHECK_MPI (mpiret);
+  mpiret = sc_MPI_Comm_size (comm, &mpisize);
+  SC_CHECK_MPI (mpiret);
+
+  /* Seed random number generator. */
+  srand (0);
+
+  for (int shmem_type_int = SC_SHMEM_BASIC;
+       shmem_type_int < SC_SHMEM_NUM_TYPES; ++shmem_type_int) {
+    const sc_shmem_type_t shmem_type = (sc_shmem_type_t) shmem_type_int;
+    t8_productionf ("Checking shared memory type %s.\n",
+                    sc_shmem_type_to_string[shmem_type]);
+
+    /* setup shared memory usage */
+    t8_shmem_init (comm);
+    t8_shmem_set_type (comm, shmem_type);
+
+    const sc_shmem_type_t control_shmem_type = sc_shmem_get_type (comm);
+    SC_CHECK_ABORT (shmem_type == control_shmem_type,
+                    "Setting shmem type not succesful.\n");
+
+    /* Allocate one integer */
+    t8_shmem_array_t    shmem_array;
+    t8_shmem_array_init (&shmem_array, element_size, array_length, comm);
+
+    sc_MPI_Comm         check_comm = t8_shmem_array_get_comm (shmem_array);
+    SC_CHECK_ABORT (comm == check_comm,
+                    "shared memory array has wrong communicator.\n");
+
+    const size_t        check_count =
+      t8_shmem_array_get_elem_count (shmem_array);
+    SC_CHECK_ABORT (check_count == array_length,
+                    "shared memory array has wrong element count.\n");
+
+    const size_t        check_size =
+      t8_shmem_array_get_elem_size (shmem_array);
+    SC_CHECK_ABORT (check_size == element_size,
+                    "shared memory array has wrong element size.\n");
+
+    t8_shmem_array_destroy (&shmem_array);
+
+    t8_shmem_finalize (comm);
+  }
+}
+
+static void
+t8_test_sc_shmem_alloc (sc_MPI_Comm comm)
+{
+  t8_global_productionf ("Starting shmem alloc test.\n");
+  int                 mpirank, mpisize;
+  int                 mpiret;
+  sc_MPI_Comm         intranode, internode;
+
+  mpiret = sc_MPI_Comm_rank (comm, &mpirank);
+  SC_CHECK_MPI (mpiret);
+  mpiret = sc_MPI_Comm_size (comm, &mpisize);
+  SC_CHECK_MPI (mpiret);
+
+  /* Seed random number generator. */
+  srand (0);
+
+  for (int shmem_type_int = SC_SHMEM_BASIC;
+       shmem_type_int < SC_SHMEM_NUM_TYPES; ++shmem_type_int) {
+    const sc_shmem_type_t shmem_type = (sc_shmem_type_t) shmem_type_int;
+    int                 intrasize, intrarank;
+    t8_productionf ("Checking shared memory type %s.\n",
+                    sc_shmem_type_to_string[shmem_type]);
+
+    /* setup shared memory usage */
+    t8_shmem_init (comm);
+    t8_shmem_set_type (comm, shmem_type);
+
+    const sc_shmem_type_t control_shmem_type = sc_shmem_get_type (comm);
+    SC_CHECK_ABORT (shmem_type == control_shmem_type,
+                    "Setting shmem type not succesful.\n");
+
+    sc_mpi_comm_get_node_comms (comm, &intranode, &internode);
+    SC_CHECK_ABORT (intranode != sc_MPI_COMM_NULL,
+                    "intra node communicator not set.");
+    SC_CHECK_ABORT (internode != sc_MPI_COMM_NULL,
+                    "inter node communicator not set.");
+
+    /* Get the size and rank on the shared memory region (intranode) */
+    mpiret = sc_MPI_Comm_size (intranode, &intrasize);
+    SC_CHECK_MPI (mpiret);
+    mpiret = sc_MPI_Comm_rank (intranode, &intrarank);
+    SC_CHECK_MPI (mpiret);
+
+    /* Allocate one integer */
+    int                *shared_int =
+      (int *) sc_shmem_malloc (t8_get_package_id (), sizeof (int), intrasize,
+                               comm);
+    t8_productionf ("Allocated %i integers at pos %p.\n", intrasize,
+                    (void *) shared_int);
+
+    /* Write something into the array */
+    const int           random_number = rand ();
+    if (sc_shmem_write_start (shared_int, comm)) {
+      if (
+#if defined(SC_ENABLE_MPIWINSHARED)
+           shmem_type == SC_SHMEM_WINDOW
+           || shmem_type == SC_SHMEM_WINDOW_PRESCAN ||
+#endif
+#if defined(__bgq__)
+           shmem_type == SC_SHMEM_BGQ || shmem_type == SC_SHMEM_BGQ_PRESCAN ||
+#endif
+           0                    /* If neither SC_ENABLE_MPIWINSHARED or __bgq__ are defined, we neet a condition in this if
+                                 * but do not want to execute any code. Hence, 0. */
+        ) {
+        SC_CHECK_ABORT (intrarank == 0,
+                        "Type is one of window, window_prescan, bgq or bgq_prescan and this process should not have write permissions.\n");
+      }
+      t8_productionf ("I have write permissions\n");
+      shared_int[0] = random_number;
+    }
+    sc_shmem_write_end (shared_int, comm);
+
+    SC_CHECK_ABORTF (shared_int[0] == random_number,
+                     "shared integer was not assigned correctly at position 0.");
+
+    /* Free the memory */
+    sc_shmem_free (t8_get_package_id (), shared_int, comm);
+    /* Finalize shmem usage so that we can use a different shmem type
+     * in the next loop iteration. */
+    t8_shmem_finalize (comm);
+  }
+}
+
+int
+main (int argc, char **argv)
+{
+  int                 mpiret;
+
+  mpiret = sc_MPI_Init (&argc, &argv);
+  SC_CHECK_MPI (mpiret);
+
+  sc_init (sc_MPI_COMM_WORLD, 1, 1, NULL, SC_LP_PRODUCTION);
+  p4est_init (NULL, SC_LP_ESSENTIAL);
+  t8_init (SC_LP_DEFAULT);
+
+#define T8_TEST_SHMEM_NUM_COMMS 2
+  sc_MPI_Comm         test_comms[T8_TEST_SHMEM_NUM_COMMS] =
+    { sc_MPI_COMM_WORLD, sc_MPI_COMM_SELF };
+  const char         *test_comms_names[T8_TEST_SHMEM_NUM_COMMS] =
+    { "comm world", "comm self" };
+
+  for (int icomm = 0; icomm < T8_TEST_SHMEM_NUM_COMMS; ++icomm) {
+    sc_MPI_Comm         comm = test_comms[icomm];
+    t8_productionf ("Checking communicator %s\n\n", test_comms_names[icomm]);
+    t8_test_shmem_init_finalize (comm);
+    t8_test_sc_shmem_alloc (comm);
+    t8_test_shmem_array (comm);
+  }
+
+  sc_finalize ();
+
+  mpiret = sc_MPI_Finalize ();
+  SC_CHECK_MPI (mpiret);
+
+  return 0;
+}

--- a/test/t8_test_shmem.cxx
+++ b/test/t8_test_shmem.cxx
@@ -37,11 +37,13 @@ t8_test_shmem_init_finalize (sc_MPI_Comm mpic)
   /* Get intranode and internode comm */
   sc_mpi_comm_get_node_comms (mpic, &intranode, &internode);
 
+#if T8_ENABLE_MPI
   /* Check that they are not NULL */
   SC_CHECK_ABORT (intranode != sc_MPI_COMM_NULL,
                   "intra node communicator not set.");
   SC_CHECK_ABORT (internode != sc_MPI_COMM_NULL,
                   "inter node communicator not set.");
+#endif
 
   /* Compute ranks and size and print them */
   mpiret = sc_MPI_Comm_size (intranode, &intrasize);
@@ -98,9 +100,11 @@ t8_test_shmem_array (sc_MPI_Comm comm)
     t8_shmem_init (comm);
     t8_shmem_set_type (comm, shmem_type);
 
+#if T8_ENABLE_MPI
     const sc_shmem_type_t control_shmem_type = sc_shmem_get_type (comm);
     SC_CHECK_ABORT (shmem_type == control_shmem_type,
                     "Setting shmem type not succesful.\n");
+#endif
 
     /* Allocate one integer */
     t8_shmem_array_t    shmem_array;
@@ -183,15 +187,19 @@ t8_test_sc_shmem_alloc (sc_MPI_Comm comm)
     t8_shmem_init (comm);
     t8_shmem_set_type (comm, shmem_type);
 
+#if T8_ENABLE_MPI
     const sc_shmem_type_t control_shmem_type = sc_shmem_get_type (comm);
     SC_CHECK_ABORT (shmem_type == control_shmem_type,
                     "Setting shmem type not succesful.\n");
+#endif
 
     sc_mpi_comm_get_node_comms (comm, &intranode, &internode);
+#if T8_ENABLE_MPI
     SC_CHECK_ABORT (intranode != sc_MPI_COMM_NULL,
                     "intra node communicator not set.");
     SC_CHECK_ABORT (internode != sc_MPI_COMM_NULL,
                     "inter node communicator not set.");
+#endif
 
     /* Get the size and rank on the shared memory region (intranode) */
     mpiret = sc_MPI_Comm_size (intranode, &intrasize);


### PR DESCRIPTION
MPI shared memory needs to be initialized by setting inter and intranode communicators before using.
Added new t8_shmem_init and t8_shmem_finalize functions to t8_shmem.h and used them whenever shared memory is needed (cmesh_partition).

Adding warnings when used without initializing.