### PR TITLE
reworked vtk user functions

### DIFF
--- a/src/t8_forest.h
+++ b/src/t8_forest.h
@@ -829,6 +829,12 @@ void                t8_forest_save (t8_forest_t forest);
  * Writes one master .pvtu file and each process writes in its own .vtu file.
  * If linked and not otherwise specified, the VTK API is used.
  * If the VTK library is not linked, an ASCII file is written.
+ * This may change in accordance with \a write_ghosts, \a curved_flag and 
+ * \a do_not_use_API, because the export of ghosts is not yet available with 
+ * the VTK API and the export of curved elements is not available with the
+ * inbuild function to write ASCII files. The function will for example
+ * still use the VTK API to satisfy \a curved_flag, even if \a do_not_use_API 
+ * is set to true.
  * Forest must be committed when calling this function.
  * This function is collective and must be called on each process.
  * \param [in]      forest              The forest to write.

--- a/src/t8_forest.h
+++ b/src/t8_forest.h
@@ -832,7 +832,7 @@ void                t8_forest_save (t8_forest_t forest);
  * This may change in accordance with \a write_ghosts, \a write_curved and 
  * \a do_not_use_API, because the export of ghosts is not yet available with 
  * the VTK API and the export of curved elements is not available with the
- * inbuild function to write ASCII files. The function will for example
+ * inbuilt function to write ASCII files. The function will for example
  * still use the VTK API to satisfy \a write_curved, even if \a do_not_use_API 
  * is set to true.
  * Forest must be committed when calling this function.

--- a/src/t8_forest.h
+++ b/src/t8_forest.h
@@ -829,11 +829,11 @@ void                t8_forest_save (t8_forest_t forest);
  * Writes one master .pvtu file and each process writes in its own .vtu file.
  * If linked and not otherwise specified, the VTK API is used.
  * If the VTK library is not linked, an ASCII file is written.
- * This may change in accordance with \a write_ghosts, \a curved_flag and 
+ * This may change in accordance with \a write_ghosts, \a write_curved and 
  * \a do_not_use_API, because the export of ghosts is not yet available with 
  * the VTK API and the export of curved elements is not available with the
  * inbuild function to write ASCII files. The function will for example
- * still use the VTK API to satisfy \a curved_flag, even if \a do_not_use_API 
+ * still use the VTK API to satisfy \a write_curved, even if \a do_not_use_API 
  * is set to true.
  * Forest must be committed when calling this function.
  * This function is collective and must be called on each process.
@@ -848,7 +848,7 @@ void                t8_forest_save (t8_forest_t forest);
  * \param [in]      write_element_id    If true, the global element id is written for each element.
  * \param [in]      write_ghosts        If true, each process additionally writes its ghost elements.
  *                                      For ghost element the treeid is -1.
- * \param [in]      curved_flag         If true, write the elements as curved element types from vtk.
+ * \param [in]      write_curved        If true, write the elements as curved element types from vtk.
  * \param [in]      do_not_use_API      Do not use the VTK API, even if linked and available.
  * \param [in]      num_data            Number of user defined double valued data fields to write.
  * \param [in]      data                Array of t8_vtk_data_field_t of length \a num_data
@@ -865,7 +865,7 @@ int                 t8_forest_write_vtk_ext (t8_forest_t forest,
                                              int write_level,
                                              int write_element_id,
                                              int write_ghosts,
-                                             int curved_flag,
+                                             int write_curved,
                                              int do_not_use_API,
                                              int num_data,
                                              t8_vtk_data_field_t *data);

--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -1350,6 +1350,7 @@ t8_forest_write_vtk_ext (t8_forest_t forest,
   }
   do_not_use_API = 1;
 #endif
