### PR TITLE
Added T8_ECLASS_INVALID

### DIFF
--- a/src/t8_eclass.c
+++ b/src/t8_eclass.c
@@ -158,3 +158,10 @@ t8_eclass_compare (t8_eclass_t eclass1, t8_eclass_t eclass2)
     }
   }
 }
+
+int
+t8_eclass_is_valid (t8_eclass_t eclass)
+{
+  /*every eclass but T8_ECLASS_INVALID is a valid class */
+  return eclass != T8_ECLASS_INVALID;
+}

--- a/src/t8_eclass.c
+++ b/src/t8_eclass.c
@@ -162,6 +162,8 @@ t8_eclass_compare (t8_eclass_t eclass1, t8_eclass_t eclass2)
 int
 t8_eclass_is_valid (t8_eclass_t eclass)
 {
-  /*every eclass but T8_ECLASS_INVALID is a valid class */
-  return eclass != T8_ECLASS_INVALID;
+  /* every eclass up to T8_ECLASS_COUNT is a valid class T8_ECLASS_COUNT 
+   * itself is invalid, every class higher than eclass count is considered 
+   * invalid.*/
+  return eclass < T8_ECLASS_COUNT;
 }

--- a/src/t8_eclass.h
+++ b/src/t8_eclass.h
@@ -56,7 +56,9 @@ typedef enum t8_eclass
   /** The pyramid has a quadrilateral as base and four triangles as sides. */
   T8_ECLASS_PYRAMID,
   /** This is no element class but can be used as the number of element classes. */
-  T8_ECLASS_COUNT
+  T8_ECLASS_COUNT,
+  /** This is no element class but can be used for the case a class of a third party library is not supported by t8code*/
+  T8_ECLASS_INVALID
 }
 t8_eclass_t;
 

