### PR TITLE
removed unnecessary forest movement

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@ Contributors:
   Lukas Dreyer <lukas.dreyer@dlr.de>
   Niklas Boeing <niklas.boeing@gmx.de>
   Veli Uenlue <veli_unlu@gmx.de>
+  Sandro Elsweijer <sandro.elsweijer@gmail.com>

--- a/example/timings/time_forest_partition.cxx
+++ b/example/timings/time_forest_partition.cxx
@@ -394,7 +394,7 @@ main (int argc, char *argv[])
                          "The maximum x coordinate " "in the mesh.");
   sc_options_add_double (opt, 'T', "time", &T, 1,
                          "The simulated time span."
-                         "We simulate the time from 0 to T");
+                         "We simulate the time from 0 to T. T has to be > 0.");
   sc_options_add_double (opt, 'D', "delta_t", &delta_t, 0.08,
                          "The time step in each simulation step. "
                          "Deprecated, use -C instead.");
@@ -414,7 +414,7 @@ main (int argc, char *argv[])
   if (first_argc < 0 || first_argc != argc || dim < 2 || dim > 3
       || (cmeshfileprefix == NULL && mshfileprefix == NULL
           && test_tet == 0) || stride <= 0
-      || (num_files - 1) * stride >= mpisize || cfl < 0) {
+      || (num_files - 1) * stride >= mpisize || cfl < 0 || T <= 0) {
     sc_options_print_usage (t8_get_package_id (), SC_LP_ERROR, opt, NULL);
     return 1;
   }

--- a/example/timings/time_forest_partition.cxx
+++ b/example/timings/time_forest_partition.cxx
@@ -249,6 +249,8 @@ t8_time_forest_cmesh_mshfile (t8_cmesh_t cmesh, const char *vtu_prefix,
         }
       }
       t8_forest_commit (forest_partition);
+      /* Set forest to the partitioned forest, so it gets adapted
+       * in the next time step. */
       forest = forest_partition;
     }
 
@@ -268,9 +270,6 @@ t8_time_forest_cmesh_mshfile (t8_cmesh_t cmesh, const char *vtu_prefix,
       t8_cmesh_print_profile (t8_forest_get_cmesh (forest_partition));
     }
     t8_forest_print_profile (forest_partition);
-    /* Set forest to the partitioned forest, so it gets adapted
-     * in the next time step. */
-    forest = forest_partition;
     /* TIME-LOOP ends here */
   }
   /* memory clean-up */


### PR DESCRIPTION
**_Describe your changes here:_**
The forest was copied two times in `time_forest_partition.cxx`



**_All these boxes must be checked by the reviewers before merging the pull request:_**

- [x] The author added a BSD statement to `doc/` (or already has one)
- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request indroduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [x] All tests pass (in various configurations, this should be executed automatically in a github action)
- [ ] New source/header files are properly added to the Makefiles
- [x] The reviewer executed the new code features at least once and checked the results manually
- [ ] The code is covered in an existing or new test case
- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [ ] Testing of this template: If you feel something is missing from this list, contact the developers
