### PR TITLE
Fixed orientation for cmesh_new_prism_geometry and enabled usage of i…

### DIFF
--- a/src/t8_cmesh/t8_cmesh_examples.c
+++ b/src/t8_cmesh/t8_cmesh_examples.c
@@ -1326,10 +1326,10 @@ t8_cmesh_new_prism_geometry (sc_MPI_Comm comm)
   for (i = 0; i < 8; i++) {
     t8_cmesh_set_tree_class (cmesh, i, T8_ECLASS_PRISM);
   }
-  t8_cmesh_set_join (cmesh, 0, 1, 2, 0, 3);
+  t8_cmesh_set_join (cmesh, 0, 1, 2, 0, 0);
   t8_cmesh_set_join (cmesh, 1, 2, 1, 2, 0);
-  t8_cmesh_set_join (cmesh, 2, 3, 4, 3, 3);
-  t8_cmesh_set_join (cmesh, 3, 4, 2, 0, 3);
+  t8_cmesh_set_join (cmesh, 2, 3, 4, 3, 1);
+  t8_cmesh_set_join (cmesh, 3, 4, 2, 0, 0);
   t8_cmesh_set_join (cmesh, 4, 5, 2, 1, 0);
   t8_cmesh_set_join (cmesh, 5, 6, 2, 1, 0);
   t8_cmesh_set_join (cmesh, 6, 7, 0, 1, 0);

--- a/src/t8_cmesh/t8_cmesh_examples.c
+++ b/src/t8_cmesh/t8_cmesh_examples.c
@@ -1326,14 +1326,14 @@ t8_cmesh_new_prism_geometry (sc_MPI_Comm comm)
   for (i = 0; i < 8; i++) {
     t8_cmesh_set_tree_class (cmesh, i, T8_ECLASS_PRISM);
   }
-  /*Ordianry join over quad-face */
+  /*Ordinary join over quad-face */
   t8_cmesh_set_join (cmesh, 0, 1, 2, 0, 0);
   /*Join over quad-face of rotated prisms, but orientation is the same */
   t8_cmesh_set_join (cmesh, 1, 2, 1, 2, 0);
   /*Join via top-triangle of prism 2 */
   t8_cmesh_set_join (cmesh, 2, 3, 4, 3, 1);
   /*Remaining joins are all via quad-faces */
-  /*prism 4 is rotated, therefore there is a differen orientation */
+  /*prism 4 is rotated, therefore there is a different orientation */
   t8_cmesh_set_join (cmesh, 3, 4, 2, 0, 1);
   /*No different orientation between these faces. */
   t8_cmesh_set_join (cmesh, 4, 5, 2, 1, 0);

--- a/src/t8_cmesh/t8_cmesh_examples.c
+++ b/src/t8_cmesh/t8_cmesh_examples.c
@@ -1326,10 +1326,16 @@ t8_cmesh_new_prism_geometry (sc_MPI_Comm comm)
   for (i = 0; i < 8; i++) {
     t8_cmesh_set_tree_class (cmesh, i, T8_ECLASS_PRISM);
   }
+  /*Ordianry join over quad-face */
   t8_cmesh_set_join (cmesh, 0, 1, 2, 0, 0);
+  /*Join over quad-face of rotated prisms, but orientation is the same */
   t8_cmesh_set_join (cmesh, 1, 2, 1, 2, 0);
+  /*Join via top-triangle of prism 2 */
   t8_cmesh_set_join (cmesh, 2, 3, 4, 3, 1);
-  t8_cmesh_set_join (cmesh, 3, 4, 2, 0, 0);
+  /*Remaining joins are all via quad-faces */
+  /*prism 4 is rotated, therefore there is a differen orientation */
+  t8_cmesh_set_join (cmesh, 3, 4, 2, 0, 1);
+  /*No different orientation between these faces. */
   t8_cmesh_set_join (cmesh, 4, 5, 2, 1, 0);
   t8_cmesh_set_join (cmesh, 5, 6, 2, 1, 0);
   t8_cmesh_set_join (cmesh, 6, 7, 0, 1, 0);

--- a/test/t8_test_forest_commit.cxx
+++ b/test/t8_test_forest_commit.cxx
@@ -50,7 +50,7 @@ t8_test_adapt_balance (t8_forest_t forest, t8_forest_t forest_from,
   int                 level;
   int                 maxlevel, child_id;
   T8_ASSERT (!is_family || (is_family && num_elements ==
-                                ts->t8_element_num_children (elements[0])));
+                            ts->t8_element_num_children (elements[0])));
 
   level = ts->t8_element_level (elements[0]);
 
@@ -170,7 +170,7 @@ test_cmesh_forest_commit_all ()
        cmesh_id++) {
     /* This if statement is necessary to make the test work by avoiding specific cmeshes which do not work yet for this test.
      * When the issues are gone, remove the if statement. */
-    if (cmesh_id != 6 && cmesh_id != 89 && (cmesh_id < 237 || cmesh_id > 256)) {
+    if (cmesh_id != 89 && (cmesh_id < 237 || cmesh_id > 256)) {
       t8_test_forest_commit (cmesh_id);
     }
   }

--- a/test/t8_test_ghost_and_owner.cxx
+++ b/test/t8_test_ghost_and_owner.cxx
@@ -159,7 +159,7 @@ test_cmesh_ghost_owner_all ()
        cmesh_id++) {
     /* This if statement is necessary to make the test work by avoiding specific cmeshes which do not work yet for this test.
      * When the issues are gone, remove the if statement. */
-    if (cmesh_id != 6 && cmesh_id != 89 && (cmesh_id < 237 || cmesh_id > 256)) {
+    if (cmesh_id != 89 && (cmesh_id < 237 || cmesh_id > 256)) {
       t8_test_ghost_owner (cmesh_id);
     }
   }

--- a/test/t8_test_ghost_exchange.cxx
+++ b/test/t8_test_ghost_exchange.cxx
@@ -220,7 +220,7 @@ test_cmesh_ghost_exchange_all ()
        cmesh_id++) {
     /* This if statement is necessary to make the test work by avoiding specific cmeshes which do not work yet for this test.
      * When the issues are gone, remove the if statement. */
-    if (cmesh_id != 6 && cmesh_id != 89 && (cmesh_id < 237 || cmesh_id > 256)) {
+    if (cmesh_id != 89 && (cmesh_id < 237 || cmesh_id > 256)) {
       t8_test_ghost_exchange (cmesh_id);
     }
   }


### PR DESCRIPTION
…t in all tests

updated the orientation of the rotated prisms in the tests.
removed the cmesh_id != 6 part in all tests that iterate over all available cmeshes.



**_All these boxes must be checked by the reviewers before merging the pull request:_**

- [x] The author added a BSD statement to `doc/` (or already has one)
- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request indroduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [x] All tests pass (in various configurations, this should be executed automatically in a github action)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The reviewer executed the new code features at least once and checked the results manually
- [x] The code is covered in an existing or new test case
- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [ ] Testing of this template: If you feel something is missing from this list, contact the developers
