### PR TITLE
Add a doxygen mainpage

### DIFF
--- a/doc/mainpage.dox
+++ b/doc/mainpage.dox
@@ -37,7 +37,7 @@
  *
  * The best place to start learning about t8code is the [Wiki](https://github.com/holke/t8code/wiki),
  * especially the [Installation Guide](https://github.com/holke/t8code/wiki/Installation) and the
- * [Tutorials](https://github.com/holke/t8code/wiki/Step-0---Hello-World).
+ * [Tutorials](https://github.com/holke/t8code/wiki/Tutorial---Overview).
  * 
  * You find the source code to t8code on [github](https://github.com/holke/t8code).
  *

--- a/doc/mainpage.dox
+++ b/doc/mainpage.dox
@@ -1,0 +1,75 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element classes in parallel.
+
+  Copyright (C) 2015 the developers
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+/** \mainpage t8code - Parallel algorithms and data structures for tree-based adaptive mesh refinement with arbitrary element shapes. 
+ *
+ * \author Johannes Holke, David Knapp, Lukas Dreyer, Niklas Böing, Sandro Elsweijer, Ioannis Lilikakis, Veli Ünlü, Carsten Burstedde et. al.
+ * \copyright GNU General Public License version 2
+ * (or, at your option, any later version)
+ * 
+ *  
+ * t8code (spoken as "tetcode") is a C/C++ library to manage parallel adaptive
+ * meshes with various element types. t8code uses a collection (a forest) of
+ * multiple connected adaptive space-trees in parallel and scales to at least
+ * one million MPI ranks and over 1 Trillion mesh elements. 
+ * 
+ * t8code is intended to be used as a thirdparty library for numerical
+ * simulation codes or any other applications that require meshes.
+ *
+ * The best place to start learning about t8code is the [Wiki](https://github.com/holke/t8code/wiki),
+ * especially the [Installation Guide](https://github.com/holke/t8code/wiki/Installation) and the
+ * [Tutorials](https://github.com/holke/t8code/wiki/Step-0---Hello-World).
+ * 
+ * You find the source code to t8code on [github](https://github.com/holke/t8code).
+ *
+ * t8code supports the following element types (also different types in the same mesh):
+ * 
+ * - 0D: vertices
+ * - 1D: lines
+ * - 2D: quadrilaterals and triangles
+ * - 3D: hexahedra, tetrahedra, prisms, and pyramids (currently in development).
+ * 
+ * Among others, t8code offers the following functionalities:
+ * 
+ * - Create distributed adaptive meshes over complex domain geometries
+ * - Adapt meshes according to user given refinement/coarsening criteria
+ * - Establish a 2:1 balance
+ * - (Re-)partition a mesh (and associated data) among MPI ranks
+ * - Manage ghost (halo) elements and data
+ * - Hierarchical search in the mesh
+ * 
+ * 
+ * t8code uses space-filling curves (SFCs) to manage the adaptive refinement and efficiently store the mesh elements and associated data.
+ * A modular approach makes it possible to exchange the underlying SFC without changing the high-level algorithms.
+ * Thus, we can use and compare different refinement schemes and users can implement their own refinement rules if so desired.
+ * 
+ * Currently, 
+ *   - lines use a 1D Morton curve with 1:2 refinement
+ *   - quadrilaterals/hexahedra are inherited from the p4est submodule, using the Morton curve 1:4, 1:8 refinement; 
+ *   - triangles/tetrahedra are implemented using the Tetrahedral Morton curve, 1:4, 1:8 refinement;
+ *   - prisms are implemented using the triangular TM curve and a line curve, 1:8 refinement.
+ *   - pyramids are implemented via a pyramidal Morton code.
+ *   - The code supports hybrid meshes including any of the above element types (of the same dimension).
+ * 
+ * You find more information on t8code in the [t8code Wiki](https://github.com/holke/t8code/wiki).
+ *
+ */


### PR DESCRIPTION
**_Describe your changes here:_**

I added a main page for the doxygen docu.

To view it compile doxygen with `make doxygen` and open the file `doxygen/html/index.html` in a browser. or navigate to `doxygen/latex`, type `make` and open the resulting `refman.pdf`.


**_All these boxes must be checked by the reviewers before merging the pull request:_**

- [x] The author added a BSD statement to `doc/` (or already has one)
- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request indroduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [x] All tests pass (in various configurations, this should be executed automatically in a github action)
- [x] New source/header files are properly added to the Makefiles
- [x] The reviewer executed the new code features at least once and checked the results manually
- [x] The code is covered in an existing or new test case
- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [x] Testing of this template: If you feel something is missing from this list, contact the developers
