### PR TITLE
fixed numeration for msh hex nodes

### DIFF
--- a/doc/author_elsweijer.txt
+++ b/doc/author_elsweijer.txt
@@ -1,0 +1,1 @@
+I place my contributions to t8code under the FreeBSD license. Sandro Elsweijer (sandro.elsweijer@gmail.com)

--- a/src/t8_cmesh/t8_cmesh_readmshfile.c
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.c
@@ -58,7 +58,7 @@ const int           t8_msh_tree_vertex_to_t8_vertex_num[T8_ECLASS_COUNT][8]
   {0, 1},                       /* LINE */
   {0, 1, 3, 2},                 /* QUAD */
   {0, 1, 2},                    /* TRIANGLE */
-  {0, 1, 5, 4, 2, 3, 7, 6},     /* HEX */
+  {0, 1, 3, 2, 4, 5, 7, 6},     /* HEX */
   {0, 1, 2, 3},                 /* TET */
   {0, 1, 2, 3, 4, 5, 6},        /* PRISM */
   {0, 1, 3, 2, 4}               /* PYRAMID */
@@ -73,7 +73,7 @@ const int           t8_vertex_to_msh_vertex_num[T8_ECLASS_COUNT][8]
   {0, 1},                       /* LINE */
   {0, 1, 3, 2},                 /* QUAD */
   {0, 1, 2},                    /* TRIANGLE */
-  {0, 1, 4, 5, 3, 2, 6, 7},     /* HEX */
+  {0, 1, 3, 2, 4, 5, 7, 6},     /* HEX */
   {0, 1, 2, 3},                 /* TET */
   {0, 1, 2, 3, 4, 5, 6},        /* PRISM */
   {0, 1, 3, 2, 4}               /* PYRAMID */


### PR DESCRIPTION
**_Describe your changes here:_**
Fixed numeration of gmsh msh hex node index to t8code hex node index


**_All these boxes must be checked by the reviewers before merging the pull request:_**

- [x] The author added a BSD statement to `doc/` (or already has one)
- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request indroduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [x] All tests pass (in various configurations, this should be executed automatically in a github action)
- [x] New source/header files are properly added to the Makefiles
- [x] The reviewer executed the new code features at least once and checked the results manually
- [x] The code is covered in an existing or new test case
- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [x] Testing of this template: If you feel something is missing from this list, contact the developers
