### PR TITLE
Fix indent script paths

### DIFF
--- a/scripts/t8indent
+++ b/scripts/t8indent
@@ -56,8 +56,23 @@ INDENT_BASE_OPTIONS="-bap -bli0 -br -nut -psl -sob -di20"
 #   static t8_cmesh_t
 #   afunction (int aparameter) {
 
+# Get the path of the file t8indent_custom_datatypes.txt in the
+# /scripts subfolder of the repo.
+
+repo_main_dir=`git rev-parse --show-toplevel`
+additional_data_types_file="${repo_main_dir}/scripts/t8indent_custom_datatypes.txt"
+
+echo $additional_data_types_file
+
+if [ ! -f $additional_data_types_file ]
+then
+  echo Error: File $additional_data_types_file does not exist. >&2
+  echo Exiting because of error.
+  exit 1
+fi
+
 T8CODE_ADDITIONAL_DATATYPES=
-for x in `cat scripts/t8indent_custom_datatypes.txt`
+for x in `cat ${additional_data_types_file}`
 do
   T8CODE_ADDITIONAL_DATATYPES="$T8CODE_ADDITIONAL_DATATYPES -T $x"
 done

--- a/scripts/t8indent
+++ b/scripts/t8indent
@@ -62,7 +62,6 @@ INDENT_BASE_OPTIONS="-bap -bli0 -br -nut -psl -sob -di20"
 repo_main_dir=`git rev-parse --show-toplevel`
 additional_data_types_file="${repo_main_dir}/scripts/t8indent_custom_datatypes.txt"
 
-echo $additional_data_types_file
 
 if [ ! -f $additional_data_types_file ]
 then


### PR DESCRIPTION
**_Describe your changes here:_**

The path of the file with additional data types that is used by t8indent was a relative path in the t8indent script.
This made the other scripts in /scripts that use indent not work, since they are required to be called from within /scripts, but then t8indent did not find the path.

We fixed this by using the absolute path, querying git for the repos path.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

- [x] The author added a BSD statement to `doc/` (or already has one)
- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request indroduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [x] All tests pass (in various configurations, this should be executed automatically in a github action)
- [x] New source/header files are properly added to the Makefiles
- [x] The reviewer executed the new code features at least once and checked the results manually
- [x] The code is covered in an existing or new test case
- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [x] Testing of this template: If you feel something is missing from this list, contact the developers
