### PR TITLE
Fix cmesh readmshfile bug with orientation

### DIFF
--- a/src/t8_cmesh/t8_cmesh_readmshfile.c
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.c
@@ -677,8 +677,8 @@ t8_msh_file_face_orientation (t8_msh_file_face_t * Face_a,
   }
   else {
     /* both classes are the same, thus
-     * the face with the smaller tree id is the smaller one */
-    if (Face_a->ltree_id < Face_b->ltree_id) {
+     * the face with the smaller face id is the smaller one */
+    if (Face_a->face_number < Face_b->face_number) {
       smaller_Face = Face_a;
       bigger_Face = Face_b;
       bigger_class =


### PR DESCRIPTION

**_Describe your changes here:_**


For a face-to-face connection one face is declared
as the 'smaller face'. This info is used when the
orientation is computed.
For cmesh read msh file the computation of the smaller face
was wrong.
If both eclasses of the trees are the same then the 'smaller face'
is the face with smaller face_id.
Instead in readmshfile the face of the tree with smaller tree id
was used.

We fixed this behaviour.



**_All these boxes must be checked by the reviewers before merging the pull request:_**

- [x] The author added a BSD statement to `doc/` (or already has one)
- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request indroduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [x] All tests pass (in various configurations, this should be executed automatically in a github action)
- [x] New source/header files are properly added to the Makefiles
- [x] The reviewer executed the new code features at least once and checked the results manually
- [ ] The code is covered in an existing or new test case
- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [ ] Testing of this template: If you feel something is missing from this list, contact the developers