+  T8_ASSERT (!write_ghost);
   if (!do_not_use_API) {
     return t8_forest_vtk_write_file_via_API (forest,
                                              fileprefix,
@@ -1360,6 +1361,7 @@ t8_forest_write_vtk_ext (t8_forest_t forest,
                                              write_curved, num_data, data);
   }
   else {
+    T8_ASSERT (!write_curved);
     return t8_forest_vtk_write_file (forest,
                                      fileprefix,
                                      write_treeid,

--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -1325,8 +1325,9 @@ t8_forest_write_vtk_ext (t8_forest_t forest,
 #if T8_WITH_VTK
   if (!do_not_use_API) {
     if (write_ghosts) {
-      t8_errorf ("WARNING: Export of ghosts not yet available with the vtk API. "
-                 "Using the inbuild function instead.\n");
+      t8_errorf
+        ("WARNING: Export of ghosts not yet available with the vtk API. "
+         "Using the inbuild function instead.\n");
       do_not_use_API = 1;
     }
   }

--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -1300,7 +1300,7 @@ t8_forest_write_vtk_ext (t8_forest_t forest,
                          int write_level,
                          int write_element_id,
                          int write_ghosts,
-                         int curved_flag,
+                         int write_curved,
                          int do_not_use_API,
                          int num_data, t8_vtk_data_field_t *data)
 {
@@ -1308,12 +1308,12 @@ t8_forest_write_vtk_ext (t8_forest_t forest,
   T8_ASSERT (forest->rc.refcount > 0);
   T8_ASSERT (forest->committed);
 
-  if (write_ghosts && curved_flag) {
+  if (write_ghosts && write_curved) {
     t8_errorf
       ("Cannot export ghosts and curved elements at the same time. "
        "Please specify only one option.\n" "Did not write anything.\n");
 #if !T8_WITH_VTK
-    if (curved_flag) {
+    if (write_curved) {
       t8_errorf
         ("t8code is not linked against VTK. "
          "Therefore, the export of curved elements is not possible anyway.\n");
@@ -1331,7 +1331,7 @@ t8_forest_write_vtk_ext (t8_forest_t forest,
     }
   }
   else {
-    if (curved_flag) {
+    if (write_curved) {
       t8_errorf
         ("Export of curved elements not yet available with the inbuild function. "
          "Using the VTK API instead.\n");
@@ -1342,7 +1342,7 @@ t8_forest_write_vtk_ext (t8_forest_t forest,
   /* We are not linked against the VTK library, so
    * we do not use the API by default.
    */
-  if (curved_flag) {
+  if (write_curved) {
     t8_errorf
       ("Export of curved elements not yet available with the inbuild function. "
        "Please link to VTK.\n"
@@ -1357,7 +1357,7 @@ t8_forest_write_vtk_ext (t8_forest_t forest,
                                              write_mpirank,
                                              write_level,
                                              write_element_id,
-                                             curved_flag, num_data, data);
+                                             write_curved, num_data, data);
   }
   else {
     return t8_forest_vtk_write_file (forest,

--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -1310,12 +1310,12 @@ t8_forest_write_vtk_ext (t8_forest_t forest,
 
   if (write_ghosts && write_curved) {
     t8_errorf
-      ("Cannot export ghosts and curved elements at the same time. "
+      ("ERROR: Cannot export ghosts and curved elements at the same time. "
        "Please specify only one option.\n" "Did not write anything.\n");
 #if !T8_WITH_VTK
     if (write_curved) {
       t8_errorf
-        ("t8code is not linked against VTK. "
+        ("WARNING: t8code is not linked against VTK. "
          "Therefore, the export of curved elements is not possible anyway.\n");
     }
 #endif
@@ -1325,7 +1325,7 @@ t8_forest_write_vtk_ext (t8_forest_t forest,
 #if T8_WITH_VTK
   if (!do_not_use_API) {
     if (write_ghosts) {
-      t8_errorf ("Export of ghosts not yet available with the vtk API. "
+      t8_errorf ("WARNING: Export of ghosts not yet available with the vtk API. "
                  "Using the inbuild function instead.\n");
       do_not_use_API = 1;
     }
@@ -1333,7 +1333,7 @@ t8_forest_write_vtk_ext (t8_forest_t forest,
   else {
     if (write_curved) {
       t8_errorf
-        ("Export of curved elements not yet available with the inbuild function. "
+        ("WARNING: Export of curved elements not yet available with the inbuild function. "
          "Using the VTK API instead.\n");
       do_not_use_API = 0;
     }
@@ -1344,7 +1344,7 @@ t8_forest_write_vtk_ext (t8_forest_t forest,
    */
   if (write_curved) {
     t8_errorf
-      ("Export of curved elements not yet available with the inbuild function. "
+      ("WARNING: Export of curved elements not yet available with the inbuild function. "
        "Please link to VTK.\n"
        "Using the inbuild function to write out uncurved elements instead.\n");
   }

--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -1351,7 +1351,7 @@ t8_forest_write_vtk_ext (t8_forest_t forest,
   }
   do_not_use_API = 1;
 #endif
-  T8_ASSERT (!write_ghost);
+  T8_ASSERT (!write_ghosts);
   if (!do_not_use_API) {
     return t8_forest_vtk_write_file_via_API (forest,
                                              fileprefix,

--- a/src/t8_forest/t8_forest.c
+++ b/src/t8_forest/t8_forest.c
@@ -1308,49 +1308,66 @@ t8_forest_write_vtk_ext (t8_forest_t forest,
   T8_ASSERT (forest->rc.refcount > 0);
   T8_ASSERT (forest->committed);
 
+  if (write_ghosts && curved_flag) {
+    t8_errorf
+      ("Cannot export ghosts and curved elements at the same time. "
+       "Please specify only one option.\n" "Did not write anything.\n");
+#if !T8_WITH_VTK
+    if (curved_flag) {
+      t8_errorf
+        ("t8code is not linked against VTK. "
+         "Therefore, the export of curved elements is not possible anyway.\n");
+    }
+#endif
+    return 0;
+  }
+
 #if T8_WITH_VTK
   if (!do_not_use_API) {
     if (write_ghosts) {
       t8_errorf ("Export of ghosts not yet available with the vtk API. "
-                 "Please use the inbuild function instead.\n"
-                 "Did not write any vtk output.\n");
-      return 0;
+                 "Using the inbuild function instead.\n");
+      do_not_use_API = 1;
     }
-    else {
-      return t8_forest_vtk_write_file_via_API (forest,
-                                               fileprefix,
-                                               write_treeid,
-                                               write_mpirank,
-                                               write_level,
-                                               write_element_id,
-                                               curved_flag, num_data, data);
+  }
+  else {
+    if (curved_flag) {
+      t8_errorf
+        ("Export of curved elements not yet available with the inbuild function. "
+         "Using the VTK API instead.\n");
+      do_not_use_API = 0;
     }
   }
 #else
   /* We are not linked against the VTK library, so
    * we do not use the API by default.
    */
+  if (curved_flag) {
+    t8_errorf
+      ("Export of curved elements not yet available with the inbuild function. "
+       "Please link to VTK.\n"
+       "Using the inbuild function to write out uncurved elements instead.\n");
+  }
   do_not_use_API = 1;
 #endif
-  if (do_not_use_API) {
-    if (curved_flag) {
-      t8_errorf
-        ("Export of curved elements not yet available with the inbuild function. "
-         "Please use the vtk API instead.\n"
-         "Did not write any vtk output.\n");
-      return 0;
-    }
-    else {
-      return t8_forest_vtk_write_file (forest,
-                                       fileprefix,
-                                       write_treeid,
-                                       write_mpirank,
-                                       write_level,
-                                       write_element_id,
-                                       write_ghosts, num_data, data);
-    }
+  if (!do_not_use_API) {
+    return t8_forest_vtk_write_file_via_API (forest,
+                                             fileprefix,
+                                             write_treeid,
+                                             write_mpirank,
+                                             write_level,
+                                             write_element_id,
+                                             curved_flag, num_data, data);
   }
-  return 0;
+  else {
+    return t8_forest_vtk_write_file (forest,
+                                     fileprefix,
+                                     write_treeid,
+                                     write_mpirank,
+                                     write_level,
+                                     write_element_id,
+                                     write_ghosts, num_data, data);
+  }
 }
 
 int


### PR DESCRIPTION
**_Describe your changes here:_**
Reworked the vtk functions to achieve this behavior:

| linked to vtk  | 1           | 1                           | 1           | 1                | 1                         | 1                     | 1               | 1                         |
|----------------|-------------|-----------------------------|-------------|------------------|---------------------------|-----------------------|-----------------|---------------------------|
| write_ghosts   | 0           | 1                           | 0           | 0                | 1                         | 0                     | 1               | 1                         |
| write_curved   | 0           | 0                           | 1           | 0                | 1                         | 1                     | 0               | 1                         |
| do_not_use_API | 0           | 0                           | 0           | 1                | 0                         | 1                     | 1               | 1                         |
| result         | uses<br>api | warns, <br>uses <br>inbuild | uses<br>api | uses <br>inbuilt | error,<br>can't<br>decide | warns,<br>uses<br>api | uses<br>inbuilt | error,<br>can't<br>decide |

| linked to vtk  | 0               | 0               | 0                         | 0                | 0                         | 0                     | 0               | 0                         |
|----------------|-----------------|-----------------|---------------------------|------------------|---------------------------|-----------------------|-----------------|---------------------------|
| write_ghosts   | 0               | 1               | 0                         | 0                | 1                         | 0                     | 1               | 1                         |
| write_curved   | 0               | 0               | 1                         | 0                | 1                         | 1                     | 0               | 1                         |
| do_not_use_API | 0               | 0               | 0                         | 1                | 0                         | 1                     | 1               | 1                         |
| result         | uses<br>inbuilt | uses<br>inbuilt | warns,<br>uses<br>inbuilt | uses <br>inbuilt | error,<br>can't<br>decide | warns,<br>uses<br>api | uses<br>inbuilt | error,<br>can't<br>decide |


**_All these boxes must be checked by the reviewers before merging the pull request:_**

- [x] The author added a BSD statement to `doc/` (or already has one)
- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request indroduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)
- [x] New source/header files are properly added to the Makefiles
- [ ] The reviewer executed the new code features at least once and checked the results manually
- [ ] The code is covered in an existing or new test case
- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [ ] Testing of this template: If you feel something is missing from this list, contact the developers
