### PR TITLE
Added nca-tests with different levels

### DIFF
--- a/test/t8_gtest_nca.cxx
+++ b/test/t8_gtest_nca.cxx
@@ -105,7 +105,7 @@ TEST_P(nca, nca_check_deep){
     /* num_children is not a const here, cause this can change for pyramids*/
     int             num_children;
     /* iterate over levels and children*/
-    int             lvl, check_lvl, child_id;
+    int             lvl, check_lvl_a, check_lvl_b, child_id;
     t8_element_t    *tmp;
 
     ts->t8_element_new(1, &tmp);
@@ -116,18 +116,20 @@ TEST_P(nca, nca_check_deep){
             ts->t8_element_child(tmp, child_id, correct_nca);
             /* Compute first and last descendant at every level up to elem_max_lvl. 
                 *They have the correct_nca as the nca*/
-            for(check_lvl = lvl + 1; check_lvl < elem_max_level; check_lvl++){
-                ts->t8_element_first_descendant(correct_nca, desc_a, check_lvl);
-                ts->t8_element_last_descendant(correct_nca, desc_b, check_lvl);
-                /* Compute the nca of desc_a and desc_b*/
-                ts->t8_element_nca(desc_a, desc_b, check);
-                if(eclass == T8_ECLASS_VERTEX){
-                    /* first- last-descendant logic does not hold for vertices.*/
-                    EXPECT_EQ(ts->t8_element_level(check), SC_MIN(ts->t8_element_level(desc_a), ts->t8_element_level(desc_b)));
-                }
-                else{
-                    /* Expect equality of correct_nca and check for every other class*/
-                    EXPECT_TRUE ((ts->t8_element_compare (correct_nca, check) == 0));
+            for(check_lvl_a = lvl + 1; check_lvl_a < elem_max_level; check_lvl_a++){
+                ts->t8_element_first_descendant(correct_nca, desc_a, check_lvl_a);
+                for(check_lvl_b = lvl + 1; check_lvl_b < elem_max_level; check_lvl_b++){
+                    ts->t8_element_last_descendant(correct_nca, desc_b, check_lvl_b);
+                    /* Compute the nca of desc_a and desc_b*/
+                    ts->t8_element_nca(desc_a, desc_b, check);
+                    if(eclass == T8_ECLASS_VERTEX){
+                        /* first- last-descendant logic does not hold for vertices.*/
+                        EXPECT_EQ(ts->t8_element_level(check), SC_MIN(ts->t8_element_level(desc_a), ts->t8_element_level(desc_b)));
+                    }
+                    else{
+                        /* Expect equality of correct_nca and check for every other class*/
+                        EXPECT_TRUE ((ts->t8_element_compare (correct_nca, check) == 0));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Enhanced nca_check_deep-test

iterate over two different levels (`check_lvl_a` and `check_lvl_b`) and according to them the first and last descendants are computed. 
This enhancement includes the old functionality, as both variables run up to `elem_max_level`

closes #226 

**_All these boxes must be checked by the reviewers before merging the pull request:_**

- [x] The author added a BSD statement to `doc/` (or already has one)
- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request indroduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [x] All tests pass (in various configurations, this should be executed automatically in a github action)
- [ ] New source/header files are properly added to the Makefiles
- [x] The reviewer executed the new code features at least once and checked the results manually
- [x] The code is covered in an existing or new test case
- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [ ] Testing of this template: If you feel something is missing from this list, contact the developers
