### PR TITLE
Fix compiler warnings with newer gcc versions

### DIFF
--- a/src/t8_cmesh/t8_cmesh_stash.h
+++ b/src/t8_cmesh/t8_cmesh_stash.h
@@ -222,7 +222,7 @@ void                t8_stash_attribute_sort (t8_stash_t stash);
  *                  elements in the classes, joinfaces and attributes arrays.
  */
 t8_stash_t          t8_stash_bcast (t8_stash_t stash, int root,
-                                    sc_MPI_Comm comm, size_t elem_counts[]);
+                                    sc_MPI_Comm comm, size_t elem_counts[3]);
 
 /* TODO: specify equivalence relation. is a different order of data allowed? */
 /** Check two stashes for equal content and return true if so.

--- a/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.h
@@ -133,7 +133,7 @@ int                 t8_dline_child_id (const t8_dline_t *t);
  *                    t may point to the same quadrant as c[0].
  */
 void                t8_dline_childrenpv (const t8_dline_t *t,
-                                         t8_dline_t *c[]);
+                                         t8_dline_t *c[T8_DLINE_CHILDREN]);
 
 /** Check whether a collection of two lines is a family in Morton order.
  * \param [in]     f  An array of two lines.

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.h
@@ -296,12 +296,12 @@ void                t8_dprism_corner_descendant (const t8_dprism_t *p,
 
 /** Compute the coordinates of a vertex of a prism.
  * \param [in] p    Input prism.
- * \param [out] coordinates An array of 2 t8_dprism_coord_t that
- * 		     will be filled with the coordinates of the vertex.
  * \param [in] vertex The number of the vertex.
+ * \param [out] coordinates An array of 3 t8_dprism_coord_t that
+ * 		     will be filled with the coordinates of the vertex.
  */
 void                t8_dprism_vertex_coords (const t8_dprism_t *p,
-                                             int vertex, int coords[]);
+                                             int vertex, int coords[3]);
 
 /** Compute the reference coordinates of a vertex of a prism when the 
  * tree (level 0 prism) is embedded in [0,1]^3.

--- a/src/t8_schemes/t8_default/t8_default_tet/t8_dtet_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_tet/t8_dtet_bits.h
@@ -112,7 +112,8 @@ void                t8_dtet_child (const t8_dtet_t *elem,
  * \param [in,out] c  Pointers to the 8 computed children in Morton order.
  *                    t may point to the same quadrant as c[0].
  */
-void                t8_dtet_childrenpv (const t8_dtet_t *t, t8_dtet_t *c[]);
+void                t8_dtet_childrenpv (const t8_dtet_t *t,
+                                        t8_dtet_t *c[T8_DTET_CHILDREN]);
 
 /** Check whether a collection of eight tetrahedra is a family in Morton order.
  * \param [in]     f  An array of eight tetrahedra.

--- a/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.h
@@ -108,7 +108,8 @@ void                t8_dtri_child (const t8_dtri_t *t,
  * \param [in,out] c  Pointers to the 4 computed children in Morton order.
  *                    t may point to the same quadrant as c[0].
  */
-void                t8_dtri_childrenpv (const t8_dtri_t *t, t8_dtri_t *c[]);
+void                t8_dtri_childrenpv (const t8_dtri_t *t,
+                                        t8_dtri_t *c[T8_DTRI_CHILDREN]);
 
 /** Check whether a collection of eight triangles is a family in Morton order.
  * \param [in]     f  An array of eight triangles.

--- a/src/t8_schemes/t8_default/t8_default_vertex/t8_dvertex_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_vertex/t8_dvertex_bits.h
@@ -109,7 +109,8 @@ void                t8_dvertex_sibling (const t8_dvertex_t *v, int sibid,
  *                    t may point to the same quadrant as c[0].
  */
 void                t8_dvertex_childrenpv (const t8_dvertex_t *t,
-                                           t8_dvertex_t *c[]);
+                                           t8_dvertex_t
+                                           *c[T8_DVERTEX_CHILDREN]);
 
 /** Check whether a collection of two vertexs is a family in Morton order.
  * \param [in]     f  An array of two vertexs.


### PR DESCRIPTION
**_Describe your changes here:_**

Fixes compiler warnings that occur with gcc version 11.2.0.
This is the code part from previous PR #257 that we closed without merging.


**_All these boxes must be checked by the reviewers before merging the pull request:_**

- [x] The author added a BSD statement to `doc/` (or already has one)
- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request indroduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)
- [x] New source/header files are properly added to the Makefiles
- [ ] The reviewer executed the new code features at least once and checked the results manually
- [x] The code is covered in an existing or new test case
- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [ ] Testing of this template: If you feel something is missing from this list, contact the developers
