### PR TITLE
Fix t8 forest set adapt docstring

### DIFF
--- a/src/t8_forest.h
+++ b/src/t8_forest.h
@@ -227,8 +227,8 @@ void                t8_forest_set_copy (t8_forest_t forest,
                                         const t8_forest_t from);
 
 /** Set a source forest with an adapt function to be adapted on commiting.
- * By default, the forest takes ownership of the source \b set_from such that it will
- * be destroyed on calling \ref t8_forest_commit. To keep ownership of \b
+ * By default, the forest takes ownership of the source \b set_from such that it
+ * will be destroyed on calling \ref t8_forest_commit. To keep ownership of \b
  * set_from, call \ref t8_forest_ref before passing it into this function.
  * This means that it is ILLEGAL to continue using \b set_from or dereferencing it
  * UNLESS it is referenced directly before passing it into this function.

--- a/src/t8_forest.h
+++ b/src/t8_forest.h
@@ -239,7 +239,6 @@ void                t8_forest_set_copy (t8_forest_t forest,
  *                          If NULL, a previously (or later) set forest will
  *                          be taken (\ref t8_forest_set_partition, \ref t8_forest_set_balance).
  * \param [in] adapt_fn     The adapt function used on commiting.
- * \param [in] replace_fn   The replace function to be used in \b adapt_fn.
  * \param [in] recursive    A flag specifying whether adaptation is to be done recursively
  *                          or not. If the value is zero, adaptation is not recursive
  *                          and it is recursive otherwise.


### PR DESCRIPTION
**_Describe your changes here:_**
Removed a no longer implemented argument from the docstring.


**_All these boxes must be checked by the reviewers before merging the pull request:_**

- [x] The author added a BSD statement to `doc/` (or already has one)
- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request indroduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [x] All tests pass (in various configurations, this should be executed automatically in a github action)
- [ ] New source/header files are properly added to the Makefiles
- [x] The reviewer executed the new code features at least once and checked the results manually
- [ ] The code is covered in an existing or new test case
- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [ ] Testing of this template: If you feel something is missing from this list, contact the developers