--- a/src/t8_eclass.h
+++ b/src/t8_eclass.h
@@ -145,6 +145,13 @@ int                 t8_eclass_count_boundary (t8_eclass_t theclass,
 int                 t8_eclass_compare (t8_eclass_t eclass1,
                                        t8_eclass_t eclass2);
 
+/** Check, if a class is a valid class. Returns non-zero if it is a valid class,
+ *  returns zero, if the class is equal to T8_ECLASS_INVALID.
+ * 
+ * \param [in] eclass    The eclass to check.
+*/
+int                 t8_eclass_is_valid (t8_eclass_t eclass);
+
 T8_EXTERN_C_END ();
 
 #endif /* !T8_ELEMENT_H */

--- a/src/t8_eclass.h
+++ b/src/t8_eclass.h
@@ -145,7 +145,7 @@ int                 t8_eclass_count_boundary (t8_eclass_t theclass,
 int                 t8_eclass_compare (t8_eclass_t eclass1,
                                        t8_eclass_t eclass2);
 
-/** Check, if a class is a valid class. Returns non-zero if it is a valid class,
+/** Check whether a class is a valid class. Returns non-zero if it is a valid class,
  *  returns zero, if the class is equal to T8_ECLASS_INVALID.
  * 
  * \param [in] eclass    The eclass to check.

--- a/src/t8_eclass.h
+++ b/src/t8_eclass.h
@@ -149,6 +149,7 @@ int                 t8_eclass_compare (t8_eclass_t eclass1,
  *  returns zero, if the class is equal to T8_ECLASS_INVALID.
  * 
  * \param [in] eclass    The eclass to check.
+ * \return               Non-zero if \a eclass is valid, zero otherwise.
 */
 int                 t8_eclass_is_valid (t8_eclass_t eclass);
 

--- a/test/t8_gtest_eclass.cxx
+++ b/test/t8_gtest_eclass.cxx
@@ -41,10 +41,13 @@ TEST (t8_gtest_eclass, dimension)
 TEST (t8_gtest_eclass, valid_class)
 {
   int                 eclass;
-  for (eclass = T8_ECLASS_ZERO; eclass <= T8_ECLASS_COUNT; ++eclass) {
+  for (eclass = T8_ECLASS_ZERO; eclass < T8_ECLASS_COUNT; ++eclass) {
     EXPECT_TRUE (t8_eclass_is_valid ((t8_eclass_t) eclass));
   }
-  EXPECT_FALSE (t8_eclass_is_valid (T8_ECLASS_INVALID));
+  for (eclass = T8_ECLASS_COUNT; eclass <= T8_ECLASS_INVALID; ++eclass) {
+    EXPECT_FALSE (t8_eclass_is_valid ((t8_eclass_t) eclass));
+  }
+
 }
 
 TEST (t8_gtest_eclass, compare)

--- a/test/t8_gtest_eclass.cxx
+++ b/test/t8_gtest_eclass.cxx
@@ -24,31 +24,41 @@
 #include <gtest/gtest.h>
 #include <t8_eclass.h>
 
-TEST (t8_gtest_eclass, eclassCountIs8) {
+TEST (t8_gtest_eclass, eclassCountIs8)
+{
   EXPECT_EQ (T8_ECLASS_COUNT, 8);
 }
 
-TEST (t8_gtest_eclass, dimension) {
-  int eclass_dims[8] = {0, 1, 2, 2, 3, 3, 3, 3};
+TEST (t8_gtest_eclass, dimension)
+{
+  int                 eclass_dims[8] = { 0, 1, 2, 2, 3, 3, 3, 3 };
 
-  for (int eci = T8_ECLASS_ZERO;eci < T8_ECLASS_COUNT;++eci) {
+  for (int eci = T8_ECLASS_ZERO; eci < T8_ECLASS_COUNT; ++eci) {
     EXPECT_EQ (t8_eclass_to_dimension[eci], eclass_dims[eci]);
+  }
+}
+
+TEST (t8_gtest_eclass, valid_class)
+{
+  int                 eclass;
+  for (eclass = T8_ECLASS_ZERO; eclass <= T8_ECLASS_COUNT; ++eclass) {
+    EXPECT_TRUE (t8_eclass_is_valid ((t8_eclass_t) eclass));
   }
 }
 
 TEST (t8_gtest_eclass, compare)
 {
   int                 eci, ecj;
-
   for (eci = T8_ECLASS_ZERO; eci < T8_ECLASS_COUNT; ++eci) {
     for (ecj = T8_ECLASS_ZERO; ecj < T8_ECLASS_COUNT; ++ecj) {
       if (eci == ecj) {
-        EXPECT_FALSE (t8_eclass_compare ((t8_eclass_t) eci, (t8_eclass_t) ecj));
+        EXPECT_FALSE (t8_eclass_compare
+                      ((t8_eclass_t) eci, (t8_eclass_t) ecj));
       }
-      else if (t8_eclass_to_dimension[eci] == t8_eclass_to_dimension[ecj]){
-        EXPECT_TRUE (t8_eclass_compare ((t8_eclass_t) eci, (t8_eclass_t) ecj));
+      else if (t8_eclass_to_dimension[eci] == t8_eclass_to_dimension[ecj]) {
+        EXPECT_TRUE (t8_eclass_compare
+                     ((t8_eclass_t) eci, (t8_eclass_t) ecj));
       }
     }
   }
 }
-


### PR DESCRIPTION
T8_ECLASS_INVALID was added to the enumerator t8_eclass to be used for the case t8code does not support a type of element that is used by a third-party library, for example vtk. As all other eclasses already have a meaning, this new class is introduced.



**_All these boxes must be checked by the reviewers before merging the pull request:_**

- [x] The author added a BSD statement to `doc/` (or already has one)
- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request indroduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [x] All tests pass (in various configurations, this should be executed automatically in a github action)
- [x] New source/header files are properly added to the Makefiles
- [x] The reviewer executed the new code features at least once and checked the results manually
- [x] The code is covered in an existing or new test case
- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [ ] Testing of this template: If you feel something is missing from this list, contact the developers
