### PR TITLE
Add a function that returns the t8code version string

### DIFF
--- a/src/t8.c
+++ b/src/t8.c
@@ -149,7 +149,7 @@ t8_init (int log_threshold)
                                        "t8", "Adaptive discretizations");
 
   w = 24;
-  t8_global_essentialf ("This is %s\n", T8_PACKAGE_STRING);
+  t8_global_essentialf ("This is %s\n", t8_get_version_string ());
   t8_global_productionf ("%-*s %s\n", w, "CPP", T8_CPP);
   t8_global_productionf ("%-*s %s\n", w, "CPPFLAGS", T8_CPPFLAGS);
   t8_global_productionf ("%-*s %s\n", w, "CC", T8_CC);
@@ -172,4 +172,10 @@ t8_sc_array_index_locidx (sc_array_t *array, t8_locidx_t it)
   P4EST_ASSERT (it >= 0 && (size_t) it < array->elem_count);
 
   return array->array + array->elem_size * (size_t) it;
+}
+
+const char         *
+t8_get_version_string ()
+{
+  return T8_PACKAGE_STRING;
 }

--- a/src/t8.h
+++ b/src/t8.h
@@ -243,6 +243,11 @@ void                t8_errorf (const char *fmt, ...)
  */
 void                t8_init (int log_threshold);
 
+/** Return the version number of t8code as a string.
+ * \return The version number of t8code as a string.
+ */
+const char         *t8_get_version_string ();
+
 /** Return a pointer to an array element indexed by a t8_topidx_t.
  * \param [in] index needs to be in [0]..[elem_count-1].
  * \return           A void * pointing to entry \a it in \a array.

--- a/src/t8_cmesh/t8_cmesh_save.c
+++ b/src/t8_cmesh/t8_cmesh_save.c
@@ -411,8 +411,8 @@ t8_cmesh_save_header (t8_cmesh_t cmesh, FILE *fp)
 
   T8_ASSERT (fp != NULL);
   ret =
-    fprintf (fp, "This is %s, file format version %u.\n\n", T8_PACKAGE_STRING,
-             T8_CMESH_FORMAT);
+    fprintf (fp, "This is %s, file format version %u.\n\n",
+             t8_get_version_string (), T8_CMESH_FORMAT);
   T8_SAVE_CHECK_CLOSE (ret > 0, fp);
 
   /* Write 0 for replicated and 1 for partitioned cmesh */


### PR DESCRIPTION
**_Describe your changes here:_**

Add a function that returns the t8code version string and use it everywhere where the version string was used before.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

- [ ] The author added a BSD statement to `doc/` (or already has one)
- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request indroduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The reviewer executed the new code features at least once and checked the results manually
- [ ] The code is covered in an existing or new test case
- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [ ] Testing of this template: If you feel something is missing from this list, contact the developers
