### PR TITLE
Cleanup and remove redundancies for the default 'quad' and 'hex' schemes.

### DIFF
--- a/example/ExtremeScaling/bunny.cxx
+++ b/example/ExtremeScaling/bunny.cxx
@@ -21,6 +21,7 @@
 */
 
 #include <sc_options.h>
+#include <p4est.h>
 #include <t8.h>
 #include <t8_cmesh.h>
 #include <t8_cmesh_tetgen.h>

--- a/example/ghost/t8_test_ghost_large_level_diff.cxx
+++ b/example/ghost/t8_test_ghost_large_level_diff.cxx
@@ -33,6 +33,7 @@
  * (This property is not tested).
  */
 
+#include <p4est.h>
 #include <sc_flops.h>
 #include <sc_statistics.h>
 #include <sc_options.h>

--- a/example/gmsh/t8_load_and_refine_square_w_hole.cxx
+++ b/example/gmsh/t8_load_and_refine_square_w_hole.cxx
@@ -26,6 +26,7 @@
  */
 
 #include <sc_refcount.h>
+#include <p4est.h>
 #include <t8_cmesh.h>
 #include <t8_cmesh_vtk.h>
 #include <t8_cmesh/t8_cmesh_partition.h>
@@ -196,7 +197,7 @@ main (int argc, char *argv[])
   t8_init (SC_LP_DEBUG);
 
   cmesh =
-    t8_load_refine_load_cmesh ("../share/data/circlesquare_hybrid_hole",
+    t8_load_refine_load_cmesh ("circlesquare_hybrid_hole",
                                sc_MPI_COMM_WORLD, 2);
   t8_load_refine_build_forest (cmesh, sc_MPI_COMM_WORLD, 1);
 

--- a/example/gmsh/t8_read_msh_file.cxx
+++ b/example/gmsh/t8_read_msh_file.cxx
@@ -21,6 +21,7 @@
 */
 
 #include <sc_options.h>
+#include <p4est.h>
 #include <t8.h>
 #include <t8_cmesh.h>
 #include <t8_cmesh/t8_cmesh_partition.h>

--- a/example/tetgen/t8_forest_from_tetgen.cxx
+++ b/example/tetgen/t8_forest_from_tetgen.cxx
@@ -21,6 +21,7 @@
 */
 
 #include <sc_options.h>
+#include <p4est.h>
 #include <t8.h>
 #include <t8_cmesh.h>
 #include <t8_cmesh/t8_cmesh_partition.h>

--- a/example/tetgen/t8_read_tetgen_file.c
+++ b/example/tetgen/t8_read_tetgen_file.c
@@ -21,6 +21,7 @@
 */
 
 #include <sc_options.h>
+#include <p4est.h>
 #include <t8.h>
 #include <t8_cmesh.h>
 #include <t8_cmesh/t8_cmesh_partition.h>

--- a/example/tetgen/t8_time_tetgen_file.c
+++ b/example/tetgen/t8_time_tetgen_file.c
@@ -21,6 +21,7 @@
 */
 
 #include <sc_options.h>
+#include <p4est.h>
 #include <t8.h>
 #include <t8_cmesh.h>
 #include <t8_cmesh_tetgen.h>

--- a/example/timings/time_forest_partition.cxx
+++ b/example/timings/time_forest_partition.cxx
@@ -24,6 +24,7 @@
 #include <sc_flops.h>
 #include <sc_statistics.h>
 #include <sc_options.h>
+#include <p4est.h>
 #include <p4est_connectivity.h>
 #include <t8_cmesh.h>
 #include <t8_cmesh/t8_cmesh_examples.h>

--- a/example/timings/time_new_refine.c
+++ b/example/timings/time_new_refine.c
@@ -20,6 +20,7 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
 
+#include <p4est.h>
 #include <sc_refcount.h>
 #include <t8_schemes/t8_default/t8_dtri.h>
 #include <t8_schemes/t8_default/t8_dtet.h>

--- a/example/timings/time_refine_type03.c
+++ b/example/timings/time_refine_type03.c
@@ -20,6 +20,7 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
 
+#include <p4est.h>
 #include <sc_refcount.h>
 #include <t8_schemes/t8_default/t8_dtri.h>
 #include <t8_schemes/t8_default/t8_dtet.h>

--- a/example/triangle/t8_read_triangle_file.cxx
+++ b/example/triangle/t8_read_triangle_file.cxx
@@ -21,6 +21,7 @@
 */
 
 #include <sc_options.h>
+#include <p4est.h>
 #include <t8.h>
 #include <t8_cmesh.h>
 #include <t8_cmesh_triangle.h>

--- a/src/t8.c
+++ b/src/t8.c
@@ -161,7 +161,7 @@ t8_init (int log_threshold)
 void               *
 t8_sc_array_index_topidx (sc_array_t *array, t8_topidx_t it)
 {
-  P4EST_ASSERT (it >= 0 && (size_t) it < array->elem_count);
+  T8_ASSERT (it >= 0 && (size_t) it < array->elem_count);
 
   return array->array + array->elem_size * (size_t) it;
 }
@@ -169,7 +169,7 @@ t8_sc_array_index_topidx (sc_array_t *array, t8_topidx_t it)
 void               *
 t8_sc_array_index_locidx (sc_array_t *array, t8_locidx_t it)
 {
-  P4EST_ASSERT (it >= 0 && (size_t) it < array->elem_count);
+  T8_ASSERT (it >= 0 && (size_t) it < array->elem_count);
 
   return array->array + array->elem_size * (size_t) it;
 }

--- a/src/t8.h
+++ b/src/t8.h
@@ -43,9 +43,8 @@
 #error "MPI I/O configured differently in t8code and libsc"
 #endif
 
-/* indirectly also include p4est_config.h, sc.h */
 #include <sc_containers.h>
-#include <p4est_base.h>
+#include <sc.h>
 
 /** This macro opens the extern "C" brace needed in C headers.
  * It needs to be followed by a semicolon to look like a statement. */
@@ -64,44 +63,55 @@ T8_EXTERN_C_BEGIN ();
 /** Portable way to use the const keyword determined by configure. */
 #define t8_restrict _sc_restrict
 
-#define T8_ASSERT P4EST_ASSERT          /**< TODO: write proper function. */
-#define T8_ALLOC P4EST_ALLOC            /**< TODO: write proper function. */
-#define T8_ALLOC_ZERO P4EST_ALLOC_ZERO  /**< TODO: write proper function. */
-#define T8_FREE P4EST_FREE              /**< TODO: write proper function. */
-#define T8_REALLOC P4EST_REALLOC        /**< TODO: write proper function. */
+/** allocate a \a t-array with \a n elements */
+#define T8_ASSERT(c) SC_CHECK_ABORT ((c), "Assertion '" #c "'")
+
+/** allocate a \a t-array with \a n elements */
+#define T8_ALLOC(t,n) (t *) sc_malloc (t8_get_package_id(),    \
+                                        (n) * sizeof(t))
+
+/** allocate a \a t-array with \a n elements and zero */
+#define T8_ALLOC_ZERO(t,n) (t *) sc_calloc (t8_get_package_id(),    \
+                                        (size_t) (n), sizeof(t))
+
+#define T8_FREE(p) sc_free (t8_get_package_id(), (p))
+
+/** reallocate the \a t-array \a p with \a n elements */
+#define T8_REALLOC(p,t,n) (t *) sc_realloc (t8_get_package_id(),   \
+                                        (p), (n) * sizeof(t))
 
 /** A type for counting coarse mesh related values (trees, tree vertices, ...).
  * The name topidx alludes to mesh topology as this is what cmesh defines.
- * We use the p4est_locidx_t type here since t8code allows for creating
+ * We use the int32_t type here since t8code allows for creating
  * really large connectivities.
  */
-typedef p4est_locidx_t t8_topidx_t;
+typedef int32_t t8_topidx_t;
 /** The MPI Datatype of t8_topidx_t */
-#define T8_MPI_TOPIDX P4EST_MPI_LOCIDX
+#define T8_MPI_TOPIDX sc_MPI_INT
 /** Macro to get the absolute value of a t8_topidx_t */
-#define T8_TOPIDX_ABS(x) P4EST_LOCIDX_ABS(x)
+#define T8_TOPIDX_ABS(x) ((t8_locidx_t) labs ((long) (x)))
 /** Comparison function for t8_topidx_t */
-#define t8_compare_topidx(v,w) p4est_locidx_compare(v,w)
+#define t8_compare_topidx(v,w) sc_int32_compare(v,w)
 
 /** A type for processor-local indexing. */
-typedef p4est_locidx_t t8_locidx_t;
+typedef int32_t t8_locidx_t;
 /** The MPI Datatype of t8_locidx_t */
-#define T8_MPI_LOCIDX P4EST_MPI_LOCIDX
+#define T8_MPI_LOCIDX sc_MPI_INT
 /** Macro to get the absolute value of a t8_locidx_t */
-#define T8_LOCIDX_ABS(x) P4EST_LOCIDX_ABS(x)
+#define T8_LOCIDX_ABS(x) ((t8_locidx_t) labs ((long) (x)))
 /** Maximum possible value of a t8_locidx_t */
-#define T8_LOCIDX_MAX P4EST_LOCIDX_MAX
+#define T8_LOCIDX_MAX INT32_MAX
 /** Comparison function for t8_locidx_t */
-#define t8_compare_locidx(v,w) p4est_locidx_compare(v,w)
+#define t8_compare_locidx(v,w) sc_int32_compare(v,w)
 
 /** A type for global indexing that holds really big numbers. */
-typedef p4est_gloidx_t t8_gloidx_t;
+typedef int64_t t8_gloidx_t;
 /** The MPI Datatype of t8_gloidx_t */
-#define T8_MPI_GLOIDX P4EST_MPI_GLOIDX
+#define T8_MPI_GLOIDX sc_MPI_LONG_LONG_INT
 /** Macro to get the absolute value of a t8_gloidx_t */
-#define T8_GLOIDX_ABS(x) P4EST_GLOIDX_ABS(x)
+#define T8_GLOIDX_ABS(x) ((t8_gloidx_t) llabs ((long long) (x)))
 /** Comparison function for t8_gloidx_t */
-#define t8_compare_gloidx(v,w) p4est_gloidx_compare(v,w)
+#define t8_compare_gloidx(v,w) sc_int64_compare(v,w)
 
 /** A type for storing SFC indices */
 typedef uint64_t    t8_linearidx_t;
@@ -117,8 +127,8 @@ typedef uint64_t    t8_linearidx_t;
 /** Communication tags used internal to t8code. */
 typedef enum
 {
-  T8_MPI_TAG_FIRST = P4EST_COMM_TAG_FIRST,
-  T8_MPI_PARTITION_CMESH = P4EST_COMM_TAG_LAST, /**< Used for coarse mesh partitioning */
+  T8_MPI_TAG_FIRST = SC_TAG_FIRST,
+  T8_MPI_PARTITION_CMESH = SC_TAG_LAST, /**< Used for coarse mesh partitioning */
   T8_MPI_PARTITION_FOREST,  /**< Used for forest partitioning */
   T8_MPI_GHOST_FOREST,  /**< Used for for ghost layer creation */
   T8_MPI_GHOST_EXC_FOREST,  /**< Used for ghost data exchange */

--- a/src/t8.h
+++ b/src/t8.h
@@ -80,6 +80,8 @@ T8_EXTERN_C_BEGIN ();
 #define T8_REALLOC(p,t,n) (t *) sc_realloc (t8_get_package_id(),   \
                                         (p), (n) * sizeof(t))
 
+typedef int32_t t8_qcoord_t;
+
 /** A type for counting coarse mesh related values (trees, tree vertices, ...).
  * The name topidx alludes to mesh topology as this is what cmesh defines.
  * We use the int32_t type here since t8code allows for creating

--- a/src/t8_cmesh.h
+++ b/src/t8_cmesh.h
@@ -48,10 +48,6 @@ typedef struct t8_cmesh *t8_cmesh_t;
  */
 #include <t8_eclass.h>
 
-/* TODO: See above comment, when moving cmesh_new these get moved too. */
-#include <p4est_connectivity.h>
-#include <p8est_connectivity.h>
-
 /* TODO: make it legal to call cmesh_set functions multiple times,
  *       just overwrite the previous setting if no inconsistency can occur.
  *       edit: This should be achieved now.

--- a/src/t8_cmesh/t8_cmesh_examples.h
+++ b/src/t8_cmesh/t8_cmesh_examples.h
@@ -28,6 +28,8 @@
 #ifndef T8_CMESH_EXAMPLES
 #define T8_CMESH_EXAMPLES
 #include <t8_cmesh.h>
+#include <p4est_connectivity.h>
+#include <p8est_connectivity.h>
 
 T8_EXTERN_C_BEGIN ();
 

--- a/src/t8_schemes/t8_default/Makefile.am
+++ b/src/t8_schemes/t8_default/Makefile.am
@@ -6,6 +6,8 @@ libt8_installed_headers += \
   src/t8_schemes/t8_default_cxx.hxx \
   src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.hxx \
   src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx \
+  src/t8_schemes/t8_default/t8_default_hex/t8_dhex.h \
+  src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.h \
   src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx \
   src/t8_schemes/t8_default/t8_default_line/t8_dline.h \
   src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.h \
@@ -13,6 +15,8 @@ libt8_installed_headers += \
   src/t8_schemes/t8_default/t8_default_prism/t8_dprism.h \
   src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.h \
   src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx \
+  src/t8_schemes/t8_default/t8_default_quad/t8_dquad.h \
+  src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.h \
   src/t8_schemes/t8_default/t8_default_tri/t8_default_tri_cxx.hxx \
   src/t8_schemes/t8_default/t8_default_tri/t8_dtri.h \
   src/t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.h \
@@ -29,11 +33,13 @@ libt8_compiled_sources += \
   src/t8_schemes/t8_default/t8_default_cxx.cxx \
   src/t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.cxx \
   src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx \
+  src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.c \
   src/t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.cxx \
   src/t8_schemes/t8_default/t8_default_line/t8_dline_bits.c \
   src/t8_schemes/t8_default/t8_default_prism/t8_default_prism_cxx.cxx \
   src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c \
   src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx \
+  src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.c \
   src/t8_schemes/t8_default/t8_default_tet/t8_default_tet_cxx.cxx \
   src/t8_schemes/t8_default/t8_default_tet/t8_dtet_bits.c \
   src/t8_schemes/t8_default/t8_default_tet/t8_dtet_connectivity.c \

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.h
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.h
@@ -26,16 +26,9 @@
 #ifndef T8_DEFAULT_HEX_H
 #define T8_DEFAULT_HEX_H
 
-#include <p8est.h>
 #include <t8_element.h>
 
 T8_EXTERN_C_BEGIN ();
-
-/** The structure holding a hexahedral element in the default scheme.
- * We make this definition public for interoperability of element classes.
- * We might want to put this into a private, scheme-specific header file.
- */
-typedef p8est_quadrant_t t8_phex_t;
 
 /** Provide an implementation for the hexahedral element class. */
 t8_eclass_scheme_t *t8_default_scheme_new_hex (void);

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.h
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex.h
@@ -20,9 +20,6 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
 
-/** \file t8_default_hex.h
- */
-
 #ifndef T8_DEFAULT_HEX_H
 #define T8_DEFAULT_HEX_H
 

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
@@ -32,14 +32,14 @@ T8_EXTERN_C_BEGIN ();
 int
 t8_default_scheme_hex_c::t8_element_maxlevel (void)
 {
-  return T8_HEX_QMAXLEVEL;
+  return T8_DHEX_QMAXLEVEL;
 }
 
 /* *INDENT-OFF* */
 t8_eclass_t
 t8_default_scheme_hex_c::t8_element_child_eclass (int childid)
 {
-  T8_ASSERT (0 <= childid && childid < T8_HEX_CHILDREN);
+  T8_ASSERT (0 <= childid && childid < T8_DHEX_CHILDREN);
 
   return T8_ECLASS_HEX;
 }
@@ -49,7 +49,7 @@ int
 t8_default_scheme_hex_c::t8_element_level (const t8_element_t *elem)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  return (int) ((const t8_phex_t *) elem)->level;
+  return (int) ((const t8_dhex_t *) elem)->level;
 }
 
 void
@@ -58,7 +58,7 @@ t8_default_scheme_hex_c::t8_element_copy (const t8_element_t *source,
 {
   T8_ASSERT (t8_element_is_valid (source));
   T8_ASSERT (t8_element_is_valid (dest));
-  *(t8_phex_t *) dest = *(const t8_phex_t *) source;
+  *(t8_dhex_t *) dest = *(const t8_dhex_t *) source;
 }
 
 int
@@ -68,8 +68,8 @@ t8_default_scheme_hex_c::t8_element_compare (const t8_element_t *elem1,
   T8_ASSERT (t8_element_is_valid (elem1));
   T8_ASSERT (t8_element_is_valid (elem2));
 
-  return t8_hex_compare ((const t8_phex_t *) elem1,
-                                 (const t8_phex_t *) elem2);
+  return t8_dhex_compare ((const t8_dhex_t *) elem1,
+                                 (const t8_dhex_t *) elem2);
 }
 
 void
@@ -78,8 +78,8 @@ t8_default_scheme_hex_c::t8_element_parent (const t8_element_t *elem,
 {
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (parent));
-  t8_hex_parent ((const t8_phex_t *) elem,
-                         (t8_phex_t *) parent);
+  t8_dhex_parent ((const t8_dhex_t *) elem,
+                         (t8_dhex_t *) parent);
 }
 
 void
@@ -88,28 +88,28 @@ t8_default_scheme_hex_c::t8_element_sibling (const t8_element_t *elem,
 {
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (sibling));
-  t8_hex_sibling ((const t8_phex_t *) elem,
-                          (t8_phex_t *) sibling, sibid);
+  t8_dhex_sibling ((const t8_dhex_t *) elem,
+                          (t8_dhex_t *) sibling, sibid);
 }
 
 int
 t8_default_scheme_hex_c::t8_element_num_faces (const t8_element_t *elem)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  return T8_HEX_FACES;
+  return T8_DHEX_FACES;
 }
 
 int
 t8_default_scheme_hex_c::t8_element_max_num_faces (const t8_element_t *elem)
 {
-  return T8_HEX_FACES;
+  return T8_DHEX_FACES;
 }
 
 int
 t8_default_scheme_hex_c::t8_element_num_children (const t8_element_t *elem)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  return T8_HEX_CHILDREN;
+  return T8_DHEX_CHILDREN;
 }
 
 int
@@ -126,31 +126,31 @@ t8_default_scheme_hex_c::t8_element_get_face_corner (const t8_element_t
                                                      int corner)
 {
   T8_ASSERT (t8_element_is_valid (element));
-  T8_ASSERT (0 <= face && face < T8_HEX_FACES);
+  T8_ASSERT (0 <= face && face < T8_DHEX_FACES);
   T8_ASSERT (0 <= corner && corner < 4);
 
-  return t8_hex_face_corners[face][corner];
+  return t8_dhex_face_corners[face][corner];
 }
 
 void
 t8_default_scheme_hex_c::t8_element_child (const t8_element_t *elem,
                                            int childid, t8_element_t *child)
 {
-  const t8_phex_t *q = (const t8_phex_t *) elem;
-  const t8_qcoord_t shift = T8_HEX_LEN (q->level + 1);
-  t8_phex_t   *r = (t8_phex_t *) child;
+  const t8_dhex_t *q = (const t8_dhex_t *) elem;
+  const t8_qcoord_t shift = T8_DHEX_LEN (q->level + 1);
+  t8_dhex_t   *r = (t8_dhex_t *) child;
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (child));
-  T8_ASSERT (t8_hex_is_extended (q));
-  T8_ASSERT (q->level < T8_HEX_QMAXLEVEL);
-  T8_ASSERT (0 <= childid && childid < T8_HEX_CHILDREN);
+  T8_ASSERT (t8_dhex_is_extended (q));
+  T8_ASSERT (q->level < T8_DHEX_QMAXLEVEL);
+  T8_ASSERT (0 <= childid && childid < T8_DHEX_CHILDREN);
 
   r->x = childid & 0x01 ? (q->x | shift) : q->x;
   r->y = childid & 0x02 ? (q->y | shift) : q->y;
   r->z = childid & 0x04 ? (q->z | shift) : q->z;
   r->level = q->level + 1;
-  T8_ASSERT (t8_hex_is_parent (q, r));
+  T8_ASSERT (t8_dhex_is_parent (q, r));
 }
 
 void
@@ -161,29 +161,29 @@ t8_default_scheme_hex_c::t8_element_children (const t8_element_t *elem,
 #ifdef T8_ENABLE_DEBUG
   {
     int                 i;
-    for (i = 0; i < T8_HEX_CHILDREN; i++) {
+    for (i = 0; i < T8_DHEX_CHILDREN; i++) {
       T8_ASSERT (t8_element_is_valid (c[i]));
     }
   }
 #endif
-  T8_ASSERT (length == T8_HEX_CHILDREN);
+  T8_ASSERT (length == T8_DHEX_CHILDREN);
 
-  t8_hex_childrenpv ((const t8_phex_t *) elem,
-                             (t8_phex_t **) c);
+  t8_dhex_childrenpv ((const t8_dhex_t *) elem,
+                             (t8_dhex_t **) c);
 }
 
 int
 t8_default_scheme_hex_c::t8_element_child_id (const t8_element_t *elem)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  return t8_hex_child_id ((const t8_phex_t *) elem);
+  return t8_dhex_child_id ((const t8_dhex_t *) elem);
 }
 
 int
 t8_default_scheme_hex_c::t8_element_ancestor_id (const t8_element_t *elem,
                                                  int level)
 {
-  return t8_hex_ancestor_id ((t8_phex_t *) elem, level);
+  return t8_dhex_ancestor_id ((t8_dhex_t *) elem, level);
 }
 
 int
@@ -192,12 +192,12 @@ t8_default_scheme_hex_c::t8_element_is_family (t8_element_t **fam)
 #ifdef T8_ENABLE_DEBUG
   {
     int                 i;
-    for (i = 0; i < T8_HEX_CHILDREN; i++) {
+    for (i = 0; i < T8_DHEX_CHILDREN; i++) {
       T8_ASSERT (t8_element_is_valid (fam[i]));
     }
   }
 #endif
-  return t8_hex_is_familypv ((t8_phex_t **) fam);
+  return t8_dhex_is_familypv ((t8_dhex_t **) fam);
 }
 
 void
@@ -207,9 +207,9 @@ t8_default_scheme_hex_c::t8_element_nca (const t8_element_t *elem1,
 {
   T8_ASSERT (t8_element_is_valid (elem1));
   T8_ASSERT (t8_element_is_valid (elem2));
-  t8_hex_nearest_common_ancestor ((const t8_phex_t *) elem1,
-                                 (const t8_phex_t *) elem2,
-                                 (t8_phex_t *) nca);
+  t8_dhex_nearest_common_ancestor ((const t8_dhex_t *) elem1,
+                                 (const t8_dhex_t *) elem2,
+                                 (t8_dhex_t *) nca);
 }
 
 t8_element_shape_t
@@ -234,12 +234,12 @@ t8_default_scheme_hex_c::t8_element_children_at_face (const t8_element_t
 #ifdef T8_ENABLE_DEBUG
   {
     int                 j;
-    for (j = 0; j < T8_QUAD_CHILDREN; j++) {
+    for (j = 0; j < T8_DQUAD_CHILDREN; j++) {
       T8_ASSERT (t8_element_is_valid (children[j]));
     }
   }
 #endif
-  T8_ASSERT (0 <= face && face < T8_HEX_FACES);
+  T8_ASSERT (0 <= face && face < T8_DHEX_FACES);
   T8_ASSERT (num_children == t8_element_num_face_children (elem, face));
 
   if (child_indices != NULL) {
@@ -328,7 +328,7 @@ t8_default_scheme_hex_c::t8_element_face_parent_face (const t8_element_t
                                                       *elem, int face)
 {
   int                 child_id;
-  const t8_phex_t *q = (const t8_phex_t *) elem;
+  const t8_dhex_t *q = (const t8_dhex_t *) elem;
 
   T8_ASSERT (t8_element_is_valid (elem));
   if (q->level == 0) {
@@ -336,11 +336,11 @@ t8_default_scheme_hex_c::t8_element_face_parent_face (const t8_element_t
   }
   /* Determine whether face is a subface of the parent.
    * This is the case if the child_id matches one of the faces corners */
-  child_id = t8_hex_child_id (q);
-  if (child_id == t8_hex_face_corners[face][0]
-      || child_id == t8_hex_face_corners[face][1]
-      || child_id == t8_hex_face_corners[face][2]
-      || child_id == t8_hex_face_corners[face][3]) {
+  child_id = t8_dhex_child_id (q);
+  if (child_id == t8_dhex_face_corners[face][0]
+      || child_id == t8_dhex_face_corners[face][1]
+      || child_id == t8_dhex_face_corners[face][2]
+      || child_id == t8_dhex_face_corners[face][3]) {
     return face;
   }
   return -1;
@@ -351,7 +351,7 @@ t8_default_scheme_hex_c::t8_element_tree_face (const t8_element_t *elem,
                                                int face)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  T8_ASSERT (0 <= face && face < T8_HEX_FACES);
+  T8_ASSERT (0 <= face && face < T8_DHEX_FACES);
   /* For hexahedra the face and the tree face number are the same. */
   return face;
 }
@@ -363,15 +363,15 @@ t8_default_scheme_hex_c::t8_element_extrude_face (const t8_element_t *face,
                                                   t8_element_t *elem,
                                                   int root_face)
 {
-  const t8_pquad_t *b = (const t8_pquad_t *) face;
-  t8_phex_t   *q = (t8_phex_t *) elem;
+  const t8_dquad_t *b = (const t8_dquad_t *) face;
+  t8_dhex_t   *q = (t8_dhex_t *) elem;
 
   T8_ASSERT (T8_COMMON_IS_TYPE
              (face_scheme, const t8_default_scheme_quad_c *));
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (face_scheme->eclass == T8_ECLASS_QUAD);
   T8_ASSERT (face_scheme->t8_element_is_valid (face));
-  T8_ASSERT (0 <= root_face && root_face < T8_HEX_FACES);
+  T8_ASSERT (0 <= root_face && root_face < T8_DHEX_FACES);
   q->level = b->level;
   /*
    * The faces of the root quadrant are enumerated like this:
@@ -390,33 +390,33 @@ t8_default_scheme_hex_c::t8_element_extrude_face (const t8_element_t *face,
   switch (root_face) {
   case 0:
     q->x = 0;
-    q->y = ((int64_t) b->x * T8_HEX_ROOT_LEN) / T8_QUAD_ROOT_LEN;
-    q->z = ((int64_t) b->y * T8_HEX_ROOT_LEN) / T8_QUAD_ROOT_LEN;
+    q->y = ((int64_t) b->x * T8_DHEX_ROOT_LEN) / T8_DQUAD_ROOT_LEN;
+    q->z = ((int64_t) b->y * T8_DHEX_ROOT_LEN) / T8_DQUAD_ROOT_LEN;
     break;
   case 1:
-    q->x = T8_HEX_LAST_OFFSET (q->level);
-    q->y = ((int64_t) b->x * T8_HEX_ROOT_LEN) / T8_QUAD_ROOT_LEN;
-    q->z = ((int64_t) b->y * T8_HEX_ROOT_LEN) / T8_QUAD_ROOT_LEN;
+    q->x = T8_DHEX_LAST_OFFSET (q->level);
+    q->y = ((int64_t) b->x * T8_DHEX_ROOT_LEN) / T8_DQUAD_ROOT_LEN;
+    q->z = ((int64_t) b->y * T8_DHEX_ROOT_LEN) / T8_DQUAD_ROOT_LEN;
     break;
   case 2:
-    q->x = ((int64_t) b->x * T8_HEX_ROOT_LEN) / T8_QUAD_ROOT_LEN;
+    q->x = ((int64_t) b->x * T8_DHEX_ROOT_LEN) / T8_DQUAD_ROOT_LEN;
     q->y = 0;
-    q->z = ((int64_t) b->y * T8_HEX_ROOT_LEN) / T8_QUAD_ROOT_LEN;
+    q->z = ((int64_t) b->y * T8_DHEX_ROOT_LEN) / T8_DQUAD_ROOT_LEN;
     break;
   case 3:
-    q->x = ((int64_t) b->x * T8_HEX_ROOT_LEN) / T8_QUAD_ROOT_LEN;
-    q->y = T8_HEX_LAST_OFFSET (q->level);
-    q->z = ((int64_t) b->y * T8_HEX_ROOT_LEN) / T8_QUAD_ROOT_LEN;
+    q->x = ((int64_t) b->x * T8_DHEX_ROOT_LEN) / T8_DQUAD_ROOT_LEN;
+    q->y = T8_DHEX_LAST_OFFSET (q->level);
+    q->z = ((int64_t) b->y * T8_DHEX_ROOT_LEN) / T8_DQUAD_ROOT_LEN;
     break;
   case 4:
-    q->x = ((int64_t) b->x * T8_HEX_ROOT_LEN) / T8_QUAD_ROOT_LEN;
-    q->y = ((int64_t) b->y * T8_HEX_ROOT_LEN) / T8_QUAD_ROOT_LEN;
+    q->x = ((int64_t) b->x * T8_DHEX_ROOT_LEN) / T8_DQUAD_ROOT_LEN;
+    q->y = ((int64_t) b->y * T8_DHEX_ROOT_LEN) / T8_DQUAD_ROOT_LEN;
     q->z = 0;
     break;
   case 5:
-    q->x = ((int64_t) b->x * T8_HEX_ROOT_LEN) / T8_QUAD_ROOT_LEN;
-    q->y = ((int64_t) b->y * T8_HEX_ROOT_LEN) / T8_QUAD_ROOT_LEN;
-    q->z = T8_HEX_LAST_OFFSET (q->level);
+    q->x = ((int64_t) b->x * T8_DHEX_ROOT_LEN) / T8_DQUAD_ROOT_LEN;
+    q->y = ((int64_t) b->y * T8_DHEX_ROOT_LEN) / T8_DQUAD_ROOT_LEN;
+    q->z = T8_DHEX_LAST_OFFSET (q->level);
     break;
   }
   /* We return the face of q at which we extruded. This is the same number
@@ -432,17 +432,17 @@ t8_default_scheme_hex_c::t8_element_first_descendant_face (const t8_element_t
                                                            *first_desc,
                                                            int level)
 {
-  const t8_phex_t *q = (const t8_phex_t *) elem;
-  t8_phex_t   *desc = (t8_phex_t *) first_desc;
+  const t8_dhex_t *q = (const t8_dhex_t *) elem;
+  t8_dhex_t   *desc = (t8_dhex_t *) first_desc;
   int                 first_face_corner;
 
-  T8_ASSERT (0 <= face && face < T8_HEX_FACES);
-  T8_ASSERT (0 <= level && level <= T8_HEX_QMAXLEVEL);
+  T8_ASSERT (0 <= face && face < T8_DHEX_FACES);
+  T8_ASSERT (0 <= level && level <= T8_DHEX_QMAXLEVEL);
 
   /* Get the first corner of q that belongs to face */
-  first_face_corner = t8_hex_face_corners[face][0];
+  first_face_corner = t8_dhex_face_corners[face][0];
   /* Construct the descendant of q in this corner */
-  t8_hex_corner_descendant (q, desc, first_face_corner, level);
+  t8_dhex_corner_descendant (q, desc, first_face_corner, level);
 }
 
 /** Construct the last descendant of an element that touches a given face. */
@@ -453,17 +453,17 @@ t8_default_scheme_hex_c::t8_element_last_descendant_face (const t8_element_t
                                                           *last_desc,
                                                           int level)
 {
-  const t8_phex_t *q = (const t8_phex_t *) elem;
-  t8_phex_t   *desc = (t8_phex_t *) last_desc;
+  const t8_dhex_t *q = (const t8_dhex_t *) elem;
+  t8_dhex_t   *desc = (t8_dhex_t *) last_desc;
   int                 last_face_corner;
 
-  T8_ASSERT (0 <= face && face < T8_HEX_FACES);
-  T8_ASSERT (0 <= level && level <= T8_HEX_QMAXLEVEL);
+  T8_ASSERT (0 <= face && face < T8_DHEX_FACES);
+  T8_ASSERT (0 <= level && level <= T8_DHEX_QMAXLEVEL);
 
   /* Get the last corner of q that belongs to face */
-  last_face_corner = t8_hex_face_corners[face][3];
+  last_face_corner = t8_dhex_face_corners[face][3];
   /* Construct the descendant of q in this corner */
-  t8_hex_corner_descendant (q, desc, last_face_corner, level);
+  t8_dhex_corner_descendant (q, desc, last_face_corner, level);
 }
 
 void
@@ -473,15 +473,15 @@ t8_default_scheme_hex_c::t8_element_boundary_face (const t8_element_t *elem,
                                                    const t8_eclass_scheme_c
                                                    *boundary_scheme)
 {
-  const t8_phex_t *q = (const t8_phex_t *) elem;
-  t8_pquad_t   *b = (t8_pquad_t *) boundary;
+  const t8_dhex_t *q = (const t8_dhex_t *) elem;
+  t8_dquad_t   *b = (t8_dquad_t *) boundary;
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (T8_COMMON_IS_TYPE
              (boundary_scheme, const t8_default_scheme_quad_c *));
   T8_ASSERT (boundary_scheme->eclass == T8_ECLASS_QUAD);
   T8_ASSERT (boundary_scheme->t8_element_is_valid (boundary));
-  T8_ASSERT (0 <= face && face < T8_HEX_FACES);
+  T8_ASSERT (0 <= face && face < T8_DHEX_FACES);
 
   /* The level of the boundary element is the same as the quadrant's level */
   b->level = q->level;
@@ -503,10 +503,10 @@ t8_default_scheme_hex_c::t8_element_boundary_face (const t8_element_t *elem,
    * We have to scale the coordinates since a root quadrant may have
    * different length than a root hex.
    */
-  b->x = (face >> 1 ? q->x : q->y) * ((t8_linearidx_t) T8_QUAD_ROOT_LEN / T8_HEX_ROOT_LEN);        /* true if face >= 2 */
-  b->y = (face >> 2 ? q->y : q->z) * ((t8_linearidx_t) T8_QUAD_ROOT_LEN / T8_HEX_ROOT_LEN);        /* true if face >= 4 */
-  T8_ASSERT (!t8_hex_is_extended (q)
-             || t8_quad_is_extended (b));
+  b->x = (face >> 1 ? q->x : q->y) * ((t8_linearidx_t) T8_DQUAD_ROOT_LEN / T8_DHEX_ROOT_LEN);        /* true if face >= 2 */
+  b->y = (face >> 2 ? q->y : q->z) * ((t8_linearidx_t) T8_DQUAD_ROOT_LEN / T8_DHEX_ROOT_LEN);        /* true if face >= 4 */
+  T8_ASSERT (!t8_dhex_is_extended (q)
+             || t8_dquad_is_extended (b));
 }
 
 void
@@ -519,8 +519,8 @@ t8_default_scheme_hex_c::t8_element_boundary (const t8_element_t *elem,
 #if 0
   int                 iface;
 
-  T8_ASSERT (length == T8_HEX_FACES);
-  for (iface = 0; iface < T8_HEX_FACES; iface++) {
+  T8_ASSERT (length == T8_DHEX_FACES);
+  for (iface = 0; iface < T8_DHEX_FACES; iface++) {
     t8_element_boundary_face (elem, iface, boundary[iface]);
   }
 #endif
@@ -530,11 +530,11 @@ int
 t8_default_scheme_hex_c::t8_element_is_root_boundary (const t8_element_t
                                                       *elem, int face)
 {
-  const t8_phex_t *q = (const t8_phex_t *) elem;
+  const t8_dhex_t *q = (const t8_dhex_t *) elem;
   t8_qcoord_t      coord;
 
   T8_ASSERT (t8_element_is_valid (elem));
-  T8_ASSERT (0 <= face && face < T8_HEX_FACES);
+  T8_ASSERT (0 <= face && face < T8_DHEX_FACES);
 
   /* if face is 0 or 1 q->x
    *            2 or 3 q->y
@@ -543,7 +543,7 @@ t8_default_scheme_hex_c::t8_element_is_root_boundary (const t8_element_t
   coord = face >> 2 ? q->z : face >> 1 ? q->y : q->x;
   /* If face is 0,2 or 4 check against 0.
    * If face is 1,3 or 5 check against LAST_OFFSET */
-  return coord == (face & 1 ? T8_HEX_LAST_OFFSET (q->level) : 0);
+  return coord == (face & 1 ? T8_DHEX_LAST_OFFSET (q->level) : 0);
 }
 
 int
@@ -553,14 +553,14 @@ t8_default_scheme_hex_c::t8_element_face_neighbor_inside (const t8_element_t
                                                           int face,
                                                           int *neigh_face)
 {
-  const t8_phex_t *q = (const t8_phex_t *) elem;
-  t8_phex_t   *n = (t8_phex_t *) neigh;
+  const t8_dhex_t *q = (const t8_dhex_t *) elem;
+  t8_dhex_t   *n = (t8_dhex_t *) neigh;
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (neigh));
-  T8_ASSERT (0 <= face && face < T8_HEX_FACES);
+  T8_ASSERT (0 <= face && face < T8_DHEX_FACES);
   /* Compute the face neighbor */
-  t8_hex_face_neighbor (q, face, n);
+  t8_dhex_face_neighbor (q, face, n);
 
   /* Compute the face of q that coincides with face.
    * face   neigh_face    face      neigh_face
@@ -570,9 +570,9 @@ t8_default_scheme_hex_c::t8_element_face_neighbor_inside (const t8_element_t
    *   3        2
    */
   T8_ASSERT (neigh_face != NULL);
-  *neigh_face = t8_hex_face_dual[face];
+  *neigh_face = t8_dhex_face_dual[face];
   /* return true if neigh is inside the root */
-  return t8_hex_is_inside_root (n);
+  return t8_dhex_is_inside_root (n);
 }
 
 void
@@ -581,10 +581,10 @@ t8_default_scheme_hex_c::t8_element_set_linear_id (t8_element_t *elem,
                                                    t8_linearidx_t id)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  T8_ASSERT (0 <= level && level <= T8_HEX_QMAXLEVEL);
-  T8_ASSERT (0 <= id && id < ((t8_linearidx_t) 1) << T8_HEX_DIM * level);
+  T8_ASSERT (0 <= level && level <= T8_DHEX_QMAXLEVEL);
+  T8_ASSERT (0 <= id && id < ((t8_linearidx_t) 1) << T8_DHEX_DIM * level);
 
-  t8_hex_set_morton ((t8_phex_t *) elem, level, id);
+  t8_dhex_set_morton ((t8_dhex_t *) elem, level, id);
 }
 
 t8_linearidx_t
@@ -592,9 +592,9 @@ t8_linearidx_t
                                                      int level)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  T8_ASSERT (0 <= level && level <= T8_HEX_QMAXLEVEL);
+  T8_ASSERT (0 <= level && level <= T8_DHEX_QMAXLEVEL);
 
-  return t8_hex_linear_id ((t8_phex_t *) elem, level);
+  return t8_dhex_linear_id ((t8_dhex_t *) elem, level);
 }
 
 void
@@ -605,9 +605,9 @@ t8_default_scheme_hex_c::t8_element_first_descendant (const t8_element_t
 {
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (desc));
-  T8_ASSERT (0 <= level && level <= T8_HEX_QMAXLEVEL);
-  t8_hex_first_descendant ((t8_phex_t *) elem,
-                                   (t8_phex_t *) desc, level);
+  T8_ASSERT (0 <= level && level <= T8_DHEX_QMAXLEVEL);
+  t8_dhex_first_descendant ((t8_dhex_t *) elem,
+                                   (t8_dhex_t *) desc, level);
 }
 
 void
@@ -617,9 +617,9 @@ t8_default_scheme_hex_c::t8_element_last_descendant (const t8_element_t *elem,
 {
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (desc));
-  T8_ASSERT (0 <= level && level <= T8_HEX_QMAXLEVEL);
-  t8_hex_last_descendant ((t8_phex_t *) elem,
-                                  (t8_phex_t *) desc, level);
+  T8_ASSERT (0 <= level && level <= T8_DHEX_QMAXLEVEL);
+  t8_dhex_last_descendant ((t8_dhex_t *) elem,
+                                  (t8_dhex_t *) desc, level);
 }
 
 void
@@ -629,21 +629,21 @@ t8_default_scheme_hex_c::t8_element_successor (const t8_element_t *elem1,
   t8_linearidx_t      id;
   T8_ASSERT (t8_element_is_valid (elem1));
   T8_ASSERT (t8_element_is_valid (elem2));
-  T8_ASSERT (0 <= level && level <= T8_HEX_QMAXLEVEL);
+  T8_ASSERT (0 <= level && level <= T8_DHEX_QMAXLEVEL);
 
-  id = t8_hex_linear_id ((const t8_phex_t *) elem1, level);
-  T8_ASSERT (id + 1 < ((t8_linearidx_t) 1) << T8_HEX_DIM * level);
-  t8_hex_set_morton ((t8_phex_t *) elem2, level, id + 1);
+  id = t8_dhex_linear_id ((const t8_dhex_t *) elem1, level);
+  T8_ASSERT (id + 1 < ((t8_linearidx_t) 1) << T8_DHEX_DIM * level);
+  t8_dhex_set_morton ((t8_dhex_t *) elem2, level, id + 1);
 }
 
 void
 t8_default_scheme_hex_c::t8_element_anchor (const t8_element_t *elem,
                                             int coord[3])
 {
-  t8_phex_t   *q;
+  t8_dhex_t   *q;
 
   T8_ASSERT (t8_element_is_valid (elem));
-  q = (t8_phex_t *) elem;
+  q = (t8_dhex_t *) elem;
   coord[0] = q->x;
   coord[1] = q->y;
   coord[2] = q->z;
@@ -653,20 +653,20 @@ int
 t8_default_scheme_hex_c::t8_element_root_len (const t8_element_t *elem)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  return T8_HEX_ROOT_LEN;
+  return T8_DHEX_ROOT_LEN;
 }
 
 void
 t8_default_scheme_hex_c::t8_element_vertex_coords (const t8_element_t *t,
                                                    int vertex, int coords[])
 {
-  const t8_phex_t *q1 = (const t8_phex_t *) t;
+  const t8_dhex_t *q1 = (const t8_dhex_t *) t;
   int                 len;
 
   T8_ASSERT (t8_element_is_valid (t));
   T8_ASSERT (0 <= vertex && vertex < 8);
   /* Get the length of the quadrant */
-  len = T8_HEX_LEN (q1->level);
+  len = T8_DHEX_LEN (q1->level);
   /* Compute the x, y and z coordinates of the vertex depending on the
    * vertex number */
   coords[0] = q1->x + (vertex & 1 ? 1 : 0) * len;
@@ -688,9 +688,9 @@ t8_default_scheme_hex_c::t8_element_vertex_reference_coords (const
 
   /* We divide the integer coordinates by the root length of the hex
    * to obtain the reference coordinates. */
-  coords[0] = coords_int[0] / (double) T8_HEX_ROOT_LEN;
-  coords[1] = coords_int[1] / (double) T8_HEX_ROOT_LEN;
-  coords[2] = coords_int[2] / (double) T8_HEX_ROOT_LEN;
+  coords[0] = coords_int[0] / (double) T8_DHEX_ROOT_LEN;
+  coords[1] = coords_int[1] / (double) T8_DHEX_ROOT_LEN;
+  coords[2] = coords_int[2] / (double) T8_DHEX_ROOT_LEN;
 }
 
 void
@@ -705,7 +705,6 @@ t8_default_scheme_hex_c::t8_element_new (int length, t8_element_t **elem)
     int                 i;
     for (i = 0; i < length; i++) {
       t8_element_init (1, elem[i], 0);
-      T8_QUAD_SET_TDIM ((t8_phex_t *) elem[i], 3);
     }
   }
 #endif
@@ -718,11 +717,10 @@ t8_default_scheme_hex_c::t8_element_init (int length, t8_element_t *elem,
 #ifdef T8_ENABLE_DEBUG
   if (!new_called) {
     int                 i;
-    t8_phex_t   *quads = (t8_phex_t *) elem;
+    t8_dhex_t   *quads = (t8_dhex_t *) elem;
     for (i = 0; i < length; i++) {
-      t8_hex_set_morton (quads + i, 0, 0);
-      T8_QUAD_SET_TDIM (quads + i, 3);
-      T8_ASSERT (t8_hex_is_extended (quads + i));
+      t8_dhex_set_morton (quads + i, 0, 0);
+      T8_ASSERT (t8_dhex_is_extended (quads + i));
     }
   }
 #endif
@@ -735,18 +733,16 @@ int
 t8_default_scheme_hex_c::t8_element_is_valid (const t8_element_t *elem) const
 /* *INDENT-ON* */
 {
-  /* TODO: additional checks? do we set pad8 or similar?
-   */
-  return t8_hex_is_extended ((const t8_phex_t *) elem)
-    && T8_QUAD_GET_TDIM ((const t8_phex_t *) elem) == 3;
+  /* TODO: additional checks? */
+  return t8_dhex_is_extended ((const t8_dhex_t *) elem);
 }
 
 void
 t8_default_scheme_hex_c::t8_element_debug_print (const t8_element_t *elem) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  t8_phex_t   *hex = (t8_phex_t *) elem;
-  t8_hex_print (SC_LP_DEBUG, hex);
+  t8_dhex_t   *hex = (t8_dhex_t *) elem;
+  t8_dhex_print (SC_LP_DEBUG, hex);
 }
 #endif
 
@@ -754,7 +750,7 @@ t8_default_scheme_hex_c::t8_element_debug_print (const t8_element_t *elem) const
 t8_default_scheme_hex_c::t8_default_scheme_hex_c (void)
 {
   eclass = T8_ECLASS_HEX;
-  element_size = sizeof (t8_phex_t);
+  element_size = sizeof (t8_dhex_t);
   ts_context = sc_mempool_new (element_size);
 }
 

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
@@ -20,8 +20,9 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
 
-#include <p8est_bits.h>
-#include <p4est_bits.h>
+#include <t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.h>
+#include <t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.h>
+
 #include <t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.hxx>
 #include <t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx>
 
@@ -31,14 +32,14 @@ T8_EXTERN_C_BEGIN ();
 int
 t8_default_scheme_hex_c::t8_element_maxlevel (void)
 {
-  return P8EST_QMAXLEVEL;
+  return T8_HEX_QMAXLEVEL;
 }
 
 /* *INDENT-OFF* */
 t8_eclass_t
 t8_default_scheme_hex_c::t8_element_child_eclass (int childid)
 {
-  T8_ASSERT (0 <= childid && childid < P8EST_CHILDREN);
+  T8_ASSERT (0 <= childid && childid < T8_HEX_CHILDREN);
 
   return T8_ECLASS_HEX;
 }
@@ -48,7 +49,7 @@ int
 t8_default_scheme_hex_c::t8_element_level (const t8_element_t *elem)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  return (int) ((const p8est_quadrant_t *) elem)->level;
+  return (int) ((const t8_phex_t *) elem)->level;
 }
 
 void
@@ -57,7 +58,7 @@ t8_default_scheme_hex_c::t8_element_copy (const t8_element_t *source,
 {
   T8_ASSERT (t8_element_is_valid (source));
   T8_ASSERT (t8_element_is_valid (dest));
-  *(p8est_quadrant_t *) dest = *(const p8est_quadrant_t *) source;
+  *(t8_phex_t *) dest = *(const t8_phex_t *) source;
 }
 
 int
@@ -67,8 +68,8 @@ t8_default_scheme_hex_c::t8_element_compare (const t8_element_t *elem1,
   T8_ASSERT (t8_element_is_valid (elem1));
   T8_ASSERT (t8_element_is_valid (elem2));
 
-  return p8est_quadrant_compare ((const p8est_quadrant_t *) elem1,
-                                 (const p8est_quadrant_t *) elem2);
+  return t8_hex_compare ((const t8_phex_t *) elem1,
+                                 (const t8_phex_t *) elem2);
 }
 
 void
@@ -77,8 +78,8 @@ t8_default_scheme_hex_c::t8_element_parent (const t8_element_t *elem,
 {
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (parent));
-  p8est_quadrant_parent ((const p8est_quadrant_t *) elem,
-                         (p8est_quadrant_t *) parent);
+  t8_hex_parent ((const t8_phex_t *) elem,
+                         (t8_phex_t *) parent);
 }
 
 void
@@ -87,28 +88,28 @@ t8_default_scheme_hex_c::t8_element_sibling (const t8_element_t *elem,
 {
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (sibling));
-  p8est_quadrant_sibling ((const p8est_quadrant_t *) elem,
-                          (p8est_quadrant_t *) sibling, sibid);
+  t8_hex_sibling ((const t8_phex_t *) elem,
+                          (t8_phex_t *) sibling, sibid);
 }
 
 int
 t8_default_scheme_hex_c::t8_element_num_faces (const t8_element_t *elem)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  return P8EST_FACES;
+  return T8_HEX_FACES;
 }
 
 int
 t8_default_scheme_hex_c::t8_element_max_num_faces (const t8_element_t *elem)
 {
-  return P8EST_FACES;
+  return T8_HEX_FACES;
 }
 
 int
 t8_default_scheme_hex_c::t8_element_num_children (const t8_element_t *elem)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  return P8EST_CHILDREN;
+  return T8_HEX_CHILDREN;
 }
 
 int
@@ -125,31 +126,31 @@ t8_default_scheme_hex_c::t8_element_get_face_corner (const t8_element_t
                                                      int corner)
 {
   T8_ASSERT (t8_element_is_valid (element));
-  T8_ASSERT (0 <= face && face < P8EST_FACES);
+  T8_ASSERT (0 <= face && face < T8_HEX_FACES);
   T8_ASSERT (0 <= corner && corner < 4);
 
-  return p8est_face_corners[face][corner];
+  return t8_hex_face_corners[face][corner];
 }
 
 void
 t8_default_scheme_hex_c::t8_element_child (const t8_element_t *elem,
                                            int childid, t8_element_t *child)
 {
-  const p8est_quadrant_t *q = (const p8est_quadrant_t *) elem;
-  const p4est_qcoord_t shift = P8EST_QUADRANT_LEN (q->level + 1);
-  p8est_quadrant_t   *r = (p8est_quadrant_t *) child;
+  const t8_phex_t *q = (const t8_phex_t *) elem;
+  const t8_qcoord_t shift = T8_HEX_LEN (q->level + 1);
+  t8_phex_t   *r = (t8_phex_t *) child;
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (child));
-  T8_ASSERT (p8est_quadrant_is_extended (q));
-  T8_ASSERT (q->level < P8EST_QMAXLEVEL);
-  T8_ASSERT (0 <= childid && childid < P8EST_CHILDREN);
+  T8_ASSERT (t8_hex_is_extended (q));
+  T8_ASSERT (q->level < T8_HEX_QMAXLEVEL);
+  T8_ASSERT (0 <= childid && childid < T8_HEX_CHILDREN);
 
   r->x = childid & 0x01 ? (q->x | shift) : q->x;
   r->y = childid & 0x02 ? (q->y | shift) : q->y;
   r->z = childid & 0x04 ? (q->z | shift) : q->z;
   r->level = q->level + 1;
-  T8_ASSERT (p8est_quadrant_is_parent (q, r));
+  T8_ASSERT (t8_hex_is_parent (q, r));
 }
 
 void
@@ -160,29 +161,29 @@ t8_default_scheme_hex_c::t8_element_children (const t8_element_t *elem,
 #ifdef T8_ENABLE_DEBUG
   {
     int                 i;
-    for (i = 0; i < P8EST_CHILDREN; i++) {
+    for (i = 0; i < T8_HEX_CHILDREN; i++) {
       T8_ASSERT (t8_element_is_valid (c[i]));
     }
   }
 #endif
-  T8_ASSERT (length == P8EST_CHILDREN);
+  T8_ASSERT (length == T8_HEX_CHILDREN);
 
-  p8est_quadrant_childrenpv ((const p8est_quadrant_t *) elem,
-                             (p8est_quadrant_t **) c);
+  t8_hex_childrenpv ((const t8_phex_t *) elem,
+                             (t8_phex_t **) c);
 }
 
 int
 t8_default_scheme_hex_c::t8_element_child_id (const t8_element_t *elem)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  return p8est_quadrant_child_id ((const p8est_quadrant_t *) elem);
+  return t8_hex_child_id ((const t8_phex_t *) elem);
 }
 
 int
 t8_default_scheme_hex_c::t8_element_ancestor_id (const t8_element_t *elem,
                                                  int level)
 {
-  return p8est_quadrant_ancestor_id ((p8est_quadrant_t *) elem, level);
+  return t8_hex_ancestor_id ((t8_phex_t *) elem, level);
 }
 
 int
@@ -191,12 +192,12 @@ t8_default_scheme_hex_c::t8_element_is_family (t8_element_t **fam)
 #ifdef T8_ENABLE_DEBUG
   {
     int                 i;
-    for (i = 0; i < P8EST_CHILDREN; i++) {
+    for (i = 0; i < T8_HEX_CHILDREN; i++) {
       T8_ASSERT (t8_element_is_valid (fam[i]));
     }
   }
 #endif
-  return p8est_quadrant_is_familypv ((p8est_quadrant_t **) fam);
+  return t8_hex_is_familypv ((t8_phex_t **) fam);
 }
 
 void
@@ -206,9 +207,9 @@ t8_default_scheme_hex_c::t8_element_nca (const t8_element_t *elem1,
 {
   T8_ASSERT (t8_element_is_valid (elem1));
   T8_ASSERT (t8_element_is_valid (elem2));
-  p8est_nearest_common_ancestor ((const p8est_quadrant_t *) elem1,
-                                 (const p8est_quadrant_t *) elem2,
-                                 (p8est_quadrant_t *) nca);
+  t8_hex_nearest_common_ancestor ((const t8_phex_t *) elem1,
+                                 (const t8_phex_t *) elem2,
+                                 (t8_phex_t *) nca);
 }
 
 t8_element_shape_t
@@ -233,12 +234,12 @@ t8_default_scheme_hex_c::t8_element_children_at_face (const t8_element_t
 #ifdef T8_ENABLE_DEBUG
   {
     int                 j;
-    for (j = 0; j < P4EST_CHILDREN; j++) {
+    for (j = 0; j < T8_QUAD_CHILDREN; j++) {
       T8_ASSERT (t8_element_is_valid (children[j]));
     }
   }
 #endif
-  T8_ASSERT (0 <= face && face < P8EST_FACES);
+  T8_ASSERT (0 <= face && face < T8_HEX_FACES);
   T8_ASSERT (num_children == t8_element_num_face_children (elem, face));
 
   if (child_indices != NULL) {
@@ -327,7 +328,7 @@ t8_default_scheme_hex_c::t8_element_face_parent_face (const t8_element_t
                                                       *elem, int face)
 {
   int                 child_id;
-  const p8est_quadrant_t *q = (const p8est_quadrant_t *) elem;
+  const t8_phex_t *q = (const t8_phex_t *) elem;
 
   T8_ASSERT (t8_element_is_valid (elem));
   if (q->level == 0) {
@@ -335,11 +336,11 @@ t8_default_scheme_hex_c::t8_element_face_parent_face (const t8_element_t
   }
   /* Determine whether face is a subface of the parent.
    * This is the case if the child_id matches one of the faces corners */
-  child_id = p8est_quadrant_child_id (q);
-  if (child_id == p8est_face_corners[face][0]
-      || child_id == p8est_face_corners[face][1]
-      || child_id == p8est_face_corners[face][2]
-      || child_id == p8est_face_corners[face][3]) {
+  child_id = t8_hex_child_id (q);
+  if (child_id == t8_hex_face_corners[face][0]
+      || child_id == t8_hex_face_corners[face][1]
+      || child_id == t8_hex_face_corners[face][2]
+      || child_id == t8_hex_face_corners[face][3]) {
     return face;
   }
   return -1;
@@ -350,7 +351,7 @@ t8_default_scheme_hex_c::t8_element_tree_face (const t8_element_t *elem,
                                                int face)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  T8_ASSERT (0 <= face && face < P8EST_FACES);
+  T8_ASSERT (0 <= face && face < T8_HEX_FACES);
   /* For hexahedra the face and the tree face number are the same. */
   return face;
 }
@@ -362,15 +363,15 @@ t8_default_scheme_hex_c::t8_element_extrude_face (const t8_element_t *face,
                                                   t8_element_t *elem,
                                                   int root_face)
 {
-  const p4est_quadrant_t *b = (const p4est_quadrant_t *) face;
-  p8est_quadrant_t   *q = (p8est_quadrant_t *) elem;
+  const t8_pquad_t *b = (const t8_pquad_t *) face;
+  t8_phex_t   *q = (t8_phex_t *) elem;
 
   T8_ASSERT (T8_COMMON_IS_TYPE
              (face_scheme, const t8_default_scheme_quad_c *));
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (face_scheme->eclass == T8_ECLASS_QUAD);
   T8_ASSERT (face_scheme->t8_element_is_valid (face));
-  T8_ASSERT (0 <= root_face && root_face < P8EST_FACES);
+  T8_ASSERT (0 <= root_face && root_face < T8_HEX_FACES);
   q->level = b->level;
   /*
    * The faces of the root quadrant are enumerated like this:
@@ -389,33 +390,33 @@ t8_default_scheme_hex_c::t8_element_extrude_face (const t8_element_t *face,
   switch (root_face) {
   case 0:
     q->x = 0;
-    q->y = ((int64_t) b->x * P8EST_ROOT_LEN) / P4EST_ROOT_LEN;
-    q->z = ((int64_t) b->y * P8EST_ROOT_LEN) / P4EST_ROOT_LEN;
+    q->y = ((int64_t) b->x * T8_HEX_ROOT_LEN) / T8_QUAD_ROOT_LEN;
+    q->z = ((int64_t) b->y * T8_HEX_ROOT_LEN) / T8_QUAD_ROOT_LEN;
     break;
   case 1:
-    q->x = P8EST_LAST_OFFSET (q->level);
-    q->y = ((int64_t) b->x * P8EST_ROOT_LEN) / P4EST_ROOT_LEN;
-    q->z = ((int64_t) b->y * P8EST_ROOT_LEN) / P4EST_ROOT_LEN;
+    q->x = T8_HEX_LAST_OFFSET (q->level);
+    q->y = ((int64_t) b->x * T8_HEX_ROOT_LEN) / T8_QUAD_ROOT_LEN;
+    q->z = ((int64_t) b->y * T8_HEX_ROOT_LEN) / T8_QUAD_ROOT_LEN;
     break;
   case 2:
-    q->x = ((int64_t) b->x * P8EST_ROOT_LEN) / P4EST_ROOT_LEN;
+    q->x = ((int64_t) b->x * T8_HEX_ROOT_LEN) / T8_QUAD_ROOT_LEN;
     q->y = 0;
-    q->z = ((int64_t) b->y * P8EST_ROOT_LEN) / P4EST_ROOT_LEN;
+    q->z = ((int64_t) b->y * T8_HEX_ROOT_LEN) / T8_QUAD_ROOT_LEN;
     break;
   case 3:
-    q->x = ((int64_t) b->x * P8EST_ROOT_LEN) / P4EST_ROOT_LEN;
-    q->y = P8EST_LAST_OFFSET (q->level);
-    q->z = ((int64_t) b->y * P8EST_ROOT_LEN) / P4EST_ROOT_LEN;
+    q->x = ((int64_t) b->x * T8_HEX_ROOT_LEN) / T8_QUAD_ROOT_LEN;
+    q->y = T8_HEX_LAST_OFFSET (q->level);
+    q->z = ((int64_t) b->y * T8_HEX_ROOT_LEN) / T8_QUAD_ROOT_LEN;
     break;
   case 4:
-    q->x = ((int64_t) b->x * P8EST_ROOT_LEN) / P4EST_ROOT_LEN;
-    q->y = ((int64_t) b->y * P8EST_ROOT_LEN) / P4EST_ROOT_LEN;
+    q->x = ((int64_t) b->x * T8_HEX_ROOT_LEN) / T8_QUAD_ROOT_LEN;
+    q->y = ((int64_t) b->y * T8_HEX_ROOT_LEN) / T8_QUAD_ROOT_LEN;
     q->z = 0;
     break;
   case 5:
-    q->x = ((int64_t) b->x * P8EST_ROOT_LEN) / P4EST_ROOT_LEN;
-    q->y = ((int64_t) b->y * P8EST_ROOT_LEN) / P4EST_ROOT_LEN;
-    q->z = P8EST_LAST_OFFSET (q->level);
+    q->x = ((int64_t) b->x * T8_HEX_ROOT_LEN) / T8_QUAD_ROOT_LEN;
+    q->y = ((int64_t) b->y * T8_HEX_ROOT_LEN) / T8_QUAD_ROOT_LEN;
+    q->z = T8_HEX_LAST_OFFSET (q->level);
     break;
   }
   /* We return the face of q at which we extruded. This is the same number
@@ -431,17 +432,17 @@ t8_default_scheme_hex_c::t8_element_first_descendant_face (const t8_element_t
                                                            *first_desc,
                                                            int level)
 {
-  const p8est_quadrant_t *q = (const p8est_quadrant_t *) elem;
-  p8est_quadrant_t   *desc = (p8est_quadrant_t *) first_desc;
+  const t8_phex_t *q = (const t8_phex_t *) elem;
+  t8_phex_t   *desc = (t8_phex_t *) first_desc;
   int                 first_face_corner;
 
-  T8_ASSERT (0 <= face && face < P8EST_FACES);
-  T8_ASSERT (0 <= level && level <= P8EST_QMAXLEVEL);
+  T8_ASSERT (0 <= face && face < T8_HEX_FACES);
+  T8_ASSERT (0 <= level && level <= T8_HEX_QMAXLEVEL);
 
   /* Get the first corner of q that belongs to face */
-  first_face_corner = p8est_face_corners[face][0];
+  first_face_corner = t8_hex_face_corners[face][0];
   /* Construct the descendant of q in this corner */
-  p8est_quadrant_corner_descendant (q, desc, first_face_corner, level);
+  t8_hex_corner_descendant (q, desc, first_face_corner, level);
 }
 
 /** Construct the last descendant of an element that touches a given face. */
@@ -452,17 +453,17 @@ t8_default_scheme_hex_c::t8_element_last_descendant_face (const t8_element_t
                                                           *last_desc,
                                                           int level)
 {
-  const p8est_quadrant_t *q = (const p8est_quadrant_t *) elem;
-  p8est_quadrant_t   *desc = (p8est_quadrant_t *) last_desc;
+  const t8_phex_t *q = (const t8_phex_t *) elem;
+  t8_phex_t   *desc = (t8_phex_t *) last_desc;
   int                 last_face_corner;
 
-  T8_ASSERT (0 <= face && face < P8EST_FACES);
-  T8_ASSERT (0 <= level && level <= P8EST_QMAXLEVEL);
+  T8_ASSERT (0 <= face && face < T8_HEX_FACES);
+  T8_ASSERT (0 <= level && level <= T8_HEX_QMAXLEVEL);
 
   /* Get the last corner of q that belongs to face */
-  last_face_corner = p8est_face_corners[face][3];
+  last_face_corner = t8_hex_face_corners[face][3];
   /* Construct the descendant of q in this corner */
-  p8est_quadrant_corner_descendant (q, desc, last_face_corner, level);
+  t8_hex_corner_descendant (q, desc, last_face_corner, level);
 }
 
 void
@@ -472,15 +473,15 @@ t8_default_scheme_hex_c::t8_element_boundary_face (const t8_element_t *elem,
                                                    const t8_eclass_scheme_c
                                                    *boundary_scheme)
 {
-  const p8est_quadrant_t *q = (const p8est_quadrant_t *) elem;
-  p4est_quadrant_t   *b = (p4est_quadrant_t *) boundary;
+  const t8_phex_t *q = (const t8_phex_t *) elem;
+  t8_pquad_t   *b = (t8_pquad_t *) boundary;
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (T8_COMMON_IS_TYPE
              (boundary_scheme, const t8_default_scheme_quad_c *));
   T8_ASSERT (boundary_scheme->eclass == T8_ECLASS_QUAD);
   T8_ASSERT (boundary_scheme->t8_element_is_valid (boundary));
-  T8_ASSERT (0 <= face && face < P8EST_FACES);
+  T8_ASSERT (0 <= face && face < T8_HEX_FACES);
 
   /* The level of the boundary element is the same as the quadrant's level */
   b->level = q->level;
@@ -502,10 +503,10 @@ t8_default_scheme_hex_c::t8_element_boundary_face (const t8_element_t *elem,
    * We have to scale the coordinates since a root quadrant may have
    * different length than a root hex.
    */
-  b->x = (face >> 1 ? q->x : q->y) * ((t8_linearidx_t) P4EST_ROOT_LEN / P8EST_ROOT_LEN);        /* true if face >= 2 */
-  b->y = (face >> 2 ? q->y : q->z) * ((t8_linearidx_t) P4EST_ROOT_LEN / P8EST_ROOT_LEN);        /* true if face >= 4 */
-  T8_ASSERT (!p8est_quadrant_is_extended (q)
-             || p4est_quadrant_is_extended (b));
+  b->x = (face >> 1 ? q->x : q->y) * ((t8_linearidx_t) T8_QUAD_ROOT_LEN / T8_HEX_ROOT_LEN);        /* true if face >= 2 */
+  b->y = (face >> 2 ? q->y : q->z) * ((t8_linearidx_t) T8_QUAD_ROOT_LEN / T8_HEX_ROOT_LEN);        /* true if face >= 4 */
+  T8_ASSERT (!t8_hex_is_extended (q)
+             || t8_quad_is_extended (b));
 }
 
 void
@@ -518,8 +519,8 @@ t8_default_scheme_hex_c::t8_element_boundary (const t8_element_t *elem,
 #if 0
   int                 iface;
 
-  T8_ASSERT (length == P8EST_FACES);
-  for (iface = 0; iface < P8EST_FACES; iface++) {
+  T8_ASSERT (length == T8_HEX_FACES);
+  for (iface = 0; iface < T8_HEX_FACES; iface++) {
     t8_element_boundary_face (elem, iface, boundary[iface]);
   }
 #endif
@@ -529,11 +530,11 @@ int
 t8_default_scheme_hex_c::t8_element_is_root_boundary (const t8_element_t
                                                       *elem, int face)
 {
-  const p8est_quadrant_t *q = (const p8est_quadrant_t *) elem;
-  p4est_qcoord_t      coord;
+  const t8_phex_t *q = (const t8_phex_t *) elem;
+  t8_qcoord_t      coord;
 
   T8_ASSERT (t8_element_is_valid (elem));
-  T8_ASSERT (0 <= face && face < P8EST_FACES);
+  T8_ASSERT (0 <= face && face < T8_HEX_FACES);
 
   /* if face is 0 or 1 q->x
    *            2 or 3 q->y
@@ -542,7 +543,7 @@ t8_default_scheme_hex_c::t8_element_is_root_boundary (const t8_element_t
   coord = face >> 2 ? q->z : face >> 1 ? q->y : q->x;
   /* If face is 0,2 or 4 check against 0.
    * If face is 1,3 or 5 check against LAST_OFFSET */
-  return coord == (face & 1 ? P8EST_LAST_OFFSET (q->level) : 0);
+  return coord == (face & 1 ? T8_HEX_LAST_OFFSET (q->level) : 0);
 }
 
 int
@@ -552,14 +553,14 @@ t8_default_scheme_hex_c::t8_element_face_neighbor_inside (const t8_element_t
                                                           int face,
                                                           int *neigh_face)
 {
-  const p8est_quadrant_t *q = (const p8est_quadrant_t *) elem;
-  p8est_quadrant_t   *n = (p8est_quadrant_t *) neigh;
+  const t8_phex_t *q = (const t8_phex_t *) elem;
+  t8_phex_t   *n = (t8_phex_t *) neigh;
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (neigh));
-  T8_ASSERT (0 <= face && face < P8EST_FACES);
+  T8_ASSERT (0 <= face && face < T8_HEX_FACES);
   /* Compute the face neighbor */
-  p8est_quadrant_face_neighbor (q, face, n);
+  t8_hex_face_neighbor (q, face, n);
 
   /* Compute the face of q that coincides with face.
    * face   neigh_face    face      neigh_face
@@ -569,9 +570,9 @@ t8_default_scheme_hex_c::t8_element_face_neighbor_inside (const t8_element_t
    *   3        2
    */
   T8_ASSERT (neigh_face != NULL);
-  *neigh_face = p8est_face_dual[face];
+  *neigh_face = t8_hex_face_dual[face];
   /* return true if neigh is inside the root */
-  return p8est_quadrant_is_inside_root (n);
+  return t8_hex_is_inside_root (n);
 }
 
 void
@@ -580,10 +581,10 @@ t8_default_scheme_hex_c::t8_element_set_linear_id (t8_element_t *elem,
                                                    t8_linearidx_t id)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  T8_ASSERT (0 <= level && level <= P8EST_QMAXLEVEL);
-  T8_ASSERT (0 <= id && id < ((t8_linearidx_t) 1) << P8EST_DIM * level);
+  T8_ASSERT (0 <= level && level <= T8_HEX_QMAXLEVEL);
+  T8_ASSERT (0 <= id && id < ((t8_linearidx_t) 1) << T8_HEX_DIM * level);
 
-  p8est_quadrant_set_morton ((p8est_quadrant_t *) elem, level, id);
+  t8_hex_set_morton ((t8_phex_t *) elem, level, id);
 }
 
 t8_linearidx_t
@@ -591,9 +592,9 @@ t8_linearidx_t
                                                      int level)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  T8_ASSERT (0 <= level && level <= P8EST_QMAXLEVEL);
+  T8_ASSERT (0 <= level && level <= T8_HEX_QMAXLEVEL);
 
-  return p8est_quadrant_linear_id ((p8est_quadrant_t *) elem, level);
+  return t8_hex_linear_id ((t8_phex_t *) elem, level);
 }
 
 void
@@ -604,9 +605,9 @@ t8_default_scheme_hex_c::t8_element_first_descendant (const t8_element_t
 {
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (desc));
-  T8_ASSERT (0 <= level && level <= P8EST_QMAXLEVEL);
-  p8est_quadrant_first_descendant ((p8est_quadrant_t *) elem,
-                                   (p8est_quadrant_t *) desc, level);
+  T8_ASSERT (0 <= level && level <= T8_HEX_QMAXLEVEL);
+  t8_hex_first_descendant ((t8_phex_t *) elem,
+                                   (t8_phex_t *) desc, level);
 }
 
 void
@@ -616,9 +617,9 @@ t8_default_scheme_hex_c::t8_element_last_descendant (const t8_element_t *elem,
 {
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (desc));
-  T8_ASSERT (0 <= level && level <= P8EST_QMAXLEVEL);
-  p8est_quadrant_last_descendant ((p8est_quadrant_t *) elem,
-                                  (p8est_quadrant_t *) desc, level);
+  T8_ASSERT (0 <= level && level <= T8_HEX_QMAXLEVEL);
+  t8_hex_last_descendant ((t8_phex_t *) elem,
+                                  (t8_phex_t *) desc, level);
 }
 
 void
@@ -628,21 +629,21 @@ t8_default_scheme_hex_c::t8_element_successor (const t8_element_t *elem1,
   t8_linearidx_t      id;
   T8_ASSERT (t8_element_is_valid (elem1));
   T8_ASSERT (t8_element_is_valid (elem2));
-  T8_ASSERT (0 <= level && level <= P8EST_QMAXLEVEL);
+  T8_ASSERT (0 <= level && level <= T8_HEX_QMAXLEVEL);
 
-  id = p8est_quadrant_linear_id ((const p8est_quadrant_t *) elem1, level);
-  T8_ASSERT (id + 1 < ((t8_linearidx_t) 1) << P8EST_DIM * level);
-  p8est_quadrant_set_morton ((p8est_quadrant_t *) elem2, level, id + 1);
+  id = t8_hex_linear_id ((const t8_phex_t *) elem1, level);
+  T8_ASSERT (id + 1 < ((t8_linearidx_t) 1) << T8_HEX_DIM * level);
+  t8_hex_set_morton ((t8_phex_t *) elem2, level, id + 1);
 }
 
 void
 t8_default_scheme_hex_c::t8_element_anchor (const t8_element_t *elem,
                                             int coord[3])
 {
-  p8est_quadrant_t   *q;
+  t8_phex_t   *q;
 
   T8_ASSERT (t8_element_is_valid (elem));
-  q = (p8est_quadrant_t *) elem;
+  q = (t8_phex_t *) elem;
   coord[0] = q->x;
   coord[1] = q->y;
   coord[2] = q->z;
@@ -652,20 +653,20 @@ int
 t8_default_scheme_hex_c::t8_element_root_len (const t8_element_t *elem)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  return P8EST_ROOT_LEN;
+  return T8_HEX_ROOT_LEN;
 }
 
 void
 t8_default_scheme_hex_c::t8_element_vertex_coords (const t8_element_t *t,
                                                    int vertex, int coords[])
 {
-  const p8est_quadrant_t *q1 = (const p8est_quadrant_t *) t;
+  const t8_phex_t *q1 = (const t8_phex_t *) t;
   int                 len;
 
   T8_ASSERT (t8_element_is_valid (t));
   T8_ASSERT (0 <= vertex && vertex < 8);
   /* Get the length of the quadrant */
-  len = P8EST_QUADRANT_LEN (q1->level);
+  len = T8_HEX_LEN (q1->level);
   /* Compute the x, y and z coordinates of the vertex depending on the
    * vertex number */
   coords[0] = q1->x + (vertex & 1 ? 1 : 0) * len;
@@ -687,9 +688,9 @@ t8_default_scheme_hex_c::t8_element_vertex_reference_coords (const
 
   /* We divide the integer coordinates by the root length of the hex
    * to obtain the reference coordinates. */
-  coords[0] = coords_int[0] / (double) P8EST_ROOT_LEN;
-  coords[1] = coords_int[1] / (double) P8EST_ROOT_LEN;
-  coords[2] = coords_int[2] / (double) P8EST_ROOT_LEN;
+  coords[0] = coords_int[0] / (double) T8_HEX_ROOT_LEN;
+  coords[1] = coords_int[1] / (double) T8_HEX_ROOT_LEN;
+  coords[2] = coords_int[2] / (double) T8_HEX_ROOT_LEN;
 }
 
 void
@@ -704,7 +705,7 @@ t8_default_scheme_hex_c::t8_element_new (int length, t8_element_t **elem)
     int                 i;
     for (i = 0; i < length; i++) {
       t8_element_init (1, elem[i], 0);
-      T8_QUAD_SET_TDIM ((p8est_quadrant_t *) elem[i], 3);
+      T8_QUAD_SET_TDIM ((t8_phex_t *) elem[i], 3);
     }
   }
 #endif
@@ -717,11 +718,11 @@ t8_default_scheme_hex_c::t8_element_init (int length, t8_element_t *elem,
 #ifdef T8_ENABLE_DEBUG
   if (!new_called) {
     int                 i;
-    p8est_quadrant_t   *quads = (p8est_quadrant_t *) elem;
+    t8_phex_t   *quads = (t8_phex_t *) elem;
     for (i = 0; i < length; i++) {
-      p8est_quadrant_set_morton (quads + i, 0, 0);
+      t8_hex_set_morton (quads + i, 0, 0);
       T8_QUAD_SET_TDIM (quads + i, 3);
-      T8_ASSERT (p8est_quadrant_is_extended (quads + i));
+      T8_ASSERT (t8_hex_is_extended (quads + i));
     }
   }
 #endif
@@ -736,16 +737,16 @@ t8_default_scheme_hex_c::t8_element_is_valid (const t8_element_t *elem) const
 {
   /* TODO: additional checks? do we set pad8 or similar?
    */
-  return p8est_quadrant_is_extended ((const p8est_quadrant_t *) elem)
-    && T8_QUAD_GET_TDIM ((const p8est_quadrant_t *) elem) == 3;
+  return t8_hex_is_extended ((const t8_phex_t *) elem)
+    && T8_QUAD_GET_TDIM ((const t8_phex_t *) elem) == 3;
 }
 
 void
 t8_default_scheme_hex_c::t8_element_debug_print (const t8_element_t *elem) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  p8est_quadrant_t   *hex = (p8est_quadrant_t *) elem;
-  p8est_quadrant_print (SC_LP_DEBUG, hex);
+  t8_phex_t   *hex = (t8_phex_t *) elem;
+  t8_hex_print (SC_LP_DEBUG, hex);
 }
 #endif
 

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.cxx
@@ -26,6 +26,16 @@
 #include <t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.hxx>
 #include <t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx>
 
+static const int    t8_dhex_face_corners[6][4] = { {0, 2, 4, 6},
+{1, 3, 5, 7},
+{0, 1, 4, 5},
+{2, 3, 6, 7},
+{0, 1, 2, 3},
+{4, 5, 6, 7}
+};
+
+static const int    t8_dhex_face_dual[6] = { 1, 0, 3, 2, 5, 4 };
+
 /* We want to export the whole implementation to be callable from "C" */
 T8_EXTERN_C_BEGIN ();
 
@@ -69,7 +79,7 @@ t8_default_scheme_hex_c::t8_element_compare (const t8_element_t *elem1,
   T8_ASSERT (t8_element_is_valid (elem2));
 
   return t8_dhex_compare ((const t8_dhex_t *) elem1,
-                                 (const t8_dhex_t *) elem2);
+                          (const t8_dhex_t *) elem2);
 }
 
 void
@@ -78,8 +88,7 @@ t8_default_scheme_hex_c::t8_element_parent (const t8_element_t *elem,
 {
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (parent));
-  t8_dhex_parent ((const t8_dhex_t *) elem,
-                         (t8_dhex_t *) parent);
+  t8_dhex_parent ((const t8_dhex_t *) elem, (t8_dhex_t *) parent);
 }
 
 void
@@ -88,8 +97,7 @@ t8_default_scheme_hex_c::t8_element_sibling (const t8_element_t *elem,
 {
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (sibling));
-  t8_dhex_sibling ((const t8_dhex_t *) elem,
-                          (t8_dhex_t *) sibling, sibid);
+  t8_dhex_sibling ((const t8_dhex_t *) elem, (t8_dhex_t *) sibling, sibid);
 }
 
 int
@@ -136,9 +144,9 @@ void
 t8_default_scheme_hex_c::t8_element_child (const t8_element_t *elem,
                                            int childid, t8_element_t *child)
 {
-  const t8_dhex_t *q = (const t8_dhex_t *) elem;
-  const t8_qcoord_t shift = T8_DHEX_LEN (q->level + 1);
-  t8_dhex_t   *r = (t8_dhex_t *) child;
+  const t8_dhex_t    *q = (const t8_dhex_t *) elem;
+  const t8_qcoord_t   shift = T8_DHEX_LEN (q->level + 1);
+  t8_dhex_t          *r = (t8_dhex_t *) child;
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (child));
@@ -168,8 +176,7 @@ t8_default_scheme_hex_c::t8_element_children (const t8_element_t *elem,
 #endif
   T8_ASSERT (length == T8_DHEX_CHILDREN);
 
-  t8_dhex_childrenpv ((const t8_dhex_t *) elem,
-                             (t8_dhex_t **) c);
+  t8_dhex_childrenpv ((const t8_dhex_t *) elem, (t8_dhex_t **) c);
 }
 
 int
@@ -208,8 +215,8 @@ t8_default_scheme_hex_c::t8_element_nca (const t8_element_t *elem1,
   T8_ASSERT (t8_element_is_valid (elem1));
   T8_ASSERT (t8_element_is_valid (elem2));
   t8_dhex_nearest_common_ancestor ((const t8_dhex_t *) elem1,
-                                 (const t8_dhex_t *) elem2,
-                                 (t8_dhex_t *) nca);
+                                   (const t8_dhex_t *) elem2,
+                                   (t8_dhex_t *) nca);
 }
 
 t8_element_shape_t
@@ -328,7 +335,7 @@ t8_default_scheme_hex_c::t8_element_face_parent_face (const t8_element_t
                                                       *elem, int face)
 {
   int                 child_id;
-  const t8_dhex_t *q = (const t8_dhex_t *) elem;
+  const t8_dhex_t    *q = (const t8_dhex_t *) elem;
 
   T8_ASSERT (t8_element_is_valid (elem));
   if (q->level == 0) {
@@ -363,8 +370,8 @@ t8_default_scheme_hex_c::t8_element_extrude_face (const t8_element_t *face,
                                                   t8_element_t *elem,
                                                   int root_face)
 {
-  const t8_dquad_t *b = (const t8_dquad_t *) face;
-  t8_dhex_t   *q = (t8_dhex_t *) elem;
+  const t8_dquad_t   *b = (const t8_dquad_t *) face;
+  t8_dhex_t          *q = (t8_dhex_t *) elem;
 
   T8_ASSERT (T8_COMMON_IS_TYPE
              (face_scheme, const t8_default_scheme_quad_c *));
@@ -432,8 +439,8 @@ t8_default_scheme_hex_c::t8_element_first_descendant_face (const t8_element_t
                                                            *first_desc,
                                                            int level)
 {
-  const t8_dhex_t *q = (const t8_dhex_t *) elem;
-  t8_dhex_t   *desc = (t8_dhex_t *) first_desc;
+  const t8_dhex_t    *q = (const t8_dhex_t *) elem;
+  t8_dhex_t          *desc = (t8_dhex_t *) first_desc;
   int                 first_face_corner;
 
   T8_ASSERT (0 <= face && face < T8_DHEX_FACES);
@@ -453,8 +460,8 @@ t8_default_scheme_hex_c::t8_element_last_descendant_face (const t8_element_t
                                                           *last_desc,
                                                           int level)
 {
-  const t8_dhex_t *q = (const t8_dhex_t *) elem;
-  t8_dhex_t   *desc = (t8_dhex_t *) last_desc;
+  const t8_dhex_t    *q = (const t8_dhex_t *) elem;
+  t8_dhex_t          *desc = (t8_dhex_t *) last_desc;
   int                 last_face_corner;
 
   T8_ASSERT (0 <= face && face < T8_DHEX_FACES);
@@ -473,8 +480,8 @@ t8_default_scheme_hex_c::t8_element_boundary_face (const t8_element_t *elem,
                                                    const t8_eclass_scheme_c
                                                    *boundary_scheme)
 {
-  const t8_dhex_t *q = (const t8_dhex_t *) elem;
-  t8_dquad_t   *b = (t8_dquad_t *) boundary;
+  const t8_dhex_t    *q = (const t8_dhex_t *) elem;
+  t8_dquad_t         *b = (t8_dquad_t *) boundary;
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (T8_COMMON_IS_TYPE
@@ -503,8 +510,8 @@ t8_default_scheme_hex_c::t8_element_boundary_face (const t8_element_t *elem,
    * We have to scale the coordinates since a root quadrant may have
    * different length than a root hex.
    */
-  b->x = (face >> 1 ? q->x : q->y) * ((t8_linearidx_t) T8_DQUAD_ROOT_LEN / T8_DHEX_ROOT_LEN);        /* true if face >= 2 */
-  b->y = (face >> 2 ? q->y : q->z) * ((t8_linearidx_t) T8_DQUAD_ROOT_LEN / T8_DHEX_ROOT_LEN);        /* true if face >= 4 */
+  b->x = (face >> 1 ? q->x : q->y) * ((t8_linearidx_t) T8_DQUAD_ROOT_LEN / T8_DHEX_ROOT_LEN);   /* true if face >= 2 */
+  b->y = (face >> 2 ? q->y : q->z) * ((t8_linearidx_t) T8_DQUAD_ROOT_LEN / T8_DHEX_ROOT_LEN);   /* true if face >= 4 */
   T8_ASSERT (!t8_dhex_is_extended (q)
              || t8_dquad_is_extended (b));
 }
@@ -530,8 +537,8 @@ int
 t8_default_scheme_hex_c::t8_element_is_root_boundary (const t8_element_t
                                                       *elem, int face)
 {
-  const t8_dhex_t *q = (const t8_dhex_t *) elem;
-  t8_qcoord_t      coord;
+  const t8_dhex_t    *q = (const t8_dhex_t *) elem;
+  t8_qcoord_t         coord;
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (0 <= face && face < T8_DHEX_FACES);
@@ -553,8 +560,8 @@ t8_default_scheme_hex_c::t8_element_face_neighbor_inside (const t8_element_t
                                                           int face,
                                                           int *neigh_face)
 {
-  const t8_dhex_t *q = (const t8_dhex_t *) elem;
-  t8_dhex_t   *n = (t8_dhex_t *) neigh;
+  const t8_dhex_t    *q = (const t8_dhex_t *) elem;
+  t8_dhex_t          *n = (t8_dhex_t *) neigh;
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (neigh));
@@ -606,8 +613,7 @@ t8_default_scheme_hex_c::t8_element_first_descendant (const t8_element_t
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (desc));
   T8_ASSERT (0 <= level && level <= T8_DHEX_QMAXLEVEL);
-  t8_dhex_first_descendant ((t8_dhex_t *) elem,
-                                   (t8_dhex_t *) desc, level);
+  t8_dhex_first_descendant ((t8_dhex_t *) elem, (t8_dhex_t *) desc, level);
 }
 
 void
@@ -618,8 +624,7 @@ t8_default_scheme_hex_c::t8_element_last_descendant (const t8_element_t *elem,
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (desc));
   T8_ASSERT (0 <= level && level <= T8_DHEX_QMAXLEVEL);
-  t8_dhex_last_descendant ((t8_dhex_t *) elem,
-                                  (t8_dhex_t *) desc, level);
+  t8_dhex_last_descendant ((t8_dhex_t *) elem, (t8_dhex_t *) desc, level);
 }
 
 void
@@ -640,7 +645,7 @@ void
 t8_default_scheme_hex_c::t8_element_anchor (const t8_element_t *elem,
                                             int coord[3])
 {
-  t8_dhex_t   *q;
+  t8_dhex_t          *q;
 
   T8_ASSERT (t8_element_is_valid (elem));
   q = (t8_dhex_t *) elem;
@@ -660,7 +665,7 @@ void
 t8_default_scheme_hex_c::t8_element_vertex_coords (const t8_element_t *t,
                                                    int vertex, int coords[])
 {
-  const t8_dhex_t *q1 = (const t8_dhex_t *) t;
+  const t8_dhex_t    *q1 = (const t8_dhex_t *) t;
   int                 len;
 
   T8_ASSERT (t8_element_is_valid (t));
@@ -717,7 +722,7 @@ t8_default_scheme_hex_c::t8_element_init (int length, t8_element_t *elem,
 #ifdef T8_ENABLE_DEBUG
   if (!new_called) {
     int                 i;
-    t8_dhex_t   *quads = (t8_dhex_t *) elem;
+    t8_dhex_t          *quads = (t8_dhex_t *) elem;
     for (i = 0; i < length; i++) {
       t8_dhex_set_morton (quads + i, 0, 0);
       T8_ASSERT (t8_dhex_is_extended (quads + i));
@@ -741,7 +746,7 @@ void
 t8_default_scheme_hex_c::t8_element_debug_print (const t8_element_t *elem) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  t8_dhex_t   *hex = (t8_dhex_t *) elem;
+  t8_dhex_t          *hex = (t8_dhex_t *) elem;
   t8_dhex_print (SC_LP_DEBUG, hex);
 }
 #endif

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
@@ -26,15 +26,8 @@
 #ifndef T8_DEFAULT_HEX_HXX
 #define T8_DEFAULT_HEX_HXX
 
-#include <p8est.h>
 #include <t8_element_cxx.hxx>
 #include <t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx>
-
-/** The structure holding a hexahedral element in the default scheme.
- * We make this definition public for interoperability of element classes.
- * We might want to put this into a private, scheme-specific header file.
- */
-typedef p8est_quadrant_t t8_phex_t;
 
 struct t8_default_scheme_hex_c:public t8_default_scheme_common_c
 {

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_default_hex_cxx.hxx
@@ -48,31 +48,31 @@ public:
   virtual void        t8_element_init (int length, t8_element_t *elem,
                                        int called_new);
 
-/** Return the maximum level allowed for this element class. */
+  /** Return the maximum level allowed for this element class. */
   virtual int         t8_element_maxlevel (void);
 
-/** Return the type of each child in the ordering of the implementation. */
+  /** Return the type of each child in the ordering of the implementation. */
   virtual t8_eclass_t t8_element_child_eclass (int childid);
 
-/** Return the refinement level of an element. */
+  /** Return the refinement level of an element. */
   virtual int         t8_element_level (const t8_element_t *elem);
 
-/** Copy one element to another */
+  /** Copy one element to another */
   virtual void        t8_element_copy (const t8_element_t *source,
                                        t8_element_t *dest);
 
-/** Compare to elements. returns negativ if elem1 < elem2, zero if elem1 equals elem2
- *  and positiv if elem1 > elem2.
- *  If elem2 is a copy of elem1 then the elements are equal.
- */
+  /** Compare to elements. returns negativ if elem1 < elem2, zero if elem1 equals elem2
+   *  and positiv if elem1 > elem2.
+   *  If elem2 is a copy of elem1 then the elements are equal.
+   */
   virtual int         t8_element_compare (const t8_element_t *elem1,
                                           const t8_element_t *elem2);
 
-/** Construct the parent of a given element. */
+  /** Construct the parent of a given element. */
   virtual void        t8_element_parent (const t8_element_t *elem,
                                          t8_element_t *parent);
 
-/** Construct a same-size sibling of a given element. */
+  /** Construct a same-size sibling of a given element. */
   virtual void        t8_element_sibling (const t8_element_t *elem,
                                           int sibid, t8_element_t *sibling);
 
@@ -104,25 +104,25 @@ public:
     return 0;                   /* prevents compiler warning */
   }
 
-/** Construct the child element of a given number. */
+  /** Construct the child element of a given number. */
   virtual void        t8_element_child (const t8_element_t *elem,
                                         int childid, t8_element_t *child);
 
-/** Construct all children of a given element. */
+  /** Construct all children of a given element. */
   virtual void        t8_element_children (const t8_element_t *elem,
                                            int length, t8_element_t *c[]);
 
-/** Return the child id of an element */
+  /** Return the child id of an element */
   virtual int         t8_element_child_id (const t8_element_t *elem);
 
   /** Compute the ancestor id of an element */
   virtual int         t8_element_ancestor_id (const t8_element_t *elem,
                                               int level);
 
-/** Return nonzero if collection of elements is a family */
+  /** Return nonzero if collection of elements is a family */
   virtual int         t8_element_is_family (t8_element_t **fam);
 
-/** Construct the nearest common ancestor of two elements in the same tree. */
+  /** Construct the nearest common ancestor of two elements in the same tree. */
   virtual void        t8_element_nca (const t8_element_t *elem1,
                                       const t8_element_t *elem2,
                                       t8_element_t *nca);
@@ -196,7 +196,7 @@ public:
                                                 const t8_eclass_scheme_c
                                                 *boundary_scheme);
 
-/** Construct all codimension-one boundary elements of a given element. */
+  /** Construct all codimension-one boundary elements of a given element. */
   virtual void        t8_element_boundary (const t8_element_t *elem,
                                            int min_dim, int length,
                                            t8_element_t **boundary);
@@ -217,40 +217,40 @@ public:
                                                        int face,
                                                        int *neigh_face);
 
-/** Initialize an element according to a given linear id */
+  /** Initialize an element according to a given linear id */
   virtual void        t8_element_set_linear_id (t8_element_t *elem,
                                                 int level, t8_linearidx_t id);
 
-/** Calculate the linear id of an element */
+  /** Calculate the linear id of an element */
   virtual t8_linearidx_t t8_element_get_linear_id (const
                                                    t8_element_t *elem,
                                                    int level);
 
-/** Calculate the first descendant of a given element e. That is, the
- *  first element in a uniform refinement of e of the maximal possible level.
- */
+  /** Calculate the first descendant of a given element e. That is, the
+   *  first element in a uniform refinement of e of the maximal possible level.
+   */
   virtual void        t8_element_first_descendant (const t8_element_t *elem,
                                                    t8_element_t *desc,
                                                    int level);
 
-/** Calculate the last descendant of a given element e. That is, the
- *  last element in a uniform refinement of e of the maximal possible level.
- */
+  /** Calculate the last descendant of a given element e. That is, the
+   *  last element in a uniform refinement of e of the maximal possible level.
+   */
   virtual void        t8_element_last_descendant (const t8_element_t *elem,
                                                   t8_element_t *desc,
                                                   int level);
 
-/** Compute s as a successor of t*/
+  /** Compute s as a successor of t*/
   virtual void        t8_element_successor (const t8_element_t *t,
                                             t8_element_t *s, int level);
 
-/** Get the integer coordinates of the anchor node of an element */
+  /** Get the integer coordinates of the anchor node of an element */
   virtual void        t8_element_anchor (const t8_element_t *elem,
                                          int anchor[3]);
 
-/** Get the integer root length of an element, that is the length of
- *  the level 0 ancestor.
- */
+  /** Get the integer root length of an element, that is the length of
+   *  the level 0 ancestor.
+   */
   virtual int         t8_element_root_len (const t8_element_t *elem);
 
   /** Compute the integer coordinates of a given element vertex. */

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_dhex.h
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_dhex.h
@@ -1,0 +1,40 @@
+#ifndef T8_DHEX_H
+#define T8_DHEX_H
+
+#include <t8.h>
+
+#define T8_HEX_QMAXLEVEL 18
+
+#define T8_HEX_MAXLEVEL 19
+
+#define T8_HEX_ROOT_LEN ((t8_qcoord_t) 1 << T8_HEX_MAXLEVEL)
+
+#define T8_HEX_CHILDREN 8
+
+#define T8_HEX_DIM 3
+
+#define T8_HEX_FACES (2 * T8_HEX_DIM)
+
+#define T8_HEX_LEN(l) ((t8_qcoord_t) 1 << (T8_HEX_MAXLEVEL - (l)))
+
+#define T8_HEX_LAST_OFFSET(l) (T8_HEX_ROOT_LEN - T8_HEX_LEN (l))
+
+static const int t8_hex_face_corners[6][4] =
+{{ 0, 2, 4, 6 },
+ { 1, 3, 5, 7 },
+ { 0, 1, 4, 5 },
+ { 2, 3, 6, 7 },
+ { 0, 1, 2, 3 },
+ { 4, 5, 6, 7 }};
+
+static const int t8_hex_face_dual[6] = { 1, 0, 3, 2, 5, 4 };
+
+typedef struct t8_dhex
+{
+  t8_qcoord_t         x, y, z;  /**< coordinates */
+  int8_t              level;    /**< level of refinement */
+  int8_t              pad8;     /**< padding */
+}
+t8_phex_t;
+
+#endif

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_dhex.h
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_dhex.h
@@ -1,34 +1,57 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element classes in parallel.
+
+  Copyright (C) 2015 the developers
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+/** \file t8_dhex.h */
+
 #ifndef T8_DHEX_H
 #define T8_DHEX_H
 
 #include <t8.h>
 
+/** Spatial dimension of a hexahedron. */
 #define T8_DHEX_DIM 3
 
+/** The number of children that a hexahedron is refined into. */
 #define T8_DHEX_CHILDREN 8
 
+/** The maximum refinement level allowed for a node within a hexahedron. */
 #define T8_DHEX_MAXLEVEL 19
 
+/** The maximum refinement level allowed for a hexahedron. */
 #define T8_DHEX_QMAXLEVEL 18
 
+/** The number of faces of a hexahedron. */
 #define T8_DHEX_FACES (2 * T8_DHEX_DIM)
 
+/** The length of the root hexahedron in integer coordinates. */
 #define T8_DHEX_ROOT_LEN ((t8_qcoord_t) 1 << T8_DHEX_MAXLEVEL)
 
+/** The length of a hexahedron at a given level in integer coordinates. */
 #define T8_DHEX_LEN(l) ((t8_qcoord_t) 1 << (T8_DHEX_MAXLEVEL - (l)))
 
+/** The offset of the highest (farthest from the origin) hexahedron at level l. */
 #define T8_DHEX_LAST_OFFSET(l) (T8_DHEX_ROOT_LEN - T8_DHEX_LEN (l))
 
-static const int t8_dhex_face_corners[6][4] =
-{{ 0, 2, 4, 6 },
- { 1, 3, 5, 7 },
- { 0, 1, 4, 5 },
- { 2, 3, 6, 7 },
- { 0, 1, 2, 3 },
- { 4, 5, 6, 7 }};
-
-static const int t8_dhex_face_dual[6] = { 1, 0, 3, 2, 5, 4 };
-
+/** This data type encodes a hexahedron. */
 typedef struct t8_dhex
 {
   t8_qcoord_t         x, y, z;
@@ -36,4 +59,4 @@ typedef struct t8_dhex
 }
 t8_dhex_t;
 
-#endif
+#endif /* T8_DHEX_H */

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_dhex.h
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_dhex.h
@@ -3,23 +3,23 @@
 
 #include <t8.h>
 
-#define T8_HEX_QMAXLEVEL 18
+#define T8_DHEX_DIM 3
 
-#define T8_HEX_MAXLEVEL 19
+#define T8_DHEX_CHILDREN 8
 
-#define T8_HEX_ROOT_LEN ((t8_qcoord_t) 1 << T8_HEX_MAXLEVEL)
+#define T8_DHEX_MAXLEVEL 19
 
-#define T8_HEX_CHILDREN 8
+#define T8_DHEX_QMAXLEVEL 18
 
-#define T8_HEX_DIM 3
+#define T8_DHEX_FACES (2 * T8_DHEX_DIM)
 
-#define T8_HEX_FACES (2 * T8_HEX_DIM)
+#define T8_DHEX_ROOT_LEN ((t8_qcoord_t) 1 << T8_DHEX_MAXLEVEL)
 
-#define T8_HEX_LEN(l) ((t8_qcoord_t) 1 << (T8_HEX_MAXLEVEL - (l)))
+#define T8_DHEX_LEN(l) ((t8_qcoord_t) 1 << (T8_DHEX_MAXLEVEL - (l)))
 
-#define T8_HEX_LAST_OFFSET(l) (T8_HEX_ROOT_LEN - T8_HEX_LEN (l))
+#define T8_DHEX_LAST_OFFSET(l) (T8_DHEX_ROOT_LEN - T8_DHEX_LEN (l))
 
-static const int t8_hex_face_corners[6][4] =
+static const int t8_dhex_face_corners[6][4] =
 {{ 0, 2, 4, 6 },
  { 1, 3, 5, 7 },
  { 0, 1, 4, 5 },
@@ -27,14 +27,13 @@ static const int t8_hex_face_corners[6][4] =
  { 0, 1, 2, 3 },
  { 4, 5, 6, 7 }};
 
-static const int t8_hex_face_dual[6] = { 1, 0, 3, 2, 5, 4 };
+static const int t8_dhex_face_dual[6] = { 1, 0, 3, 2, 5, 4 };
 
 typedef struct t8_dhex
 {
-  t8_qcoord_t         x, y, z;  /**< coordinates */
-  int8_t              level;    /**< level of refinement */
-  int8_t              pad8;     /**< padding */
+  t8_qcoord_t         x, y, z;
+  int8_t              level;
 }
-t8_phex_t;
+t8_dhex_t;
 
 #endif

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.c
@@ -1,0 +1,2 @@
+#define T8_QUAD_TO_HEX 1
+#include <t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.c>

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.c
@@ -1,2 +1,2 @@
-#define T8_QUAD_TO_HEX 1
+#define T8_DQUAD_TO_DHEX 1
 #include <t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.c>

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.h
@@ -1,3 +1,28 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element classes in parallel.
+
+  Copyright (C) 2015 the developers
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+/** \file t8_dhex_bits.h
+ */
+
 #ifndef T8_DHEX_BITS_H
 #define T8_DHEX_BITS_H
 
@@ -6,64 +31,173 @@
 
 T8_EXTERN_C_BEGIN ();
 
+/** Compute the parent of given hexaeder.
+ * \param [in]  q Input hexaeder.
+ * \param [in,out] r Existing hexaeder whose Morton index will be filled
+ *                   with the Morton index of the parent of \a q.
+ */
 void t8_dhex_parent (const t8_dhex_t * q, t8_dhex_t * r);
 
-void t8_dhex_sibling (const t8_dhex_t * q, t8_dhex_t * r, int sibling_id);
+/** Compute the specified sibling of given hexaeder.
+ * \param [in]     q  Input hexaeder.
+ * \param [in,out] r  Existing hexaeder whose Morton index will be filled
+ *                    with the coordinates of specified sibling.
+ * \param [in]     sibling_id The id of the sibling computed: 0,...,7.
+ */
+void t8_dhex_sibling (const t8_dhex_t * q, t8_dhex_t * r,
+                                      int sibling_id);
 
+/** Compare two hexaeders with respect to their Morton ordering.
+ * \return < 0 if \a v1 < \a v2,
+ *           0 if \a v1 == \a v2,
+ *         > 0 if \a v1 > \a v2
+ */
 int t8_dhex_compare (const void *v1, const void *v2);
 
+/** Test if a hexaeder has valid Morton indices
+ * in the 3x3x3 box around root.
+ * \param [in] q Quadrant to be tested.
+ * \return True if \a q is extended.
+ */
 int t8_dhex_is_extended (const t8_dhex_t * q);
 
+/** Test if a hexaeder is parent of another hexaeder.
+ * \param [in] q Quadrant to be tested.
+ * \param [in] r Possible child hexaeder.
+ * \return true if \a q is the parent of \a r.
+ */
 int t8_dhex_is_parent (const t8_dhex_t * q, const t8_dhex_t * r);
 
+/** Compute the eight children of a hexaeder, array version.
+ * \param [in]     q  Input hexaeder.
+ * \param [in,out] c  Pointers to the eight computed children in z-order.
+ *                    q may point to the same hexaeder as c[0].
+ * \note The user_data of c[i] is never modified.
+ */
 void t8_dhex_childrenpv (const t8_dhex_t * q, t8_dhex_t * c[]);
 
+/** Compute the position of this child within its siblings.
+ * \return Child id: 0,...,7
+ */
 int t8_dhex_child_id (const t8_dhex_t * q);
 
+/** Compute the position of the ancestor of this child at
+ * level \a level within its siblings.
+ * \return Child id: 0,...,7
+ */
 int t8_dhex_ancestor_id (const t8_dhex_t * q, int level);
 
+/** Test if eight hexaeders are siblings in Morton ordering, array version.
+ * \param [in] q   Array of eight pointers to hexaeders.
+ */
 int t8_dhex_is_familypv (t8_dhex_t * q[]);
 
-void t8_dhex_set_morton (t8_dhex_t * quadrant, int level, uint64_t id);
+/** Set hexaeder Morton indices based on linear position in uniform grid.
+ * \param [in,out] q         Quadrant whose Morton indices will be set.
+ * \param [in]     level     Level of the grid and of the resulting hexaeder.
+ * \param [in]     id        Linear index of the hexaeder on a uniform grid.
+ */
+void t8_dhex_set_morton (t8_dhex_t * q, int level, uint64_t id);
 
-uint64_t t8_dhex_linear_id (const t8_dhex_t * quadrant, int level);
+/** Computes the linear position of a hexaeder in a uniform grid.
+ * \param [in] q         Quadrant whose linear index will be computed.
+ * \param [in] level     The level of the regular grid compared to which the
+ *                       linear position is to be computed.
+ * \return               Linear position of this hexaeder on a grid.
+ * \note                 If the hexaeder is smaller than the grid (has a higher
+ *                       hexaeder->level), the result is computed from its
+ *                       ancestor at the grid's level.
+ *                       If the hexaeder has a smaller level than the grid (it
+ *                       is bigger than a grid cell), the grid cell sharing its
+ *                       lower left corner is used as reference.
+ */
+uint64_t t8_dhex_linear_id (const t8_dhex_t * q, int level);
 
+/** Compute the first descendant of a given hexaeder on a given level.
+ * \param [in]  q      Input hexaeder.
+ * \param [out] fd     First descendant of \a q on level \a level.
+ * \param [in]  level  Level must be greater equal than q's level.
+ */
 void t8_dhex_first_descendant (const t8_dhex_t * q, t8_dhex_t * fd, int level);
 
+/** Computes the nearest common ancestor of two hexaeders in the same tree.
+ * \param [in]     q1 First input hexaeder.
+ * \param [in]     q2 Second input hexaeder.
+ * \param [in,out] r Existing hexaeder whose Morton index will be filled.
+ * \note \a q1, \a q2, \a r may point to the same hexaeder.
+ */
 void t8_dhex_nearest_common_ancestor (const t8_dhex_t * q1, const t8_dhex_t * q2, t8_dhex_t * r);
 
+/** Compute the descendant of a hexaeder touching a given corner.
+ * \param [in]     q   Input hexaeder.
+ * \param [in,out] r   Existing hexaeder whose Morton index will be filled.
+ * \param [in]     c   The corner of \a q that \a r touches.
+ * \param [in] level   The size of \a r.
+ */
 void t8_dhex_corner_descendant (const t8_dhex_t * q, t8_dhex_t * r, int c, int level);
 
+/** Compute the face neighbor of a hexaeder.
+ * \param [in]     q      Input hexaeder, must be valid.
+ * \param [in]     face   The face across which to generate the neighbor.
+ * \param [in,out] r      Existing hexaeder whose Morton index will be filled.
+ * \note \a q may point to the same hexaeder as \a r.
+ */
 void t8_dhex_face_neighbor (const t8_dhex_t * q, int face, t8_dhex_t * r);
 
+/** Test if a hexaeder is inside the unit tree.
+ * \param [in] q Quadrant to be tested.
+ * \return True if \a q is inside the unit tree.
+ */
 int t8_dhex_is_inside_root (const t8_dhex_t * q);
 
+/** Prints one line with x, y and level of the hexaeder.
+ * \param [in] log_priority  See \ref logpriorities in sc.h.
+ * \param [in] q             Puadrant to print.
+ */
 void t8_dhex_print (int log_priority, const t8_dhex_t * q);
 
+/** Compute the last descendant of a hexaeder on a given level.
+ * \param [in]  q      Input hexaeder.
+ * \param [out] ld     Last descendant of \a q on level \a level.
+ * \param [in]  level  Level must be greater equal than q's level.
+ */
 void t8_dhex_last_descendant (const t8_dhex_t * q, t8_dhex_t * ld, int level);
 
+/** Test if a hexaeder is used to represent a mesh node.
+ * \param [in] q        Quadrant to be tested.
+ * \param [in] inside   If true, boundary nodes must be clamped inside.
+ *                      If false, nodes must align with the hexaeder grid.
+ * \return True if \a q is a node.
+ */
 int t8_dhex_is_node (const t8_dhex_t * q, int inside);
 
-int t8_dhex_is_inside_3x3 (const t8_dhex_t * q);
-
+/** Test if a hexaeder has valid Morton indices and is inside the unit tree.
+ * \param [in] q Quadrant to be tested.
+ * \return True if \a q is valid.
+ */
 int t8_dhex_is_valid (const t8_dhex_t * q);
 
-int t8_dhex_is_family (    const t8_dhex_t * q0,
-                          const t8_dhex_t * q1,
-                          const t8_dhex_t * q2,
-                          const t8_dhex_t * q3,
-                          const t8_dhex_t * q4,
-                          const t8_dhex_t * q5,
-                          const t8_dhex_t * q6,
-                          const t8_dhex_t * q7);
+/** Test if eight hexaeders are siblings in Morton ordering.
+ */
+int t8_dhex_is_family (const t8_dhex_t * q0,
+                       const t8_dhex_t * q1,
+                       const t8_dhex_t * q2,
+                       const t8_dhex_t * q3,
+                       const t8_dhex_t * q4,
+                       const t8_dhex_t * q5,
+                       const t8_dhex_t * q6,
+                       const t8_dhex_t * q7);
 
-void
-t8_dhex_children (const t8_dhex_t * q,
-                         t8_dhex_t * c0, t8_dhex_t * c1,
-                         t8_dhex_t * c2, t8_dhex_t * c3,
-                         t8_dhex_t * c4, t8_dhex_t * c5,
-                         t8_dhex_t * c6, t8_dhex_t * c7
-);
+/** Compute the eight children of a hexaeder.
+ * \param [in]     q  Input hexaeder.
+ * \param [in,out] c0 First computed child.
+ * \note  \a c0 may point to the same hexaeder as \a q.
+ */
+void t8_dhex_children (const t8_dhex_t * q,
+                    t8_dhex_t * c0, t8_dhex_t * c1,
+                    t8_dhex_t * c2, t8_dhex_t * c3,
+                    t8_dhex_t * c4, t8_dhex_t * c5,
+                    t8_dhex_t * c6, t8_dhex_t * c7);
 
 T8_EXTERN_C_END ();
 

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.h
@@ -6,63 +6,63 @@
 
 T8_EXTERN_C_BEGIN ();
 
-void t8_hex_parent (const t8_phex_t * q, t8_phex_t * r);
+void t8_dhex_parent (const t8_dhex_t * q, t8_dhex_t * r);
 
-void t8_hex_sibling (const t8_phex_t * q, t8_phex_t * r, int sibling_id);
+void t8_dhex_sibling (const t8_dhex_t * q, t8_dhex_t * r, int sibling_id);
 
-int t8_hex_compare (const void *v1, const void *v2);
+int t8_dhex_compare (const void *v1, const void *v2);
 
-int t8_hex_is_extended (const t8_phex_t * q);
+int t8_dhex_is_extended (const t8_dhex_t * q);
 
-int t8_hex_is_parent (const t8_phex_t * q, const t8_phex_t * r);
+int t8_dhex_is_parent (const t8_dhex_t * q, const t8_dhex_t * r);
 
-void t8_hex_childrenpv (const t8_phex_t * q, t8_phex_t * c[]);
+void t8_dhex_childrenpv (const t8_dhex_t * q, t8_dhex_t * c[]);
 
-int t8_hex_child_id (const t8_phex_t * q);
+int t8_dhex_child_id (const t8_dhex_t * q);
 
-int t8_hex_ancestor_id (const t8_phex_t * q, int level);
+int t8_dhex_ancestor_id (const t8_dhex_t * q, int level);
 
-int t8_hex_is_familypv (t8_phex_t * q[]);
+int t8_dhex_is_familypv (t8_dhex_t * q[]);
 
-void t8_hex_set_morton (t8_phex_t * quadrant, int level, uint64_t id);
+void t8_dhex_set_morton (t8_dhex_t * quadrant, int level, uint64_t id);
 
-uint64_t t8_hex_linear_id (const t8_phex_t * quadrant, int level);
+uint64_t t8_dhex_linear_id (const t8_dhex_t * quadrant, int level);
 
-void t8_hex_first_descendant (const t8_phex_t * q, t8_phex_t * fd, int level);
+void t8_dhex_first_descendant (const t8_dhex_t * q, t8_dhex_t * fd, int level);
 
-void t8_hex_nearest_common_ancestor (const t8_phex_t * q1, const t8_phex_t * q2, t8_phex_t * r);
+void t8_dhex_nearest_common_ancestor (const t8_dhex_t * q1, const t8_dhex_t * q2, t8_dhex_t * r);
 
-void t8_hex_corner_descendant (const t8_phex_t * q, t8_phex_t * r, int c, int level);
+void t8_dhex_corner_descendant (const t8_dhex_t * q, t8_dhex_t * r, int c, int level);
 
-void t8_hex_face_neighbor (const t8_phex_t * q, int face, t8_phex_t * r);
+void t8_dhex_face_neighbor (const t8_dhex_t * q, int face, t8_dhex_t * r);
 
-int t8_hex_is_inside_root (const t8_phex_t * q);
+int t8_dhex_is_inside_root (const t8_dhex_t * q);
 
-void t8_hex_print (int log_priority, const t8_phex_t * q);
+void t8_dhex_print (int log_priority, const t8_dhex_t * q);
 
-void t8_hex_last_descendant (const t8_phex_t * q, t8_phex_t * ld, int level);
+void t8_dhex_last_descendant (const t8_dhex_t * q, t8_dhex_t * ld, int level);
 
-int t8_hex_is_node (const t8_phex_t * q, int inside);
+int t8_dhex_is_node (const t8_dhex_t * q, int inside);
 
-int t8_hex_is_inside_3x3 (const t8_phex_t * q);
+int t8_dhex_is_inside_3x3 (const t8_dhex_t * q);
 
-int t8_hex_is_valid (const t8_phex_t * q);
+int t8_dhex_is_valid (const t8_dhex_t * q);
 
-int t8_hex_is_family (    const t8_phex_t * q0,
-                          const t8_phex_t * q1,
-                          const t8_phex_t * q2,
-                          const t8_phex_t * q3,
-                          const t8_phex_t * q4,
-                          const t8_phex_t * q5,
-                          const t8_phex_t * q6,
-                          const t8_phex_t * q7);
+int t8_dhex_is_family (    const t8_dhex_t * q0,
+                          const t8_dhex_t * q1,
+                          const t8_dhex_t * q2,
+                          const t8_dhex_t * q3,
+                          const t8_dhex_t * q4,
+                          const t8_dhex_t * q5,
+                          const t8_dhex_t * q6,
+                          const t8_dhex_t * q7);
 
 void
-t8_hex_children (const t8_phex_t * q,
-                         t8_phex_t * c0, t8_phex_t * c1,
-                         t8_phex_t * c2, t8_phex_t * c3,
-                         t8_phex_t * c4, t8_phex_t * c5,
-                         t8_phex_t * c6, t8_phex_t * c7
+t8_dhex_children (const t8_dhex_t * q,
+                         t8_dhex_t * c0, t8_dhex_t * c1,
+                         t8_dhex_t * c2, t8_dhex_t * c3,
+                         t8_dhex_t * c4, t8_dhex_t * c5,
+                         t8_dhex_t * c6, t8_dhex_t * c7
 );
 
 T8_EXTERN_C_END ();

--- a/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.h
@@ -1,0 +1,70 @@
+#ifndef T8_DHEX_BITS_H
+#define T8_DHEX_BITS_H
+
+#include <t8.h>
+#include <t8_schemes/t8_default/t8_default_hex/t8_dhex.h>
+
+T8_EXTERN_C_BEGIN ();
+
+void t8_hex_parent (const t8_phex_t * q, t8_phex_t * r);
+
+void t8_hex_sibling (const t8_phex_t * q, t8_phex_t * r, int sibling_id);
+
+int t8_hex_compare (const void *v1, const void *v2);
+
+int t8_hex_is_extended (const t8_phex_t * q);
+
+int t8_hex_is_parent (const t8_phex_t * q, const t8_phex_t * r);
+
+void t8_hex_childrenpv (const t8_phex_t * q, t8_phex_t * c[]);
+
+int t8_hex_child_id (const t8_phex_t * q);
+
+int t8_hex_ancestor_id (const t8_phex_t * q, int level);
+
+int t8_hex_is_familypv (t8_phex_t * q[]);
+
+void t8_hex_set_morton (t8_phex_t * quadrant, int level, uint64_t id);
+
+uint64_t t8_hex_linear_id (const t8_phex_t * quadrant, int level);
+
+void t8_hex_first_descendant (const t8_phex_t * q, t8_phex_t * fd, int level);
+
+void t8_hex_nearest_common_ancestor (const t8_phex_t * q1, const t8_phex_t * q2, t8_phex_t * r);
+
+void t8_hex_corner_descendant (const t8_phex_t * q, t8_phex_t * r, int c, int level);
+
+void t8_hex_face_neighbor (const t8_phex_t * q, int face, t8_phex_t * r);
+
+int t8_hex_is_inside_root (const t8_phex_t * q);
+
+void t8_hex_print (int log_priority, const t8_phex_t * q);
+
+void t8_hex_last_descendant (const t8_phex_t * q, t8_phex_t * ld, int level);
+
+int t8_hex_is_node (const t8_phex_t * q, int inside);
+
+int t8_hex_is_inside_3x3 (const t8_phex_t * q);
+
+int t8_hex_is_valid (const t8_phex_t * q);
+
+int t8_hex_is_family (    const t8_phex_t * q0,
+                          const t8_phex_t * q1,
+                          const t8_phex_t * q2,
+                          const t8_phex_t * q3,
+                          const t8_phex_t * q4,
+                          const t8_phex_t * q5,
+                          const t8_phex_t * q6,
+                          const t8_phex_t * q7);
+
+void
+t8_hex_children (const t8_phex_t * q,
+                         t8_phex_t * c0, t8_phex_t * c1,
+                         t8_phex_t * c2, t8_phex_t * c3,
+                         t8_phex_t * c4, t8_phex_t * c5,
+                         t8_phex_t * c6, t8_phex_t * c7
+);
+
+T8_EXTERN_C_END ();
+
+#endif

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism.h
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism.h
@@ -30,6 +30,7 @@
 #include <t8.h>
 #include <t8_schemes/t8_default/t8_default_line/t8_dline.h>
 #include <t8_schemes/t8_default/t8_default_tri/t8_dtri.h>
+#include <t8_schemes/t8_default/t8_default_quad/t8_dquad.h>
 
 /** The number of children that a prism is refined into. */
 #define T8_DPRISM_CHILDREN 8
@@ -51,7 +52,7 @@
 
 /** The length of a prism divided by the length of a Quad.
  *  This is useful to convert boundary coordinates from prism to quad. */
-#define T8_DPRISM_ROOT_BY_QUAD_ROOT (1 << (P4EST_QMAXLEVEL - T8_DPRISM_MAXLEVEL))
+#define T8_DPRISM_ROOT_BY_QUAD_ROOT (1 << (T8_QUAD_QMAXLEVEL - T8_DPRISM_MAXLEVEL))
 
 /** The length of a prism divided by the length of a triangle.
  *  This is useful to convert boundary coordinates from prism to triangle. */

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
@@ -203,7 +203,7 @@ t8_dprism_boundary_face (const t8_dprism_t *p, int face,
                          t8_element_t *boundary)
 {
   T8_ASSERT (0 <= face && face < T8_DPRISM_FACES);
-  t8_dquad_t   *q = (t8_dquad_t *) boundary;
+  t8_dquad_t         *q = (t8_dquad_t *) boundary;
   if (face >= 3) {
     t8_dtri_t          *t = (t8_dtri_t *) boundary;
     t8_dtri_copy (&p->tri, t);
@@ -415,7 +415,7 @@ t8_dprism_extrude_face (const t8_element_t *face,
 {
   t8_dprism_t        *p = (t8_dprism_t *) elem;
   const t8_dtri_t    *t = (const t8_dtri_t *) face;
-  const t8_dquad_t *q = (const t8_dquad_t *) face;
+  const t8_dquad_t   *q = (const t8_dquad_t *) face;
   T8_ASSERT (0 <= root_face && root_face < T8_DPRISM_FACES);
   switch (root_face) {
   case 0:

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
@@ -20,11 +20,11 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
 
-#include <p4est_bits.h>
 #include <sc_functions.h>
 #include <t8_schemes/t8_default/t8_default_line/t8_dline_bits.h>
 #include <t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.h>
 #include <t8_schemes/t8_default/t8_default_tri/t8_dtri_bits.h>
+#include <t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.h>
 
 int                 t8_dprism_face_corners[5][4] = {
   {1, 2, 4, 5},
@@ -203,7 +203,7 @@ t8_dprism_boundary_face (const t8_dprism_t *p, int face,
                          t8_element_t *boundary)
 {
   T8_ASSERT (0 <= face && face < T8_DPRISM_FACES);
-  p4est_quadrant_t   *q = (p4est_quadrant_t *) boundary;
+  t8_pquad_t   *q = (t8_pquad_t *) boundary;
   if (face >= 3) {
     t8_dtri_t          *t = (t8_dtri_t *) boundary;
     t8_dtri_copy (&p->tri, t);
@@ -211,18 +211,18 @@ t8_dprism_boundary_face (const t8_dprism_t *p, int face,
   }
   switch (face) {
   case 0:
-    q->x = ((int64_t) p->tri.y * P4EST_ROOT_LEN) / T8_DTRI_ROOT_LEN;
-    q->y = ((int64_t) p->line.x * P4EST_ROOT_LEN) / T8_DLINE_ROOT_LEN;
+    q->x = ((int64_t) p->tri.y * T8_QUAD_ROOT_LEN) / T8_DTRI_ROOT_LEN;
+    q->y = ((int64_t) p->line.x * T8_QUAD_ROOT_LEN) / T8_DLINE_ROOT_LEN;
     q->level = p->tri.level;
     break;
   case 1:
-    q->x = ((int64_t) p->tri.x * P4EST_ROOT_LEN) / T8_DTRI_ROOT_LEN;
-    q->y = ((int64_t) p->line.x * P4EST_ROOT_LEN) / T8_DLINE_ROOT_LEN;
+    q->x = ((int64_t) p->tri.x * T8_QUAD_ROOT_LEN) / T8_DTRI_ROOT_LEN;
+    q->y = ((int64_t) p->line.x * T8_QUAD_ROOT_LEN) / T8_DLINE_ROOT_LEN;
     q->level = p->tri.level;
     break;
   case 2:
-    q->x = ((int64_t) p->tri.x * P4EST_ROOT_LEN) / T8_DTRI_ROOT_LEN;
-    q->y = ((int64_t) p->line.x * P4EST_ROOT_LEN) / T8_DLINE_ROOT_LEN;
+    q->x = ((int64_t) p->tri.x * T8_QUAD_ROOT_LEN) / T8_DTRI_ROOT_LEN;
+    q->y = ((int64_t) p->line.x * T8_QUAD_ROOT_LEN) / T8_DLINE_ROOT_LEN;
     q->level = p->tri.level;
     break;
   default:
@@ -415,7 +415,7 @@ t8_dprism_extrude_face (const t8_element_t *face,
 {
   t8_dprism_t        *p = (t8_dprism_t *) elem;
   const t8_dtri_t    *t = (const t8_dtri_t *) face;
-  const p4est_quadrant_t *q = (const p4est_quadrant_t *) face;
+  const t8_pquad_t *q = (const t8_pquad_t *) face;
   T8_ASSERT (0 <= root_face && root_face < T8_DPRISM_FACES);
   switch (root_face) {
   case 0:
@@ -423,24 +423,24 @@ t8_dprism_extrude_face (const t8_element_t *face,
     p->line.level = q->level;
     p->tri.level = q->level;
     p->tri.x = T8_DTRI_ROOT_LEN - T8_DTRI_LEN (p->tri.level);
-    p->tri.y = ((int64_t) q->x * T8_DTRI_ROOT_LEN) / P4EST_ROOT_LEN;
-    p->line.x = ((int64_t) q->y * T8_DLINE_ROOT_LEN) / P4EST_ROOT_LEN;
+    p->tri.y = ((int64_t) q->x * T8_DTRI_ROOT_LEN) / T8_QUAD_ROOT_LEN;
+    p->line.x = ((int64_t) q->y * T8_DLINE_ROOT_LEN) / T8_QUAD_ROOT_LEN;
     break;
   case 1:
     p->tri.type = 0;
     p->line.level = q->level;
     p->tri.level = q->level;
-    p->tri.x = ((int64_t) q->x * T8_DTRI_ROOT_LEN) / P4EST_ROOT_LEN;
-    p->tri.y = ((int64_t) q->x * T8_DTRI_ROOT_LEN) / P4EST_ROOT_LEN;
-    p->line.x = ((int64_t) q->y * T8_DLINE_ROOT_LEN) / P4EST_ROOT_LEN;
+    p->tri.x = ((int64_t) q->x * T8_DTRI_ROOT_LEN) / T8_QUAD_ROOT_LEN;
+    p->tri.y = ((int64_t) q->x * T8_DTRI_ROOT_LEN) / T8_QUAD_ROOT_LEN;
+    p->line.x = ((int64_t) q->y * T8_DLINE_ROOT_LEN) / T8_QUAD_ROOT_LEN;
     break;
   case 2:
     p->tri.type = 0;
     p->line.level = q->level;
     p->tri.level = q->level;
-    p->tri.x = ((int64_t) q->x * T8_DTRI_ROOT_LEN) / P4EST_ROOT_LEN;;
+    p->tri.x = ((int64_t) q->x * T8_DTRI_ROOT_LEN) / T8_QUAD_ROOT_LEN;;
     p->tri.y = 0;
-    p->line.x = ((int64_t) q->y * T8_DLINE_ROOT_LEN) / P4EST_ROOT_LEN;
+    p->line.x = ((int64_t) q->y * T8_DLINE_ROOT_LEN) / T8_QUAD_ROOT_LEN;
     break;
   case 3:
     p->tri.type = t->type;

--- a/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_prism/t8_dprism_bits.c
@@ -203,7 +203,7 @@ t8_dprism_boundary_face (const t8_dprism_t *p, int face,
                          t8_element_t *boundary)
 {
   T8_ASSERT (0 <= face && face < T8_DPRISM_FACES);
-  t8_pquad_t   *q = (t8_pquad_t *) boundary;
+  t8_dquad_t   *q = (t8_dquad_t *) boundary;
   if (face >= 3) {
     t8_dtri_t          *t = (t8_dtri_t *) boundary;
     t8_dtri_copy (&p->tri, t);
@@ -211,18 +211,18 @@ t8_dprism_boundary_face (const t8_dprism_t *p, int face,
   }
   switch (face) {
   case 0:
-    q->x = ((int64_t) p->tri.y * T8_QUAD_ROOT_LEN) / T8_DTRI_ROOT_LEN;
-    q->y = ((int64_t) p->line.x * T8_QUAD_ROOT_LEN) / T8_DLINE_ROOT_LEN;
+    q->x = ((int64_t) p->tri.y * T8_DQUAD_ROOT_LEN) / T8_DTRI_ROOT_LEN;
+    q->y = ((int64_t) p->line.x * T8_DQUAD_ROOT_LEN) / T8_DLINE_ROOT_LEN;
     q->level = p->tri.level;
     break;
   case 1:
-    q->x = ((int64_t) p->tri.x * T8_QUAD_ROOT_LEN) / T8_DTRI_ROOT_LEN;
-    q->y = ((int64_t) p->line.x * T8_QUAD_ROOT_LEN) / T8_DLINE_ROOT_LEN;
+    q->x = ((int64_t) p->tri.x * T8_DQUAD_ROOT_LEN) / T8_DTRI_ROOT_LEN;
+    q->y = ((int64_t) p->line.x * T8_DQUAD_ROOT_LEN) / T8_DLINE_ROOT_LEN;
     q->level = p->tri.level;
     break;
   case 2:
-    q->x = ((int64_t) p->tri.x * T8_QUAD_ROOT_LEN) / T8_DTRI_ROOT_LEN;
-    q->y = ((int64_t) p->line.x * T8_QUAD_ROOT_LEN) / T8_DLINE_ROOT_LEN;
+    q->x = ((int64_t) p->tri.x * T8_DQUAD_ROOT_LEN) / T8_DTRI_ROOT_LEN;
+    q->y = ((int64_t) p->line.x * T8_DQUAD_ROOT_LEN) / T8_DLINE_ROOT_LEN;
     q->level = p->tri.level;
     break;
   default:
@@ -415,7 +415,7 @@ t8_dprism_extrude_face (const t8_element_t *face,
 {
   t8_dprism_t        *p = (t8_dprism_t *) elem;
   const t8_dtri_t    *t = (const t8_dtri_t *) face;
-  const t8_pquad_t *q = (const t8_pquad_t *) face;
+  const t8_dquad_t *q = (const t8_dquad_t *) face;
   T8_ASSERT (0 <= root_face && root_face < T8_DPRISM_FACES);
   switch (root_face) {
   case 0:
@@ -423,24 +423,24 @@ t8_dprism_extrude_face (const t8_element_t *face,
     p->line.level = q->level;
     p->tri.level = q->level;
     p->tri.x = T8_DTRI_ROOT_LEN - T8_DTRI_LEN (p->tri.level);
-    p->tri.y = ((int64_t) q->x * T8_DTRI_ROOT_LEN) / T8_QUAD_ROOT_LEN;
-    p->line.x = ((int64_t) q->y * T8_DLINE_ROOT_LEN) / T8_QUAD_ROOT_LEN;
+    p->tri.y = ((int64_t) q->x * T8_DTRI_ROOT_LEN) / T8_DQUAD_ROOT_LEN;
+    p->line.x = ((int64_t) q->y * T8_DLINE_ROOT_LEN) / T8_DQUAD_ROOT_LEN;
     break;
   case 1:
     p->tri.type = 0;
     p->line.level = q->level;
     p->tri.level = q->level;
-    p->tri.x = ((int64_t) q->x * T8_DTRI_ROOT_LEN) / T8_QUAD_ROOT_LEN;
-    p->tri.y = ((int64_t) q->x * T8_DTRI_ROOT_LEN) / T8_QUAD_ROOT_LEN;
-    p->line.x = ((int64_t) q->y * T8_DLINE_ROOT_LEN) / T8_QUAD_ROOT_LEN;
+    p->tri.x = ((int64_t) q->x * T8_DTRI_ROOT_LEN) / T8_DQUAD_ROOT_LEN;
+    p->tri.y = ((int64_t) q->x * T8_DTRI_ROOT_LEN) / T8_DQUAD_ROOT_LEN;
+    p->line.x = ((int64_t) q->y * T8_DLINE_ROOT_LEN) / T8_DQUAD_ROOT_LEN;
     break;
   case 2:
     p->tri.type = 0;
     p->line.level = q->level;
     p->tri.level = q->level;
-    p->tri.x = ((int64_t) q->x * T8_DTRI_ROOT_LEN) / T8_QUAD_ROOT_LEN;;
+    p->tri.x = ((int64_t) q->x * T8_DTRI_ROOT_LEN) / T8_DQUAD_ROOT_LEN;;
     p->tri.y = 0;
-    p->line.x = ((int64_t) q->y * T8_DLINE_ROOT_LEN) / T8_QUAD_ROOT_LEN;
+    p->line.x = ((int64_t) q->y * T8_DLINE_ROOT_LEN) / T8_DQUAD_ROOT_LEN;
     break;
   case 3:
     p->tri.type = t->type;

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.h
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.h
@@ -21,24 +21,17 @@
 */
 
 /** \file t8_default_quad.h
- * We use a p4est_quadrant_t object as storage for the T8 quadrant.
+ * We use a T8 quadrant object as basic storage unit per element.
  * To record if and if yes, how this quadrant is part of a 3D octant, we use
  * the member pad8 for the surrounding toplevel dimension (2 or 3), pad16 for
  * the direction of its normal relative to a toplevel octant (0, 1, or 2), and
- * p.user_long for the p4est_qcoord_t coordinate in the normal direction.
+ * p.user_long for the t8_qcoord_t coordinate in the normal direction.
  */
 
 #ifndef T8_DEFAULT_QUAD_H
 #define T8_DEFAULT_QUAD_H
 
-#include <p4est.h>
 #include <t8_element.h>
-
-/** The structure holding a quadrilateral element in the default scheme.
- * We make this definition public for interoperability of element classes.
- * We might want to put this into a private, scheme-specific header file.
- */
-typedef p4est_quadrant_t t8_pquad_t;
 
 /** Return the toplevel dimension. */
 #define T8_QUAD_GET_TDIM(quad) ((int) (quad)->pad8)

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.h
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad.h
@@ -20,51 +20,16 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
 
-/** \file t8_default_quad.h
- * We use a T8 quadrant object as basic storage unit per element.
- * To record if and if yes, how this quadrant is part of a 3D octant, we use
- * the member pad8 for the surrounding toplevel dimension (2 or 3), pad16 for
- * the direction of its normal relative to a toplevel octant (0, 1, or 2), and
- * p.user_long for the t8_qcoord_t coordinate in the normal direction.
- */
-
 #ifndef T8_DEFAULT_QUAD_H
 #define T8_DEFAULT_QUAD_H
 
 #include <t8_element.h>
 
-/** Return the toplevel dimension. */
-#define T8_QUAD_GET_TDIM(quad) ((int) (quad)->pad8)
-
-/** Return the direction of the third dimension.
- * This is only valid to call if the toplevel dimension is three.
- */
-#define T8_QUAD_GET_TNORMAL(quad)                               \
-  ( T8_ASSERT (T8_QUAD_GET_TDIM(quad) == 3),                    \
-    ((int) (quad)->pad16) )
-
-/** Return the coordinate in the third dimension.
- * This is only valid to call if the toplevel dimension is three.
- */
-#define T8_QUAD_GET_TCOORD(quad)                                \
-  ( T8_ASSERT (T8_QUAD_GET_TDIM(quad) == 3),                    \
-    ((int) (quad)->p.user_long) )
-
-/** Set the toplevel dimension of a quadrilateral. */
-#define T8_QUAD_SET_TDIM(quad,dim)                              \
-  do { T8_ASSERT ((dim) == 2 || (dim) == 3);                    \
-       (quad)->pad8 = (int8_t) (dim); } while (0)
-
-/** Set the direction of the third demension. */
-#define T8_QUAD_SET_TNORMAL(quad,normal)                        \
-  do { T8_ASSERT ((normal) >= 0 && (normal) < 3);               \
-       (quad)->pad16 = (int16_t) (normal); } while (0)
-
-/** Set the coordinate in the third dimension. */
-#define T8_QUAD_SET_TCOORD(quad,coord)                          \
-  do { (quad)->p.user_long = (long) (coord); } while (0)
+T8_EXTERN_C_BEGIN ();
 
 /** Provide an implementation for the quadrilateral element class. */
 t8_eclass_scheme_t *t8_default_scheme_new_quad (void);
+
+T8_EXTERN_C_END ();
 
 #endif /* !T8_DEFAULT_QUAD_H */

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
@@ -25,6 +25,20 @@
 #include <t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx>
 #include <t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.h>
 
+static const int    t8_dquad_face_corners[4][2] = { {0, 2},
+{1, 3},
+{0, 1},
+{2, 3}
+};
+
+static const int    t8_dquad_face_dual[4] = { 1, 0, 3, 2 };
+
+static const int    t8_dquad_corner_faces[4][2] = { {0, 2},
+{1, 2},
+{0, 3},
+{1, 3}
+};
+
 /* We want to export the whole implementation to be callable from "C" */
 T8_EXTERN_C_BEGIN ();
 
@@ -61,8 +75,8 @@ void
 t8_default_scheme_quad_c::t8_element_copy (const t8_element_t *source,
                                            t8_element_t *dest)
 {
-  const t8_dquad_t *q = (const t8_dquad_t *) source;
-  t8_dquad_t   *r = (t8_dquad_t *) dest;
+  const t8_dquad_t   *q = (const t8_dquad_t *) source;
+  t8_dquad_t         *r = (t8_dquad_t *) dest;
 
   T8_ASSERT (t8_element_is_valid (source));
   T8_ASSERT (t8_element_is_valid (dest));
@@ -81,15 +95,15 @@ t8_default_scheme_quad_c::t8_element_compare (const t8_element_t *elem1,
   T8_ASSERT (t8_element_is_valid (elem2));
 
   return t8_dquad_compare ((const t8_dquad_t *) elem1,
-                          (const t8_dquad_t *) elem2);
+                           (const t8_dquad_t *) elem2);
 }
 
 void
 t8_default_scheme_quad_c::t8_element_parent (const t8_element_t *elem,
                                              t8_element_t *parent)
 {
-  const t8_dquad_t *q = (const t8_dquad_t *) elem;
-  t8_dquad_t   *r = (t8_dquad_t *) parent;
+  const t8_dquad_t   *q = (const t8_dquad_t *) elem;
+  t8_dquad_t         *r = (t8_dquad_t *) parent;
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (parent));
@@ -101,8 +115,8 @@ t8_default_scheme_quad_c::t8_element_sibling (const t8_element_t *elem,
                                               int sibid,
                                               t8_element_t *sibling)
 {
-  const t8_dquad_t *q = (const t8_dquad_t *) elem;
-  t8_dquad_t   *r = (t8_dquad_t *) sibling;
+  const t8_dquad_t   *q = (const t8_dquad_t *) elem;
+  t8_dquad_t         *r = (t8_dquad_t *) sibling;
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (sibling));
@@ -172,9 +186,9 @@ void
 t8_default_scheme_quad_c::t8_element_child (const t8_element_t *elem,
                                             int childid, t8_element_t *child)
 {
-  const t8_dquad_t *q = (const t8_dquad_t *) elem;
-  const t8_qcoord_t shift = T8_DQUAD_LEN (q->level + 1);
-  t8_dquad_t   *r = (t8_dquad_t *) child;
+  const t8_dquad_t   *q = (const t8_dquad_t *) elem;
+  const t8_qcoord_t   shift = T8_DQUAD_LEN (q->level + 1);
+  t8_dquad_t         *r = (t8_dquad_t *) child;
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (child));
@@ -192,7 +206,7 @@ void
 t8_default_scheme_quad_c::t8_element_children (const t8_element_t *elem,
                                                int length, t8_element_t *c[])
 {
-  const t8_dquad_t *q = (const t8_dquad_t *) elem;
+  const t8_dquad_t   *q = (const t8_dquad_t *) elem;
   int                 i;
 
   T8_ASSERT (t8_element_is_valid (elem));
@@ -266,8 +280,7 @@ t8_default_scheme_quad_c::t8_element_first_descendant (const t8_element_t
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (desc));
   T8_ASSERT (0 <= level && level <= T8_DQUAD_QMAXLEVEL);
-  t8_dquad_first_descendant ((t8_dquad_t *) elem,
-                                   (t8_dquad_t *) desc, level);
+  t8_dquad_first_descendant ((t8_dquad_t *) elem, (t8_dquad_t *) desc, level);
 }
 
 void
@@ -279,8 +292,7 @@ t8_default_scheme_quad_c::t8_element_last_descendant (const t8_element_t
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (desc));
   T8_ASSERT (0 <= level && level <= T8_DQUAD_QMAXLEVEL);
-  t8_dquad_last_descendant ((t8_dquad_t *) elem,
-                                  (t8_dquad_t *) desc, level);
+  t8_dquad_last_descendant ((t8_dquad_t *) elem, (t8_dquad_t *) desc, level);
 }
 
 void
@@ -304,9 +316,9 @@ t8_default_scheme_quad_c::t8_element_nca (const t8_element_t *elem1,
                                           const t8_element_t *elem2,
                                           t8_element_t *nca)
 {
-  const t8_dquad_t *q1 = (const t8_dquad_t *) elem1;
-  const t8_dquad_t *q2 = (const t8_dquad_t *) elem2;
-  t8_dquad_t   *r = (t8_dquad_t *) nca;
+  const t8_dquad_t   *q1 = (const t8_dquad_t *) elem1;
+  const t8_dquad_t   *q2 = (const t8_dquad_t *) elem2;
+  t8_dquad_t         *r = (t8_dquad_t *) nca;
 
   T8_ASSERT (t8_element_is_valid (elem1));
   T8_ASSERT (t8_element_is_valid (elem2));
@@ -406,7 +418,7 @@ int
 t8_default_scheme_quad_c::t8_element_face_parent_face (const t8_element_t
                                                        *elem, int face)
 {
-  const t8_dquad_t *q = (const t8_dquad_t *) elem;
+  const t8_dquad_t   *q = (const t8_dquad_t *) elem;
   int                 child_id;
 
   T8_ASSERT (t8_element_is_valid (elem));
@@ -431,11 +443,11 @@ t8_default_scheme_quad_c::t8_element_transform_face (const t8_element_t
                                                      int sign,
                                                      int is_smaller_face)
 {
-  const t8_dquad_t *qin = (const t8_dquad_t *) elem1;
-  const t8_dquad_t *q;
-  t8_dquad_t   *p = (t8_dquad_t *) elem2;
-  t8_qcoord_t      h = T8_DQUAD_LEN (qin->level);
-  t8_qcoord_t      x = qin->x;       /* temp storage for x coordinate in case elem1 = elem 2 */
+  const t8_dquad_t   *qin = (const t8_dquad_t *) elem1;
+  const t8_dquad_t   *q;
+  t8_dquad_t         *p = (t8_dquad_t *) elem2;
+  t8_qcoord_t         h = T8_DQUAD_LEN (qin->level);
+  t8_qcoord_t         x = qin->x;       /* temp storage for x coordinate in case elem1 = elem 2 */
 
   T8_ASSERT (t8_element_is_valid (elem1));
   T8_ASSERT (t8_element_is_valid (elem2));
@@ -511,7 +523,7 @@ t8_default_scheme_quad_c::t8_element_extrude_face (const t8_element_t *face,
                                                    int root_face)
 {
   const t8_dline_t   *l = (const t8_dline_t *) face;
-  t8_dquad_t   *q = (t8_dquad_t *) elem;
+  t8_dquad_t         *q = (t8_dquad_t *) elem;
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (T8_COMMON_IS_TYPE
@@ -578,8 +590,8 @@ t8_default_scheme_quad_c::t8_element_first_descendant_face (const t8_element_t
                                                             *first_desc,
                                                             int level)
 {
-  const t8_dquad_t *q = (const t8_dquad_t *) elem;
-  t8_dquad_t   *desc = (t8_dquad_t *) first_desc;
+  const t8_dquad_t   *q = (const t8_dquad_t *) elem;
+  t8_dquad_t         *desc = (t8_dquad_t *) first_desc;
   int                 first_face_corner;
 
   T8_ASSERT (0 <= face && face < T8_DQUAD_FACES);
@@ -599,8 +611,8 @@ t8_default_scheme_quad_c::t8_element_last_descendant_face (const t8_element_t
                                                            *last_desc,
                                                            int level)
 {
-  const t8_dquad_t *q = (const t8_dquad_t *) elem;
-  t8_dquad_t   *desc = (t8_dquad_t *) last_desc;
+  const t8_dquad_t   *q = (const t8_dquad_t *) elem;
+  t8_dquad_t         *desc = (t8_dquad_t *) last_desc;
   int                 last_face_corner;
 
   T8_ASSERT (0 <= face && face < T8_DQUAD_FACES);
@@ -619,7 +631,7 @@ t8_default_scheme_quad_c::t8_element_boundary_face (const t8_element_t *elem,
                                                     const t8_eclass_scheme_c
                                                     *boundary_scheme)
 {
-  const t8_dquad_t *q = (const t8_dquad_t *) elem;
+  const t8_dquad_t   *q = (const t8_dquad_t *) elem;
   t8_dline_t         *l = (t8_dline_t *) boundary;
 
   T8_ASSERT (t8_element_is_valid (elem));
@@ -672,8 +684,8 @@ int
 t8_default_scheme_quad_c::t8_element_is_root_boundary (const t8_element_t
                                                        *elem, int face)
 {
-  const t8_dquad_t *q = (const t8_dquad_t *) elem;
-  t8_qcoord_t      coord;
+  const t8_dquad_t   *q = (const t8_dquad_t *) elem;
+  t8_qcoord_t         coord;
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (0 <= face && face < T8_DQUAD_FACES);
@@ -694,8 +706,8 @@ t8_default_scheme_quad_c::t8_element_face_neighbor_inside (const t8_element_t
                                                            *neigh, int face,
                                                            int *neigh_face)
 {
-  const t8_dquad_t *q = (const t8_dquad_t *) elem;
-  t8_dquad_t   *n = (t8_dquad_t *) neigh;
+  const t8_dquad_t   *q = (const t8_dquad_t *) elem;
+  t8_dquad_t         *n = (t8_dquad_t *) neigh;
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (neigh));
@@ -716,7 +728,7 @@ void
 t8_default_scheme_quad_c::t8_element_anchor (const t8_element_t *elem,
                                              int coord[3])
 {
-  t8_dquad_t   *q;
+  t8_dquad_t         *q;
 
   T8_ASSERT (t8_element_is_valid (elem));
   q = (t8_dquad_t *) elem;
@@ -735,7 +747,7 @@ void
 t8_default_scheme_quad_c::t8_element_vertex_coords (const t8_element_t *t,
                                                     int vertex, int coords[])
 {
-  const t8_dquad_t *q1 = (const t8_dquad_t *) t;
+  const t8_dquad_t   *q1 = (const t8_dquad_t *) t;
   int                 len;
 
   T8_ASSERT (t8_element_is_valid (t));
@@ -788,7 +800,7 @@ t8_default_scheme_quad_c::t8_element_init (int length, t8_element_t *elem,
 #ifdef T8_ENABLE_DEBUG
   if (!new_called) {
     int                 i;
-    t8_dquad_t   *quads = (t8_dquad_t *) elem;
+    t8_dquad_t         *quads = (t8_dquad_t *) elem;
     /* Set all values to 0 */
     for (i = 0; i < length; i++) {
       t8_dquad_set_morton (quads + i, 0, 0);
@@ -813,7 +825,7 @@ void
 t8_default_scheme_quad_c::t8_element_debug_print (const t8_element_t *elem) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  t8_dquad_t   *quad = (t8_dquad_t *) elem;
+  t8_dquad_t         *quad = (t8_dquad_t *) elem;
   t8_dquad_print (SC_LP_DEBUG, quad);
 }
 #endif

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
@@ -33,28 +33,10 @@ T8_EXTERN_C_BEGIN ();
 t8_linearidx_t      t8_element_get_linear_id (const t8_element_t *elem,
                                               int level);
 
-#ifdef T8_ENABLE_DEBUG
-
-#if 0
-/* TODO: Used in one assertion in t8_element_nca, but wrongly triggers error there.
-         Investigate and decide whether we really need this. */
-static int
-t8_element_surround_matches (const t8_pquad_t * q,
-                             const t8_pquad_t * r)
-{
-  return T8_QUAD_GET_TDIM (q) == T8_QUAD_GET_TDIM (r) &&
-    (T8_QUAD_GET_TDIM (q) == -1 ||
-     (T8_QUAD_GET_TNORMAL (q) == T8_QUAD_GET_TNORMAL (r) &&
-      T8_QUAD_GET_TCOORD (q) == T8_QUAD_GET_TCOORD (r)));
-}
-#endif
-
-#endif /* T8_ENABLE_DEBUG */
-
 int
 t8_default_scheme_quad_c::t8_element_maxlevel (void)
 {
-  return T8_QUAD_QMAXLEVEL;
+  return T8_DQUAD_QMAXLEVEL;
 }
 
 /* *INDENT-OFF* */
@@ -63,7 +45,7 @@ t8_default_scheme_quad_c::t8_element_child_eclass (int childid)
 /* *INDENT-ON* */
 
 {
-  T8_ASSERT (0 <= childid && childid < T8_QUAD_CHILDREN);
+  T8_ASSERT (0 <= childid && childid < T8_DQUAD_CHILDREN);
 
   return T8_ECLASS_QUAD;
 }
@@ -72,25 +54,15 @@ int
 t8_default_scheme_quad_c::t8_element_level (const t8_element_t *elem)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  return (int) ((const t8_pquad_t *) elem)->level;
-}
-
-static void
-t8_element_copy_surround (const t8_pquad_t * q, t8_pquad_t * r)
-{
-  T8_QUAD_SET_TDIM (r, T8_QUAD_GET_TDIM (q));
-  if (T8_QUAD_GET_TDIM (q) == 3) {
-    T8_QUAD_SET_TNORMAL (r, T8_QUAD_GET_TNORMAL (q));
-    T8_QUAD_SET_TCOORD (r, T8_QUAD_GET_TCOORD (q));
-  }
+  return (int) ((const t8_dquad_t *) elem)->level;
 }
 
 void
 t8_default_scheme_quad_c::t8_element_copy (const t8_element_t *source,
                                            t8_element_t *dest)
 {
-  const t8_pquad_t *q = (const t8_pquad_t *) source;
-  t8_pquad_t   *r = (t8_pquad_t *) dest;
+  const t8_dquad_t *q = (const t8_dquad_t *) source;
+  t8_dquad_t   *r = (t8_dquad_t *) dest;
 
   T8_ASSERT (t8_element_is_valid (source));
   T8_ASSERT (t8_element_is_valid (dest));
@@ -99,7 +71,6 @@ t8_default_scheme_quad_c::t8_element_copy (const t8_element_t *source,
     return;
   }
   *r = *q;
-  t8_element_copy_surround (q, r);
 }
 
 int
@@ -109,21 +80,20 @@ t8_default_scheme_quad_c::t8_element_compare (const t8_element_t *elem1,
   T8_ASSERT (t8_element_is_valid (elem1));
   T8_ASSERT (t8_element_is_valid (elem2));
 
-  return t8_quad_compare ((const t8_pquad_t *) elem1,
-                                 (const t8_pquad_t *) elem2);
+  return t8_dquad_compare ((const t8_dquad_t *) elem1,
+                          (const t8_dquad_t *) elem2);
 }
 
 void
 t8_default_scheme_quad_c::t8_element_parent (const t8_element_t *elem,
                                              t8_element_t *parent)
 {
-  const t8_pquad_t *q = (const t8_pquad_t *) elem;
-  t8_pquad_t   *r = (t8_pquad_t *) parent;
+  const t8_dquad_t *q = (const t8_dquad_t *) elem;
+  t8_dquad_t   *r = (t8_dquad_t *) parent;
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (parent));
-  t8_quad_parent (q, r);
-  t8_element_copy_surround (q, r);
+  t8_dquad_parent (q, r);
 }
 
 void
@@ -131,33 +101,32 @@ t8_default_scheme_quad_c::t8_element_sibling (const t8_element_t *elem,
                                               int sibid,
                                               t8_element_t *sibling)
 {
-  const t8_pquad_t *q = (const t8_pquad_t *) elem;
-  t8_pquad_t   *r = (t8_pquad_t *) sibling;
+  const t8_dquad_t *q = (const t8_dquad_t *) elem;
+  t8_dquad_t   *r = (t8_dquad_t *) sibling;
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (sibling));
-  t8_quad_sibling (q, r, sibid);
-  t8_element_copy_surround (q, r);
+  t8_dquad_sibling (q, r, sibid);
 }
 
 int
 t8_default_scheme_quad_c::t8_element_num_faces (const t8_element_t *elem)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  return T8_QUAD_FACES;
+  return T8_DQUAD_FACES;
 }
 
 int
 t8_default_scheme_quad_c::t8_element_max_num_faces (const t8_element_t *elem)
 {
-  return T8_QUAD_FACES;
+  return T8_DQUAD_FACES;
 }
 
 int
 t8_default_scheme_quad_c::t8_element_num_children (const t8_element_t *elem)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  return T8_QUAD_CHILDREN;
+  return T8_DQUAD_CHILDREN;
 }
 
 int
@@ -183,9 +152,9 @@ t8_default_scheme_quad_c::t8_element_get_face_corner (const t8_element_t
    *   0    f_3    1
    */
 
-  T8_ASSERT (0 <= face && face < T8_QUAD_FACES);
+  T8_ASSERT (0 <= face && face < T8_DQUAD_FACES);
   T8_ASSERT (0 <= corner && corner < 2);
-  return t8_quad_face_corners[face][corner];
+  return t8_dquad_face_corners[face][corner];
 }
 
 int
@@ -194,69 +163,64 @@ t8_default_scheme_quad_c::t8_element_get_corner_face (const t8_element_t
                                                       int face)
 {
   T8_ASSERT (t8_element_is_valid (element));
-  T8_ASSERT (0 <= corner && corner < T8_QUAD_CHILDREN);
+  T8_ASSERT (0 <= corner && corner < T8_DQUAD_CHILDREN);
   T8_ASSERT (0 <= face && face < 2);
-  return t8_quad_corner_faces[corner][face];
+  return t8_dquad_corner_faces[corner][face];
 }
 
 void
 t8_default_scheme_quad_c::t8_element_child (const t8_element_t *elem,
                                             int childid, t8_element_t *child)
 {
-  const t8_pquad_t *q = (const t8_pquad_t *) elem;
-  const t8_qcoord_t shift = T8_QUAD_QUADRANT_LEN (q->level + 1);
-  t8_pquad_t   *r = (t8_pquad_t *) child;
+  const t8_dquad_t *q = (const t8_dquad_t *) elem;
+  const t8_qcoord_t shift = T8_DQUAD_LEN (q->level + 1);
+  t8_dquad_t   *r = (t8_dquad_t *) child;
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (child));
-  T8_ASSERT (t8_quad_is_extended (q));
-  T8_ASSERT (q->level < T8_QUAD_QMAXLEVEL);
-  T8_ASSERT (childid >= 0 && childid < T8_QUAD_CHILDREN);
+  T8_ASSERT (t8_dquad_is_extended (q));
+  T8_ASSERT (q->level < T8_DQUAD_QMAXLEVEL);
+  T8_ASSERT (childid >= 0 && childid < T8_DQUAD_CHILDREN);
 
   r->x = childid & 0x01 ? (q->x | shift) : q->x;
   r->y = childid & 0x02 ? (q->y | shift) : q->y;
   r->level = q->level + 1;
-  T8_ASSERT (t8_quad_is_parent (q, r));
-
-  t8_element_copy_surround (q, r);
+  T8_ASSERT (t8_dquad_is_parent (q, r));
 }
 
 void
 t8_default_scheme_quad_c::t8_element_children (const t8_element_t *elem,
                                                int length, t8_element_t *c[])
 {
-  const t8_pquad_t *q = (const t8_pquad_t *) elem;
+  const t8_dquad_t *q = (const t8_dquad_t *) elem;
   int                 i;
 
   T8_ASSERT (t8_element_is_valid (elem));
 #ifdef T8_ENABLE_DEBUG
   {
     int                 j;
-    for (j = 0; j < T8_QUAD_CHILDREN; j++) {
+    for (j = 0; j < T8_DQUAD_CHILDREN; j++) {
       T8_ASSERT (t8_element_is_valid (c[j]));
     }
   }
 #endif
-  T8_ASSERT (length == T8_QUAD_CHILDREN);
+  T8_ASSERT (length == T8_DQUAD_CHILDREN);
 
-  t8_quad_childrenpv (q, (t8_pquad_t **) c);
-  for (i = 0; i < T8_QUAD_CHILDREN; ++i) {
-    t8_element_copy_surround (q, (t8_pquad_t *) c[i]);
-  }
+  t8_dquad_childrenpv (q, (t8_dquad_t **) c);
 }
 
 int
 t8_default_scheme_quad_c::t8_element_child_id (const t8_element_t *elem)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  return t8_quad_child_id ((const t8_pquad_t *) elem);
+  return t8_dquad_child_id ((const t8_dquad_t *) elem);
 }
 
 int
 t8_default_scheme_quad_c::t8_element_ancestor_id (const t8_element_t *elem,
                                                   int level)
 {
-  return t8_quad_ancestor_id ((t8_pquad_t *) elem, level);
+  return t8_dquad_ancestor_id ((t8_dquad_t *) elem, level);
 }
 
 int
@@ -264,11 +228,11 @@ t8_default_scheme_quad_c::t8_element_is_family (t8_element_t **fam)
 {
 #ifdef T8_ENABLE_DEBUG
   int                 i;
-  for (i = 0; i < T8_QUAD_CHILDREN; i++) {
+  for (i = 0; i < T8_DQUAD_CHILDREN; i++) {
     T8_ASSERT (t8_element_is_valid (fam[i]));
   }
 #endif
-  return t8_quad_is_familypv ((t8_pquad_t **) fam);
+  return t8_dquad_is_familypv ((t8_dquad_t **) fam);
 }
 
 void
@@ -277,11 +241,10 @@ t8_default_scheme_quad_c::t8_element_set_linear_id (t8_element_t *elem,
                                                     t8_linearidx_t id)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  T8_ASSERT (0 <= level && level <= T8_QUAD_QMAXLEVEL);
-  T8_ASSERT (0 <= id && id < ((t8_linearidx_t) 1) << T8_QUAD_DIM * level);
+  T8_ASSERT (0 <= level && level <= T8_DQUAD_QMAXLEVEL);
+  T8_ASSERT (0 <= id && id < ((t8_linearidx_t) 1) << T8_DQUAD_DIM * level);
 
-  t8_quad_set_morton ((t8_pquad_t *) elem, level, id);
-  T8_QUAD_SET_TDIM ((t8_pquad_t *) elem, 2);
+  t8_dquad_set_morton ((t8_dquad_t *) elem, level, id);
 }
 
 t8_linearidx_t
@@ -289,9 +252,9 @@ t8_linearidx_t
                                                       *elem, int level)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  T8_ASSERT (0 <= level && level <= T8_QUAD_QMAXLEVEL);
+  T8_ASSERT (0 <= level && level <= T8_DQUAD_QMAXLEVEL);
 
-  return t8_quad_linear_id ((t8_pquad_t *) elem, level);
+  return t8_dquad_linear_id ((t8_dquad_t *) elem, level);
 }
 
 void
@@ -302,10 +265,9 @@ t8_default_scheme_quad_c::t8_element_first_descendant (const t8_element_t
 {
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (desc));
-  T8_ASSERT (0 <= level && level <= T8_QUAD_QMAXLEVEL);
-  t8_quad_first_descendant ((t8_pquad_t *) elem,
-                                   (t8_pquad_t *) desc, level);
-  T8_QUAD_SET_TDIM ((t8_pquad_t *) desc, 2);
+  T8_ASSERT (0 <= level && level <= T8_DQUAD_QMAXLEVEL);
+  t8_dquad_first_descendant ((t8_dquad_t *) elem,
+                                   (t8_dquad_t *) desc, level);
 }
 
 void
@@ -316,10 +278,9 @@ t8_default_scheme_quad_c::t8_element_last_descendant (const t8_element_t
 {
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (desc));
-  T8_ASSERT (0 <= level && level <= T8_QUAD_QMAXLEVEL);
-  t8_quad_last_descendant ((t8_pquad_t *) elem,
-                                  (t8_pquad_t *) desc, level);
-  T8_QUAD_SET_TDIM ((t8_pquad_t *) desc, 2);
+  T8_ASSERT (0 <= level && level <= T8_DQUAD_QMAXLEVEL);
+  t8_dquad_last_descendant ((t8_dquad_t *) elem,
+                                  (t8_dquad_t *) desc, level);
 }
 
 void
@@ -331,13 +292,11 @@ t8_default_scheme_quad_c::t8_element_successor (const t8_element_t *elem1,
 
   T8_ASSERT (t8_element_is_valid (elem1));
   T8_ASSERT (t8_element_is_valid (elem2));
-  T8_ASSERT (0 <= level && level <= T8_QUAD_QMAXLEVEL);
+  T8_ASSERT (0 <= level && level <= T8_DQUAD_QMAXLEVEL);
 
-  id = t8_quad_linear_id ((const t8_pquad_t *) elem1, level);
-  T8_ASSERT (id + 1 < ((t8_linearidx_t) 1) << T8_QUAD_DIM * level);
-  t8_quad_set_morton ((t8_pquad_t *) elem2, level, id + 1);
-  t8_element_copy_surround ((const t8_pquad_t *) elem1,
-                            (t8_pquad_t *) elem2);
+  id = t8_dquad_linear_id ((const t8_dquad_t *) elem1, level);
+  T8_ASSERT (id + 1 < ((t8_linearidx_t) 1) << T8_DQUAD_DIM * level);
+  t8_dquad_set_morton ((t8_dquad_t *) elem2, level, id + 1);
 }
 
 void
@@ -345,20 +304,13 @@ t8_default_scheme_quad_c::t8_element_nca (const t8_element_t *elem1,
                                           const t8_element_t *elem2,
                                           t8_element_t *nca)
 {
-  const t8_pquad_t *q1 = (const t8_pquad_t *) elem1;
-  const t8_pquad_t *q2 = (const t8_pquad_t *) elem2;
-  t8_pquad_t   *r = (t8_pquad_t *) nca;
+  const t8_dquad_t *q1 = (const t8_dquad_t *) elem1;
+  const t8_dquad_t *q2 = (const t8_dquad_t *) elem2;
+  t8_dquad_t   *r = (t8_dquad_t *) nca;
 
   T8_ASSERT (t8_element_is_valid (elem1));
   T8_ASSERT (t8_element_is_valid (elem2));
-#if 0
-  /* TODO: This assertions throws an error since it expects a 3D hex.
-   *       this does not make sense. investigate. */
-  T8_ASSERT (t8_element_surround_matches (q1, q2));
-#endif
-
-  t8_quad_nearest_common_ancestor (q1, q2, r);
-  t8_element_copy_surround (q1, r);
+  t8_dquad_nearest_common_ancestor (q1, q2, r);
 }
 
 t8_element_shape_t
@@ -388,7 +340,7 @@ t8_default_scheme_quad_c::t8_element_children_at_face (const t8_element_t
   }
 #endif
   T8_ASSERT (t8_element_is_valid (elem));
-  T8_ASSERT (0 <= face && face < T8_QUAD_FACES);
+  T8_ASSERT (0 <= face && face < T8_DQUAD_FACES);
   T8_ASSERT (num_children == t8_element_num_face_children (elem, face));
 
   /*
@@ -454,7 +406,7 @@ int
 t8_default_scheme_quad_c::t8_element_face_parent_face (const t8_element_t
                                                        *elem, int face)
 {
-  const t8_pquad_t *q = (const t8_pquad_t *) elem;
+  const t8_dquad_t *q = (const t8_dquad_t *) elem;
   int                 child_id;
 
   T8_ASSERT (t8_element_is_valid (elem));
@@ -463,9 +415,9 @@ t8_default_scheme_quad_c::t8_element_face_parent_face (const t8_element_t
   }
   /* Determine whether face is a subface of the parent.
    * This is the case if the child_id matches one of the faces corners */
-  child_id = t8_quad_child_id (q);
-  if (child_id == t8_quad_face_corners[face][0]
-      || child_id == t8_quad_face_corners[face][1]) {
+  child_id = t8_dquad_child_id (q);
+  if (child_id == t8_dquad_face_corners[face][0]
+      || child_id == t8_dquad_face_corners[face][1]) {
     return face;
   }
   return -1;
@@ -479,25 +431,24 @@ t8_default_scheme_quad_c::t8_element_transform_face (const t8_element_t
                                                      int sign,
                                                      int is_smaller_face)
 {
-  const t8_pquad_t *qin = (const t8_pquad_t *) elem1;
-  const t8_pquad_t *q;
-  t8_pquad_t   *p = (t8_pquad_t *) elem2;
-  t8_qcoord_t      h = T8_QUAD_QUADRANT_LEN (qin->level);
+  const t8_dquad_t *qin = (const t8_dquad_t *) elem1;
+  const t8_dquad_t *q;
+  t8_dquad_t   *p = (t8_dquad_t *) elem2;
+  t8_qcoord_t      h = T8_DQUAD_LEN (qin->level);
   t8_qcoord_t      x = qin->x;       /* temp storage for x coordinate in case elem1 = elem 2 */
 
   T8_ASSERT (t8_element_is_valid (elem1));
   T8_ASSERT (t8_element_is_valid (elem2));
-  T8_ASSERT (0 <= orientation && orientation < T8_QUAD_FACES);
+  T8_ASSERT (0 <= orientation && orientation < T8_DQUAD_FACES);
 
   if (sign) {
     /* The tree faces have the same topological orientation, and
      * thus we have to perform a coordinate switch. */
     /* We use p as storage, since elem1 and elem2 are allowed to
      * point to the same quad */
-    q = (const t8_pquad_t *) p;
-    t8_element_copy_surround (qin, (t8_pquad_t *) q);
-    ((t8_pquad_t *) q)->x = qin->y;
-    ((t8_pquad_t *) q)->y = x;
+    q = (const t8_dquad_t *) p;
+    ((t8_dquad_t *) q)->x = qin->y;
+    ((t8_dquad_t *) q)->y = x;
     x = q->x;                   /* temp storage in case elem1 = elem 2 */
   }
   else {
@@ -536,21 +487,20 @@ t8_default_scheme_quad_c::t8_element_transform_face (const t8_element_t
     p->y = q->y;
     break;
   case 1:
-    p->x = T8_QUAD_ROOT_LEN - q->y - h;
+    p->x = T8_DQUAD_ROOT_LEN - q->y - h;
     p->y = x;
     break;
   case 2:
     p->x = q->y;
-    p->y = T8_QUAD_ROOT_LEN - x - h;
+    p->y = T8_DQUAD_ROOT_LEN - x - h;
     break;
   case 3:
-    p->x = T8_QUAD_ROOT_LEN - q->x - h;
-    p->y = T8_QUAD_ROOT_LEN - q->y - h;
+    p->x = T8_DQUAD_ROOT_LEN - q->x - h;
+    p->y = T8_DQUAD_ROOT_LEN - q->y - h;
     break;
   default:
     SC_ABORT_NOT_REACHED ();
   }
-  T8_QUAD_SET_TDIM (p, 2);
 }
 
 int
@@ -561,14 +511,14 @@ t8_default_scheme_quad_c::t8_element_extrude_face (const t8_element_t *face,
                                                    int root_face)
 {
   const t8_dline_t   *l = (const t8_dline_t *) face;
-  t8_pquad_t   *q = (t8_pquad_t *) elem;
+  t8_dquad_t   *q = (t8_dquad_t *) elem;
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (T8_COMMON_IS_TYPE
              (face_scheme, const t8_default_scheme_line_c *));
   T8_ASSERT (face_scheme->eclass == T8_ECLASS_LINE);
   T8_ASSERT (face_scheme->t8_element_is_valid (elem));
-  T8_ASSERT (0 <= root_face && root_face < T8_QUAD_FACES);
+  T8_ASSERT (0 <= root_face && root_face < T8_DQUAD_FACES);
   /*
    * The faces of the root quadrant are enumerated like this:
    *
@@ -588,19 +538,19 @@ t8_default_scheme_quad_c::t8_element_extrude_face (const t8_element_t *face,
   switch (root_face) {
   case 0:
     q->x = 0;
-    q->y = ((int64_t) l->x * T8_QUAD_ROOT_LEN) / T8_DLINE_ROOT_LEN;
+    q->y = ((int64_t) l->x * T8_DQUAD_ROOT_LEN) / T8_DLINE_ROOT_LEN;
     break;
   case 1:
-    q->x = T8_QUAD_LAST_OFFSET (q->level);
-    q->y = ((int64_t) l->x * T8_QUAD_ROOT_LEN) / T8_DLINE_ROOT_LEN;
+    q->x = T8_DQUAD_LAST_OFFSET (q->level);
+    q->y = ((int64_t) l->x * T8_DQUAD_ROOT_LEN) / T8_DLINE_ROOT_LEN;
     break;
   case 2:
-    q->x = ((int64_t) l->x * T8_QUAD_ROOT_LEN) / T8_DLINE_ROOT_LEN;
+    q->x = ((int64_t) l->x * T8_DQUAD_ROOT_LEN) / T8_DLINE_ROOT_LEN;
     q->y = 0;
     break;
   case 3:
-    q->x = ((int64_t) l->x * T8_QUAD_ROOT_LEN) / T8_DLINE_ROOT_LEN;
-    q->y = T8_QUAD_LAST_OFFSET (q->level);
+    q->x = ((int64_t) l->x * T8_DQUAD_ROOT_LEN) / T8_DLINE_ROOT_LEN;
+    q->y = T8_DQUAD_LAST_OFFSET (q->level);
     break;
   default:
     SC_ABORT_NOT_REACHED ();
@@ -615,7 +565,7 @@ t8_default_scheme_quad_c::t8_element_tree_face (const t8_element_t *elem,
                                                 int face)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  T8_ASSERT (0 <= face && face < T8_QUAD_FACES);
+  T8_ASSERT (0 <= face && face < T8_DQUAD_FACES);
   /* For quadrants the face and the tree face number are the same. */
   return face;
 }
@@ -628,17 +578,17 @@ t8_default_scheme_quad_c::t8_element_first_descendant_face (const t8_element_t
                                                             *first_desc,
                                                             int level)
 {
-  const t8_pquad_t *q = (const t8_pquad_t *) elem;
-  t8_pquad_t   *desc = (t8_pquad_t *) first_desc;
+  const t8_dquad_t *q = (const t8_dquad_t *) elem;
+  t8_dquad_t   *desc = (t8_dquad_t *) first_desc;
   int                 first_face_corner;
 
-  T8_ASSERT (0 <= face && face < T8_QUAD_FACES);
-  T8_ASSERT (0 <= level && level <= T8_QUAD_QMAXLEVEL);
+  T8_ASSERT (0 <= face && face < T8_DQUAD_FACES);
+  T8_ASSERT (0 <= level && level <= T8_DQUAD_QMAXLEVEL);
 
   /* Get the first corner of q that belongs to face */
-  first_face_corner = t8_quad_face_corners[face][0];
+  first_face_corner = t8_dquad_face_corners[face][0];
   /* Construce the descendant in that corner */
-  t8_quad_corner_descendant (q, desc, first_face_corner, level);
+  t8_dquad_corner_descendant (q, desc, first_face_corner, level);
 }
 
 /** Construct the last descendant of an element that touches a given face.   */
@@ -649,17 +599,17 @@ t8_default_scheme_quad_c::t8_element_last_descendant_face (const t8_element_t
                                                            *last_desc,
                                                            int level)
 {
-  const t8_pquad_t *q = (const t8_pquad_t *) elem;
-  t8_pquad_t   *desc = (t8_pquad_t *) last_desc;
+  const t8_dquad_t *q = (const t8_dquad_t *) elem;
+  t8_dquad_t   *desc = (t8_dquad_t *) last_desc;
   int                 last_face_corner;
 
-  T8_ASSERT (0 <= face && face < T8_QUAD_FACES);
-  T8_ASSERT (0 <= level && level <= T8_QUAD_QMAXLEVEL);
+  T8_ASSERT (0 <= face && face < T8_DQUAD_FACES);
+  T8_ASSERT (0 <= level && level <= T8_DQUAD_QMAXLEVEL);
 
   /* Get the last corner of q that belongs to face */
-  last_face_corner = t8_quad_face_corners[face][1];
+  last_face_corner = t8_dquad_face_corners[face][1];
   /* Construce the descendant in that corner */
-  t8_quad_corner_descendant (q, desc, last_face_corner, level);
+  t8_dquad_corner_descendant (q, desc, last_face_corner, level);
 }
 
 void
@@ -669,7 +619,7 @@ t8_default_scheme_quad_c::t8_element_boundary_face (const t8_element_t *elem,
                                                     const t8_eclass_scheme_c
                                                     *boundary_scheme)
 {
-  const t8_pquad_t *q = (const t8_pquad_t *) elem;
+  const t8_dquad_t *q = (const t8_dquad_t *) elem;
   t8_dline_t         *l = (t8_dline_t *) boundary;
 
   T8_ASSERT (t8_element_is_valid (elem));
@@ -677,7 +627,7 @@ t8_default_scheme_quad_c::t8_element_boundary_face (const t8_element_t *elem,
              (boundary_scheme, const t8_default_scheme_line_c *));
   T8_ASSERT (boundary_scheme->eclass == T8_ECLASS_LINE);
   T8_ASSERT (boundary_scheme->t8_element_is_valid (boundary));
-  T8_ASSERT (0 <= face && face < T8_QUAD_FACES);
+  T8_ASSERT (0 <= face && face < T8_DQUAD_FACES);
   /* The level of the boundary element is the same as the quadrant's level */
   l->level = q->level;
   /*
@@ -693,7 +643,7 @@ t8_default_scheme_quad_c::t8_element_boundary_face (const t8_element_t *elem,
    * if face = 2 or face = 3 then l->x = q->x
    */
   l->x = ((face >> 1 ? q->x : q->y) *
-          ((int64_t) T8_DLINE_ROOT_LEN) / T8_QUAD_ROOT_LEN);
+          ((int64_t) T8_DLINE_ROOT_LEN) / T8_DQUAD_ROOT_LEN);
 }
 
 void
@@ -711,8 +661,8 @@ t8_default_scheme_quad_c::t8_element_boundary (const t8_element_t *elem,
   T8_ASSERT (length ==
              t8_eclass_count_boundary (T8_ECLASS_QUAD, min_dim, per_eclass));
 
-  T8_ASSERT (length == T8_QUAD_FACES);
-  for (iface = 0; iface < T8_QUAD_FACES; iface++) {
+  T8_ASSERT (length == T8_DQUAD_FACES);
+  for (iface = 0; iface < T8_DQUAD_FACES; iface++) {
     t8_element_boundary_face (elem, iface, boundary[iface]);
   }
 #endif
@@ -722,11 +672,11 @@ int
 t8_default_scheme_quad_c::t8_element_is_root_boundary (const t8_element_t
                                                        *elem, int face)
 {
-  const t8_pquad_t *q = (const t8_pquad_t *) elem;
+  const t8_dquad_t *q = (const t8_dquad_t *) elem;
   t8_qcoord_t      coord;
 
   T8_ASSERT (t8_element_is_valid (elem));
-  T8_ASSERT (0 <= face && face < T8_QUAD_FACES);
+  T8_ASSERT (0 <= face && face < T8_DQUAD_FACES);
 
   /* if face is 0 or 1 q->x
    *            2 or 3 q->y
@@ -734,7 +684,7 @@ t8_default_scheme_quad_c::t8_element_is_root_boundary (const t8_element_t
   coord = face >> 1 ? q->y : q->x;
   /* If face is 0 or 2 check against 0.
    * If face is 1 or 3  check against LAST_OFFSET */
-  return coord == (face & 1 ? T8_QUAD_LAST_OFFSET (q->level) : 0);
+  return coord == (face & 1 ? T8_DQUAD_LAST_OFFSET (q->level) : 0);
 }
 
 int
@@ -744,56 +694,54 @@ t8_default_scheme_quad_c::t8_element_face_neighbor_inside (const t8_element_t
                                                            *neigh, int face,
                                                            int *neigh_face)
 {
-  const t8_pquad_t *q = (const t8_pquad_t *) elem;
-  t8_pquad_t   *n = (t8_pquad_t *) neigh;
+  const t8_dquad_t *q = (const t8_dquad_t *) elem;
+  t8_dquad_t   *n = (t8_dquad_t *) neigh;
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (neigh));
-  T8_ASSERT (0 <= face && face < T8_QUAD_FACES);
+  T8_ASSERT (0 <= face && face < T8_DQUAD_FACES);
   /* Construct the face neighbor */
-  t8_quad_face_neighbor (q, face, n);
-  T8_QUAD_SET_TDIM (n, 2);
+  t8_dquad_face_neighbor (q, face, n);
   /* Compute the face number as seen from q.
    *  0 -> 1    2 -> 3
    *  1 -> 0    3 -> 2
    */
   T8_ASSERT (neigh_face != NULL);
-  *neigh_face = t8_quad_face_dual[face];
+  *neigh_face = t8_dquad_face_dual[face];
   /* return true if neigh is inside the root */
-  return t8_quad_is_inside_root (n);
+  return t8_dquad_is_inside_root (n);
 }
 
 void
 t8_default_scheme_quad_c::t8_element_anchor (const t8_element_t *elem,
                                              int coord[3])
 {
-  t8_pquad_t   *q;
+  t8_dquad_t   *q;
 
   T8_ASSERT (t8_element_is_valid (elem));
-  q = (t8_pquad_t *) elem;
+  q = (t8_dquad_t *) elem;
   coord[0] = q->x;
   coord[1] = q->y;
   coord[2] = 0;
-  T8_QUAD_SET_TDIM (q, 2);
 }
 
 int
 t8_default_scheme_quad_c::t8_element_root_len (const t8_element_t *elem)
 {
-  return T8_QUAD_ROOT_LEN;
+  return T8_DQUAD_ROOT_LEN;
 }
 
 void
 t8_default_scheme_quad_c::t8_element_vertex_coords (const t8_element_t *t,
                                                     int vertex, int coords[])
 {
-  const t8_pquad_t *q1 = (const t8_pquad_t *) t;
+  const t8_dquad_t *q1 = (const t8_dquad_t *) t;
   int                 len;
 
   T8_ASSERT (t8_element_is_valid (t));
   T8_ASSERT (0 <= vertex && vertex < 4);
   /* Get the length of the quadrant */
-  len = T8_QUAD_QUADRANT_LEN (q1->level);
+  len = T8_DQUAD_LEN (q1->level);
   /* Compute the x and y coordinates of the vertex depending on the
    * vertex number */
   coords[0] = q1->x + (vertex & 1 ? 1 : 0) * len;
@@ -814,8 +762,8 @@ t8_default_scheme_quad_c::t8_element_vertex_reference_coords (const
 
   /* We divide the integer coordinates by the root length of the quad
    * to obtain the reference coordinates. */
-  coords[0] = coords_int[0] / (double) T8_QUAD_ROOT_LEN;
-  coords[1] = coords_int[1] / (double) T8_QUAD_ROOT_LEN;
+  coords[0] = coords_int[0] / (double) T8_DQUAD_ROOT_LEN;
+  coords[1] = coords_int[1] / (double) T8_DQUAD_ROOT_LEN;
 }
 
 void
@@ -829,10 +777,8 @@ t8_default_scheme_quad_c::t8_element_new (int length, t8_element_t **elem)
     int                 i;
     for (i = 0; i < length; i++) {
       t8_element_init (1, elem[i], 0);
-      T8_QUAD_SET_TDIM ((t8_pquad_t *) elem[i], 2);
     }
   }
-
 }
 
 void
@@ -842,12 +788,11 @@ t8_default_scheme_quad_c::t8_element_init (int length, t8_element_t *elem,
 #ifdef T8_ENABLE_DEBUG
   if (!new_called) {
     int                 i;
-    t8_pquad_t   *quads = (t8_pquad_t *) elem;
+    t8_dquad_t   *quads = (t8_dquad_t *) elem;
     /* Set all values to 0 */
     for (i = 0; i < length; i++) {
-      t8_quad_set_morton (quads + i, 0, 0);
-      T8_QUAD_SET_TDIM (quads + i, 2);
-      T8_ASSERT (t8_quad_is_extended (quads + i));
+      t8_dquad_set_morton (quads + i, 0, 0);
+      T8_ASSERT (t8_dquad_is_extended (quads + i));
     }
   }
 #endif
@@ -860,17 +805,16 @@ int
 t8_default_scheme_quad_c::t8_element_is_valid (const t8_element_t * elem) const
 /* *INDENT-ON* */
 {
-  /* TODO: additional checks? do we set pad8 or similar?
-   */
-  return t8_quad_is_extended ((const t8_pquad_t *) elem);
+  /* TODO: additional checks? do we set pad8 or similar? */
+  return t8_dquad_is_extended ((const t8_dquad_t *) elem);
 }
 
 void
 t8_default_scheme_quad_c::t8_element_debug_print (const t8_element_t *elem) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  t8_pquad_t   *quad = (t8_pquad_t *) elem;
-  t8_quad_print (SC_LP_DEBUG, quad);
+  t8_dquad_t   *quad = (t8_dquad_t *) elem;
+  t8_dquad_print (SC_LP_DEBUG, quad);
 }
 #endif
 
@@ -878,7 +822,7 @@ t8_default_scheme_quad_c::t8_element_debug_print (const t8_element_t *elem) cons
 t8_default_scheme_quad_c::t8_default_scheme_quad_c (void)
 {
   eclass = T8_ECLASS_QUAD;
-  element_size = sizeof (t8_pquad_t);
+  element_size = sizeof (t8_dquad_t);
   ts_context = sc_mempool_new (element_size);
 }
 

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.cxx
@@ -20,10 +20,10 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
 
-#include <p4est_bits.h>
 #include <t8_schemes/t8_default/t8_default_line/t8_dline_bits.h>
 #include <t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.hxx>
 #include <t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx>
+#include <t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.h>
 
 /* We want to export the whole implementation to be callable from "C" */
 T8_EXTERN_C_BEGIN ();
@@ -39,8 +39,8 @@ t8_linearidx_t      t8_element_get_linear_id (const t8_element_t *elem,
 /* TODO: Used in one assertion in t8_element_nca, but wrongly triggers error there.
          Investigate and decide whether we really need this. */
 static int
-t8_element_surround_matches (const p4est_quadrant_t * q,
-                             const p4est_quadrant_t * r)
+t8_element_surround_matches (const t8_pquad_t * q,
+                             const t8_pquad_t * r)
 {
   return T8_QUAD_GET_TDIM (q) == T8_QUAD_GET_TDIM (r) &&
     (T8_QUAD_GET_TDIM (q) == -1 ||
@@ -54,7 +54,7 @@ t8_element_surround_matches (const p4est_quadrant_t * q,
 int
 t8_default_scheme_quad_c::t8_element_maxlevel (void)
 {
-  return P4EST_QMAXLEVEL;
+  return T8_QUAD_QMAXLEVEL;
 }
 
 /* *INDENT-OFF* */
@@ -63,7 +63,7 @@ t8_default_scheme_quad_c::t8_element_child_eclass (int childid)
 /* *INDENT-ON* */
 
 {
-  T8_ASSERT (0 <= childid && childid < P4EST_CHILDREN);
+  T8_ASSERT (0 <= childid && childid < T8_QUAD_CHILDREN);
 
   return T8_ECLASS_QUAD;
 }
@@ -72,11 +72,11 @@ int
 t8_default_scheme_quad_c::t8_element_level (const t8_element_t *elem)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  return (int) ((const p4est_quadrant_t *) elem)->level;
+  return (int) ((const t8_pquad_t *) elem)->level;
 }
 
 static void
-t8_element_copy_surround (const p4est_quadrant_t * q, p4est_quadrant_t * r)
+t8_element_copy_surround (const t8_pquad_t * q, t8_pquad_t * r)
 {
   T8_QUAD_SET_TDIM (r, T8_QUAD_GET_TDIM (q));
   if (T8_QUAD_GET_TDIM (q) == 3) {
@@ -89,8 +89,8 @@ void
 t8_default_scheme_quad_c::t8_element_copy (const t8_element_t *source,
                                            t8_element_t *dest)
 {
-  const p4est_quadrant_t *q = (const p4est_quadrant_t *) source;
-  p4est_quadrant_t   *r = (p4est_quadrant_t *) dest;
+  const t8_pquad_t *q = (const t8_pquad_t *) source;
+  t8_pquad_t   *r = (t8_pquad_t *) dest;
 
   T8_ASSERT (t8_element_is_valid (source));
   T8_ASSERT (t8_element_is_valid (dest));
@@ -109,20 +109,20 @@ t8_default_scheme_quad_c::t8_element_compare (const t8_element_t *elem1,
   T8_ASSERT (t8_element_is_valid (elem1));
   T8_ASSERT (t8_element_is_valid (elem2));
 
-  return p4est_quadrant_compare ((const p4est_quadrant_t *) elem1,
-                                 (const p4est_quadrant_t *) elem2);
+  return t8_quad_compare ((const t8_pquad_t *) elem1,
+                                 (const t8_pquad_t *) elem2);
 }
 
 void
 t8_default_scheme_quad_c::t8_element_parent (const t8_element_t *elem,
                                              t8_element_t *parent)
 {
-  const p4est_quadrant_t *q = (const p4est_quadrant_t *) elem;
-  p4est_quadrant_t   *r = (p4est_quadrant_t *) parent;
+  const t8_pquad_t *q = (const t8_pquad_t *) elem;
+  t8_pquad_t   *r = (t8_pquad_t *) parent;
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (parent));
-  p4est_quadrant_parent (q, r);
+  t8_quad_parent (q, r);
   t8_element_copy_surround (q, r);
 }
 
@@ -131,12 +131,12 @@ t8_default_scheme_quad_c::t8_element_sibling (const t8_element_t *elem,
                                               int sibid,
                                               t8_element_t *sibling)
 {
-  const p4est_quadrant_t *q = (const p4est_quadrant_t *) elem;
-  p4est_quadrant_t   *r = (p4est_quadrant_t *) sibling;
+  const t8_pquad_t *q = (const t8_pquad_t *) elem;
+  t8_pquad_t   *r = (t8_pquad_t *) sibling;
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (sibling));
-  p4est_quadrant_sibling (q, r, sibid);
+  t8_quad_sibling (q, r, sibid);
   t8_element_copy_surround (q, r);
 }
 
@@ -144,20 +144,20 @@ int
 t8_default_scheme_quad_c::t8_element_num_faces (const t8_element_t *elem)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  return P4EST_FACES;
+  return T8_QUAD_FACES;
 }
 
 int
 t8_default_scheme_quad_c::t8_element_max_num_faces (const t8_element_t *elem)
 {
-  return P4EST_FACES;
+  return T8_QUAD_FACES;
 }
 
 int
 t8_default_scheme_quad_c::t8_element_num_children (const t8_element_t *elem)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  return P4EST_CHILDREN;
+  return T8_QUAD_CHILDREN;
 }
 
 int
@@ -183,9 +183,9 @@ t8_default_scheme_quad_c::t8_element_get_face_corner (const t8_element_t
    *   0    f_3    1
    */
 
-  T8_ASSERT (0 <= face && face < P4EST_FACES);
+  T8_ASSERT (0 <= face && face < T8_QUAD_FACES);
   T8_ASSERT (0 <= corner && corner < 2);
-  return p4est_face_corners[face][corner];
+  return t8_quad_face_corners[face][corner];
 }
 
 int
@@ -194,29 +194,29 @@ t8_default_scheme_quad_c::t8_element_get_corner_face (const t8_element_t
                                                       int face)
 {
   T8_ASSERT (t8_element_is_valid (element));
-  T8_ASSERT (0 <= corner && corner < P4EST_CHILDREN);
+  T8_ASSERT (0 <= corner && corner < T8_QUAD_CHILDREN);
   T8_ASSERT (0 <= face && face < 2);
-  return p4est_corner_faces[corner][face];
+  return t8_quad_corner_faces[corner][face];
 }
 
 void
 t8_default_scheme_quad_c::t8_element_child (const t8_element_t *elem,
                                             int childid, t8_element_t *child)
 {
-  const p4est_quadrant_t *q = (const p4est_quadrant_t *) elem;
-  const p4est_qcoord_t shift = P4EST_QUADRANT_LEN (q->level + 1);
-  p4est_quadrant_t   *r = (p4est_quadrant_t *) child;
+  const t8_pquad_t *q = (const t8_pquad_t *) elem;
+  const t8_qcoord_t shift = T8_QUAD_QUADRANT_LEN (q->level + 1);
+  t8_pquad_t   *r = (t8_pquad_t *) child;
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (child));
-  T8_ASSERT (p4est_quadrant_is_extended (q));
-  T8_ASSERT (q->level < P4EST_QMAXLEVEL);
-  T8_ASSERT (childid >= 0 && childid < P4EST_CHILDREN);
+  T8_ASSERT (t8_quad_is_extended (q));
+  T8_ASSERT (q->level < T8_QUAD_QMAXLEVEL);
+  T8_ASSERT (childid >= 0 && childid < T8_QUAD_CHILDREN);
 
   r->x = childid & 0x01 ? (q->x | shift) : q->x;
   r->y = childid & 0x02 ? (q->y | shift) : q->y;
   r->level = q->level + 1;
-  T8_ASSERT (p4est_quadrant_is_parent (q, r));
+  T8_ASSERT (t8_quad_is_parent (q, r));
 
   t8_element_copy_surround (q, r);
 }
@@ -225,23 +225,23 @@ void
 t8_default_scheme_quad_c::t8_element_children (const t8_element_t *elem,
                                                int length, t8_element_t *c[])
 {
-  const p4est_quadrant_t *q = (const p4est_quadrant_t *) elem;
+  const t8_pquad_t *q = (const t8_pquad_t *) elem;
   int                 i;
 
   T8_ASSERT (t8_element_is_valid (elem));
 #ifdef T8_ENABLE_DEBUG
   {
     int                 j;
-    for (j = 0; j < P4EST_CHILDREN; j++) {
+    for (j = 0; j < T8_QUAD_CHILDREN; j++) {
       T8_ASSERT (t8_element_is_valid (c[j]));
     }
   }
 #endif
-  T8_ASSERT (length == P4EST_CHILDREN);
+  T8_ASSERT (length == T8_QUAD_CHILDREN);
 
-  p4est_quadrant_childrenpv (q, (p4est_quadrant_t **) c);
-  for (i = 0; i < P4EST_CHILDREN; ++i) {
-    t8_element_copy_surround (q, (p4est_quadrant_t *) c[i]);
+  t8_quad_childrenpv (q, (t8_pquad_t **) c);
+  for (i = 0; i < T8_QUAD_CHILDREN; ++i) {
+    t8_element_copy_surround (q, (t8_pquad_t *) c[i]);
   }
 }
 
@@ -249,14 +249,14 @@ int
 t8_default_scheme_quad_c::t8_element_child_id (const t8_element_t *elem)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  return p4est_quadrant_child_id ((const p4est_quadrant_t *) elem);
+  return t8_quad_child_id ((const t8_pquad_t *) elem);
 }
 
 int
 t8_default_scheme_quad_c::t8_element_ancestor_id (const t8_element_t *elem,
                                                   int level)
 {
-  return p4est_quadrant_ancestor_id ((p4est_quadrant_t *) elem, level);
+  return t8_quad_ancestor_id ((t8_pquad_t *) elem, level);
 }
 
 int
@@ -264,11 +264,11 @@ t8_default_scheme_quad_c::t8_element_is_family (t8_element_t **fam)
 {
 #ifdef T8_ENABLE_DEBUG
   int                 i;
-  for (i = 0; i < P4EST_CHILDREN; i++) {
+  for (i = 0; i < T8_QUAD_CHILDREN; i++) {
     T8_ASSERT (t8_element_is_valid (fam[i]));
   }
 #endif
-  return p4est_quadrant_is_familypv ((p4est_quadrant_t **) fam);
+  return t8_quad_is_familypv ((t8_pquad_t **) fam);
 }
 
 void
@@ -277,11 +277,11 @@ t8_default_scheme_quad_c::t8_element_set_linear_id (t8_element_t *elem,
                                                     t8_linearidx_t id)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  T8_ASSERT (0 <= level && level <= P4EST_QMAXLEVEL);
-  T8_ASSERT (0 <= id && id < ((t8_linearidx_t) 1) << P4EST_DIM * level);
+  T8_ASSERT (0 <= level && level <= T8_QUAD_QMAXLEVEL);
+  T8_ASSERT (0 <= id && id < ((t8_linearidx_t) 1) << T8_QUAD_DIM * level);
 
-  p4est_quadrant_set_morton ((p4est_quadrant_t *) elem, level, id);
-  T8_QUAD_SET_TDIM ((p4est_quadrant_t *) elem, 2);
+  t8_quad_set_morton ((t8_pquad_t *) elem, level, id);
+  T8_QUAD_SET_TDIM ((t8_pquad_t *) elem, 2);
 }
 
 t8_linearidx_t
@@ -289,9 +289,9 @@ t8_linearidx_t
                                                       *elem, int level)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  T8_ASSERT (0 <= level && level <= P4EST_QMAXLEVEL);
+  T8_ASSERT (0 <= level && level <= T8_QUAD_QMAXLEVEL);
 
-  return p4est_quadrant_linear_id ((p4est_quadrant_t *) elem, level);
+  return t8_quad_linear_id ((t8_pquad_t *) elem, level);
 }
 
 void
@@ -302,10 +302,10 @@ t8_default_scheme_quad_c::t8_element_first_descendant (const t8_element_t
 {
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (desc));
-  T8_ASSERT (0 <= level && level <= P4EST_QMAXLEVEL);
-  p4est_quadrant_first_descendant ((p4est_quadrant_t *) elem,
-                                   (p4est_quadrant_t *) desc, level);
-  T8_QUAD_SET_TDIM ((p4est_quadrant_t *) desc, 2);
+  T8_ASSERT (0 <= level && level <= T8_QUAD_QMAXLEVEL);
+  t8_quad_first_descendant ((t8_pquad_t *) elem,
+                                   (t8_pquad_t *) desc, level);
+  T8_QUAD_SET_TDIM ((t8_pquad_t *) desc, 2);
 }
 
 void
@@ -316,10 +316,10 @@ t8_default_scheme_quad_c::t8_element_last_descendant (const t8_element_t
 {
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (desc));
-  T8_ASSERT (0 <= level && level <= P4EST_QMAXLEVEL);
-  p4est_quadrant_last_descendant ((p4est_quadrant_t *) elem,
-                                  (p4est_quadrant_t *) desc, level);
-  T8_QUAD_SET_TDIM ((p4est_quadrant_t *) desc, 2);
+  T8_ASSERT (0 <= level && level <= T8_QUAD_QMAXLEVEL);
+  t8_quad_last_descendant ((t8_pquad_t *) elem,
+                                  (t8_pquad_t *) desc, level);
+  T8_QUAD_SET_TDIM ((t8_pquad_t *) desc, 2);
 }
 
 void
@@ -331,13 +331,13 @@ t8_default_scheme_quad_c::t8_element_successor (const t8_element_t *elem1,
 
   T8_ASSERT (t8_element_is_valid (elem1));
   T8_ASSERT (t8_element_is_valid (elem2));
-  T8_ASSERT (0 <= level && level <= P4EST_QMAXLEVEL);
+  T8_ASSERT (0 <= level && level <= T8_QUAD_QMAXLEVEL);
 
-  id = p4est_quadrant_linear_id ((const p4est_quadrant_t *) elem1, level);
-  T8_ASSERT (id + 1 < ((t8_linearidx_t) 1) << P4EST_DIM * level);
-  p4est_quadrant_set_morton ((p4est_quadrant_t *) elem2, level, id + 1);
-  t8_element_copy_surround ((const p4est_quadrant_t *) elem1,
-                            (p4est_quadrant_t *) elem2);
+  id = t8_quad_linear_id ((const t8_pquad_t *) elem1, level);
+  T8_ASSERT (id + 1 < ((t8_linearidx_t) 1) << T8_QUAD_DIM * level);
+  t8_quad_set_morton ((t8_pquad_t *) elem2, level, id + 1);
+  t8_element_copy_surround ((const t8_pquad_t *) elem1,
+                            (t8_pquad_t *) elem2);
 }
 
 void
@@ -345,9 +345,9 @@ t8_default_scheme_quad_c::t8_element_nca (const t8_element_t *elem1,
                                           const t8_element_t *elem2,
                                           t8_element_t *nca)
 {
-  const p4est_quadrant_t *q1 = (const p4est_quadrant_t *) elem1;
-  const p4est_quadrant_t *q2 = (const p4est_quadrant_t *) elem2;
-  p4est_quadrant_t   *r = (p4est_quadrant_t *) nca;
+  const t8_pquad_t *q1 = (const t8_pquad_t *) elem1;
+  const t8_pquad_t *q2 = (const t8_pquad_t *) elem2;
+  t8_pquad_t   *r = (t8_pquad_t *) nca;
 
   T8_ASSERT (t8_element_is_valid (elem1));
   T8_ASSERT (t8_element_is_valid (elem2));
@@ -357,7 +357,7 @@ t8_default_scheme_quad_c::t8_element_nca (const t8_element_t *elem1,
   T8_ASSERT (t8_element_surround_matches (q1, q2));
 #endif
 
-  p4est_nearest_common_ancestor (q1, q2, r);
+  t8_quad_nearest_common_ancestor (q1, q2, r);
   t8_element_copy_surround (q1, r);
 }
 
@@ -388,7 +388,7 @@ t8_default_scheme_quad_c::t8_element_children_at_face (const t8_element_t
   }
 #endif
   T8_ASSERT (t8_element_is_valid (elem));
-  T8_ASSERT (0 <= face && face < P4EST_FACES);
+  T8_ASSERT (0 <= face && face < T8_QUAD_FACES);
   T8_ASSERT (num_children == t8_element_num_face_children (elem, face));
 
   /*
@@ -454,7 +454,7 @@ int
 t8_default_scheme_quad_c::t8_element_face_parent_face (const t8_element_t
                                                        *elem, int face)
 {
-  const p4est_quadrant_t *q = (const p4est_quadrant_t *) elem;
+  const t8_pquad_t *q = (const t8_pquad_t *) elem;
   int                 child_id;
 
   T8_ASSERT (t8_element_is_valid (elem));
@@ -463,9 +463,9 @@ t8_default_scheme_quad_c::t8_element_face_parent_face (const t8_element_t
   }
   /* Determine whether face is a subface of the parent.
    * This is the case if the child_id matches one of the faces corners */
-  child_id = p4est_quadrant_child_id (q);
-  if (child_id == p4est_face_corners[face][0]
-      || child_id == p4est_face_corners[face][1]) {
+  child_id = t8_quad_child_id (q);
+  if (child_id == t8_quad_face_corners[face][0]
+      || child_id == t8_quad_face_corners[face][1]) {
     return face;
   }
   return -1;
@@ -479,25 +479,25 @@ t8_default_scheme_quad_c::t8_element_transform_face (const t8_element_t
                                                      int sign,
                                                      int is_smaller_face)
 {
-  const p4est_quadrant_t *qin = (const p4est_quadrant_t *) elem1;
-  const p4est_quadrant_t *q;
-  p4est_quadrant_t   *p = (p4est_quadrant_t *) elem2;
-  p4est_qcoord_t      h = P4EST_QUADRANT_LEN (qin->level);
-  p4est_qcoord_t      x = qin->x;       /* temp storage for x coordinate in case elem1 = elem 2 */
+  const t8_pquad_t *qin = (const t8_pquad_t *) elem1;
+  const t8_pquad_t *q;
+  t8_pquad_t   *p = (t8_pquad_t *) elem2;
+  t8_qcoord_t      h = T8_QUAD_QUADRANT_LEN (qin->level);
+  t8_qcoord_t      x = qin->x;       /* temp storage for x coordinate in case elem1 = elem 2 */
 
   T8_ASSERT (t8_element_is_valid (elem1));
   T8_ASSERT (t8_element_is_valid (elem2));
-  T8_ASSERT (0 <= orientation && orientation < P4EST_FACES);
+  T8_ASSERT (0 <= orientation && orientation < T8_QUAD_FACES);
 
   if (sign) {
     /* The tree faces have the same topological orientation, and
      * thus we have to perform a coordinate switch. */
     /* We use p as storage, since elem1 and elem2 are allowed to
      * point to the same quad */
-    q = (const p4est_quadrant_t *) p;
-    t8_element_copy_surround (qin, (p4est_quadrant_t *) q);
-    ((p4est_quadrant_t *) q)->x = qin->y;
-    ((p4est_quadrant_t *) q)->y = x;
+    q = (const t8_pquad_t *) p;
+    t8_element_copy_surround (qin, (t8_pquad_t *) q);
+    ((t8_pquad_t *) q)->x = qin->y;
+    ((t8_pquad_t *) q)->y = x;
     x = q->x;                   /* temp storage in case elem1 = elem 2 */
   }
   else {
@@ -536,16 +536,16 @@ t8_default_scheme_quad_c::t8_element_transform_face (const t8_element_t
     p->y = q->y;
     break;
   case 1:
-    p->x = P4EST_ROOT_LEN - q->y - h;
+    p->x = T8_QUAD_ROOT_LEN - q->y - h;
     p->y = x;
     break;
   case 2:
     p->x = q->y;
-    p->y = P4EST_ROOT_LEN - x - h;
+    p->y = T8_QUAD_ROOT_LEN - x - h;
     break;
   case 3:
-    p->x = P4EST_ROOT_LEN - q->x - h;
-    p->y = P4EST_ROOT_LEN - q->y - h;
+    p->x = T8_QUAD_ROOT_LEN - q->x - h;
+    p->y = T8_QUAD_ROOT_LEN - q->y - h;
     break;
   default:
     SC_ABORT_NOT_REACHED ();
@@ -561,14 +561,14 @@ t8_default_scheme_quad_c::t8_element_extrude_face (const t8_element_t *face,
                                                    int root_face)
 {
   const t8_dline_t   *l = (const t8_dline_t *) face;
-  p4est_quadrant_t   *q = (p4est_quadrant_t *) elem;
+  t8_pquad_t   *q = (t8_pquad_t *) elem;
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (T8_COMMON_IS_TYPE
              (face_scheme, const t8_default_scheme_line_c *));
   T8_ASSERT (face_scheme->eclass == T8_ECLASS_LINE);
   T8_ASSERT (face_scheme->t8_element_is_valid (elem));
-  T8_ASSERT (0 <= root_face && root_face < P4EST_FACES);
+  T8_ASSERT (0 <= root_face && root_face < T8_QUAD_FACES);
   /*
    * The faces of the root quadrant are enumerated like this:
    *
@@ -588,19 +588,19 @@ t8_default_scheme_quad_c::t8_element_extrude_face (const t8_element_t *face,
   switch (root_face) {
   case 0:
     q->x = 0;
-    q->y = ((int64_t) l->x * P4EST_ROOT_LEN) / T8_DLINE_ROOT_LEN;
+    q->y = ((int64_t) l->x * T8_QUAD_ROOT_LEN) / T8_DLINE_ROOT_LEN;
     break;
   case 1:
-    q->x = P4EST_LAST_OFFSET (q->level);
-    q->y = ((int64_t) l->x * P4EST_ROOT_LEN) / T8_DLINE_ROOT_LEN;
+    q->x = T8_QUAD_LAST_OFFSET (q->level);
+    q->y = ((int64_t) l->x * T8_QUAD_ROOT_LEN) / T8_DLINE_ROOT_LEN;
     break;
   case 2:
-    q->x = ((int64_t) l->x * P4EST_ROOT_LEN) / T8_DLINE_ROOT_LEN;
+    q->x = ((int64_t) l->x * T8_QUAD_ROOT_LEN) / T8_DLINE_ROOT_LEN;
     q->y = 0;
     break;
   case 3:
-    q->x = ((int64_t) l->x * P4EST_ROOT_LEN) / T8_DLINE_ROOT_LEN;
-    q->y = P4EST_LAST_OFFSET (q->level);
+    q->x = ((int64_t) l->x * T8_QUAD_ROOT_LEN) / T8_DLINE_ROOT_LEN;
+    q->y = T8_QUAD_LAST_OFFSET (q->level);
     break;
   default:
     SC_ABORT_NOT_REACHED ();
@@ -615,7 +615,7 @@ t8_default_scheme_quad_c::t8_element_tree_face (const t8_element_t *elem,
                                                 int face)
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  T8_ASSERT (0 <= face && face < P4EST_FACES);
+  T8_ASSERT (0 <= face && face < T8_QUAD_FACES);
   /* For quadrants the face and the tree face number are the same. */
   return face;
 }
@@ -628,17 +628,17 @@ t8_default_scheme_quad_c::t8_element_first_descendant_face (const t8_element_t
                                                             *first_desc,
                                                             int level)
 {
-  const p4est_quadrant_t *q = (const p4est_quadrant_t *) elem;
-  p4est_quadrant_t   *desc = (p4est_quadrant_t *) first_desc;
+  const t8_pquad_t *q = (const t8_pquad_t *) elem;
+  t8_pquad_t   *desc = (t8_pquad_t *) first_desc;
   int                 first_face_corner;
 
-  T8_ASSERT (0 <= face && face < P4EST_FACES);
-  T8_ASSERT (0 <= level && level <= P4EST_QMAXLEVEL);
+  T8_ASSERT (0 <= face && face < T8_QUAD_FACES);
+  T8_ASSERT (0 <= level && level <= T8_QUAD_QMAXLEVEL);
 
   /* Get the first corner of q that belongs to face */
-  first_face_corner = p4est_face_corners[face][0];
+  first_face_corner = t8_quad_face_corners[face][0];
   /* Construce the descendant in that corner */
-  p4est_quadrant_corner_descendant (q, desc, first_face_corner, level);
+  t8_quad_corner_descendant (q, desc, first_face_corner, level);
 }
 
 /** Construct the last descendant of an element that touches a given face.   */
@@ -649,17 +649,17 @@ t8_default_scheme_quad_c::t8_element_last_descendant_face (const t8_element_t
                                                            *last_desc,
                                                            int level)
 {
-  const p4est_quadrant_t *q = (const p4est_quadrant_t *) elem;
-  p4est_quadrant_t   *desc = (p4est_quadrant_t *) last_desc;
+  const t8_pquad_t *q = (const t8_pquad_t *) elem;
+  t8_pquad_t   *desc = (t8_pquad_t *) last_desc;
   int                 last_face_corner;
 
-  T8_ASSERT (0 <= face && face < P4EST_FACES);
-  T8_ASSERT (0 <= level && level <= P4EST_QMAXLEVEL);
+  T8_ASSERT (0 <= face && face < T8_QUAD_FACES);
+  T8_ASSERT (0 <= level && level <= T8_QUAD_QMAXLEVEL);
 
   /* Get the last corner of q that belongs to face */
-  last_face_corner = p4est_face_corners[face][1];
+  last_face_corner = t8_quad_face_corners[face][1];
   /* Construce the descendant in that corner */
-  p4est_quadrant_corner_descendant (q, desc, last_face_corner, level);
+  t8_quad_corner_descendant (q, desc, last_face_corner, level);
 }
 
 void
@@ -669,7 +669,7 @@ t8_default_scheme_quad_c::t8_element_boundary_face (const t8_element_t *elem,
                                                     const t8_eclass_scheme_c
                                                     *boundary_scheme)
 {
-  const p4est_quadrant_t *q = (const p4est_quadrant_t *) elem;
+  const t8_pquad_t *q = (const t8_pquad_t *) elem;
   t8_dline_t         *l = (t8_dline_t *) boundary;
 
   T8_ASSERT (t8_element_is_valid (elem));
@@ -677,7 +677,7 @@ t8_default_scheme_quad_c::t8_element_boundary_face (const t8_element_t *elem,
              (boundary_scheme, const t8_default_scheme_line_c *));
   T8_ASSERT (boundary_scheme->eclass == T8_ECLASS_LINE);
   T8_ASSERT (boundary_scheme->t8_element_is_valid (boundary));
-  T8_ASSERT (0 <= face && face < P4EST_FACES);
+  T8_ASSERT (0 <= face && face < T8_QUAD_FACES);
   /* The level of the boundary element is the same as the quadrant's level */
   l->level = q->level;
   /*
@@ -693,7 +693,7 @@ t8_default_scheme_quad_c::t8_element_boundary_face (const t8_element_t *elem,
    * if face = 2 or face = 3 then l->x = q->x
    */
   l->x = ((face >> 1 ? q->x : q->y) *
-          ((int64_t) T8_DLINE_ROOT_LEN) / P4EST_ROOT_LEN);
+          ((int64_t) T8_DLINE_ROOT_LEN) / T8_QUAD_ROOT_LEN);
 }
 
 void
@@ -711,8 +711,8 @@ t8_default_scheme_quad_c::t8_element_boundary (const t8_element_t *elem,
   T8_ASSERT (length ==
              t8_eclass_count_boundary (T8_ECLASS_QUAD, min_dim, per_eclass));
 
-  T8_ASSERT (length == P4EST_FACES);
-  for (iface = 0; iface < P4EST_FACES; iface++) {
+  T8_ASSERT (length == T8_QUAD_FACES);
+  for (iface = 0; iface < T8_QUAD_FACES; iface++) {
     t8_element_boundary_face (elem, iface, boundary[iface]);
   }
 #endif
@@ -722,11 +722,11 @@ int
 t8_default_scheme_quad_c::t8_element_is_root_boundary (const t8_element_t
                                                        *elem, int face)
 {
-  const p4est_quadrant_t *q = (const p4est_quadrant_t *) elem;
-  p4est_qcoord_t      coord;
+  const t8_pquad_t *q = (const t8_pquad_t *) elem;
+  t8_qcoord_t      coord;
 
   T8_ASSERT (t8_element_is_valid (elem));
-  T8_ASSERT (0 <= face && face < P4EST_FACES);
+  T8_ASSERT (0 <= face && face < T8_QUAD_FACES);
 
   /* if face is 0 or 1 q->x
    *            2 or 3 q->y
@@ -734,7 +734,7 @@ t8_default_scheme_quad_c::t8_element_is_root_boundary (const t8_element_t
   coord = face >> 1 ? q->y : q->x;
   /* If face is 0 or 2 check against 0.
    * If face is 1 or 3  check against LAST_OFFSET */
-  return coord == (face & 1 ? P4EST_LAST_OFFSET (q->level) : 0);
+  return coord == (face & 1 ? T8_QUAD_LAST_OFFSET (q->level) : 0);
 }
 
 int
@@ -744,33 +744,33 @@ t8_default_scheme_quad_c::t8_element_face_neighbor_inside (const t8_element_t
                                                            *neigh, int face,
                                                            int *neigh_face)
 {
-  const p4est_quadrant_t *q = (const p4est_quadrant_t *) elem;
-  p4est_quadrant_t   *n = (p4est_quadrant_t *) neigh;
+  const t8_pquad_t *q = (const t8_pquad_t *) elem;
+  t8_pquad_t   *n = (t8_pquad_t *) neigh;
 
   T8_ASSERT (t8_element_is_valid (elem));
   T8_ASSERT (t8_element_is_valid (neigh));
-  T8_ASSERT (0 <= face && face < P4EST_FACES);
+  T8_ASSERT (0 <= face && face < T8_QUAD_FACES);
   /* Construct the face neighbor */
-  p4est_quadrant_face_neighbor (q, face, n);
+  t8_quad_face_neighbor (q, face, n);
   T8_QUAD_SET_TDIM (n, 2);
   /* Compute the face number as seen from q.
    *  0 -> 1    2 -> 3
    *  1 -> 0    3 -> 2
    */
   T8_ASSERT (neigh_face != NULL);
-  *neigh_face = p4est_face_dual[face];
+  *neigh_face = t8_quad_face_dual[face];
   /* return true if neigh is inside the root */
-  return p4est_quadrant_is_inside_root (n);
+  return t8_quad_is_inside_root (n);
 }
 
 void
 t8_default_scheme_quad_c::t8_element_anchor (const t8_element_t *elem,
                                              int coord[3])
 {
-  p4est_quadrant_t   *q;
+  t8_pquad_t   *q;
 
   T8_ASSERT (t8_element_is_valid (elem));
-  q = (p4est_quadrant_t *) elem;
+  q = (t8_pquad_t *) elem;
   coord[0] = q->x;
   coord[1] = q->y;
   coord[2] = 0;
@@ -780,20 +780,20 @@ t8_default_scheme_quad_c::t8_element_anchor (const t8_element_t *elem,
 int
 t8_default_scheme_quad_c::t8_element_root_len (const t8_element_t *elem)
 {
-  return P4EST_ROOT_LEN;
+  return T8_QUAD_ROOT_LEN;
 }
 
 void
 t8_default_scheme_quad_c::t8_element_vertex_coords (const t8_element_t *t,
                                                     int vertex, int coords[])
 {
-  const p4est_quadrant_t *q1 = (const p4est_quadrant_t *) t;
+  const t8_pquad_t *q1 = (const t8_pquad_t *) t;
   int                 len;
 
   T8_ASSERT (t8_element_is_valid (t));
   T8_ASSERT (0 <= vertex && vertex < 4);
   /* Get the length of the quadrant */
-  len = P4EST_QUADRANT_LEN (q1->level);
+  len = T8_QUAD_QUADRANT_LEN (q1->level);
   /* Compute the x and y coordinates of the vertex depending on the
    * vertex number */
   coords[0] = q1->x + (vertex & 1 ? 1 : 0) * len;
@@ -814,8 +814,8 @@ t8_default_scheme_quad_c::t8_element_vertex_reference_coords (const
 
   /* We divide the integer coordinates by the root length of the quad
    * to obtain the reference coordinates. */
-  coords[0] = coords_int[0] / (double) P4EST_ROOT_LEN;
-  coords[1] = coords_int[1] / (double) P4EST_ROOT_LEN;
+  coords[0] = coords_int[0] / (double) T8_QUAD_ROOT_LEN;
+  coords[1] = coords_int[1] / (double) T8_QUAD_ROOT_LEN;
 }
 
 void
@@ -829,7 +829,7 @@ t8_default_scheme_quad_c::t8_element_new (int length, t8_element_t **elem)
     int                 i;
     for (i = 0; i < length; i++) {
       t8_element_init (1, elem[i], 0);
-      T8_QUAD_SET_TDIM ((p4est_quadrant_t *) elem[i], 2);
+      T8_QUAD_SET_TDIM ((t8_pquad_t *) elem[i], 2);
     }
   }
 
@@ -842,12 +842,12 @@ t8_default_scheme_quad_c::t8_element_init (int length, t8_element_t *elem,
 #ifdef T8_ENABLE_DEBUG
   if (!new_called) {
     int                 i;
-    p4est_quadrant_t   *quads = (p4est_quadrant_t *) elem;
+    t8_pquad_t   *quads = (t8_pquad_t *) elem;
     /* Set all values to 0 */
     for (i = 0; i < length; i++) {
-      p4est_quadrant_set_morton (quads + i, 0, 0);
+      t8_quad_set_morton (quads + i, 0, 0);
       T8_QUAD_SET_TDIM (quads + i, 2);
-      T8_ASSERT (p4est_quadrant_is_extended (quads + i));
+      T8_ASSERT (t8_quad_is_extended (quads + i));
     }
   }
 #endif
@@ -862,15 +862,15 @@ t8_default_scheme_quad_c::t8_element_is_valid (const t8_element_t * elem) const
 {
   /* TODO: additional checks? do we set pad8 or similar?
    */
-  return p4est_quadrant_is_extended ((const p4est_quadrant_t *) elem);
+  return t8_quad_is_extended ((const t8_pquad_t *) elem);
 }
 
 void
 t8_default_scheme_quad_c::t8_element_debug_print (const t8_element_t *elem) const
 {
   T8_ASSERT (t8_element_is_valid (elem));
-  p4est_quadrant_t   *quad = (p4est_quadrant_t *) elem;
-  p4est_quadrant_print (SC_LP_DEBUG, quad);
+  t8_pquad_t   *quad = (t8_pquad_t *) elem;
+  t8_quad_print (SC_LP_DEBUG, quad);
 }
 #endif
 

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
@@ -20,51 +20,12 @@
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
 
-/** \file t8_default_quad.h
- * We use a T8 quadrant object as basic storage unit per element.
- * To record if and if yes, how this quadrant is part of a 3D octant, we use
- * the member pad8 for the surrounding toplevel dimension (2 or 3), pad16 for
- * the direction of its normal relative to a toplevel octant (0, 1, or 2), and
- * p.user_long for the t8_qcoord_t coordinate in the normal direction.
- */
-
 #ifndef T8_DEFAULT_QUAD_CXX_HXX
 #define T8_DEFAULT_QUAD_CXX_HXX
 
 #include <t8_element_cxx.hxx>
 #include <t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx>
 #include <t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.hxx>
-
-/** Return the toplevel dimension. */
-#define T8_QUAD_GET_TDIM(quad) ((int) (quad)->pad8)
-
-/** Return the direction of the third dimension.
- * This is only valid to call if the toplevel dimension is three.
- */
-#define T8_QUAD_GET_TNORMAL(quad)                               \
-  ( T8_ASSERT (T8_QUAD_GET_TDIM(quad) == 3),                    \
-    ((int) (quad)->pad16) )
-
-/** Return the coordinate in the third dimension.
- * This is only valid to call if the toplevel dimension is three.
- */
-#define T8_QUAD_GET_TCOORD(quad)                                \
-  ( T8_ASSERT (T8_QUAD_GET_TDIM(quad) == 3),                    \
-    ((int) (quad)->p.user_long) )
-
-/** Set the toplevel dimension of a quadrilateral. */
-#define T8_QUAD_SET_TDIM(quad,dim)                              \
-  do { T8_ASSERT ((dim) == 2 || (dim) == 3);                    \
-       (quad)->pad8 = (int8_t) (dim); } while (0)
-
-/** Set the direction of the third demension. */
-#define T8_QUAD_SET_TNORMAL(quad,normal)                        \
-  do { T8_ASSERT ((normal) >= 0 && (normal) < 3);               \
-       (quad)->pad16 = (int16_t) (normal); } while (0)
-
-/** Set the coordinate in the third dimension. */
-#define T8_QUAD_SET_TCOORD(quad,coord)                          \
-  do { (quad)->p.user_long = (long) (coord); } while (0)
 
 #if 0
 /** Provide an implementation for the quadrilateral element class. */
@@ -90,35 +51,35 @@ public:
   virtual void        t8_element_init (int length, t8_element_t *elem,
                                        int called_new);
 
-/** Return the maximum level allowed for this element class. */
+  /** Return the maximum level allowed for this element class. */
   virtual int         t8_element_maxlevel (void);
 
-/** Return the type of each child in the ordering of the implementation. */
+  /** Return the type of each child in the ordering of the implementation. */
   virtual t8_eclass_t t8_element_child_eclass (int childid);
 
-/** Return the refinement level of an element. */
+  /** Return the refinement level of an element. */
   virtual int         t8_element_level (const t8_element_t *elem);
 
-/** Copy one element to another */
+  /** Copy one element to another */
   virtual void        t8_element_copy (const t8_element_t *source,
                                        t8_element_t *dest);
 
-/** Compare to elements. returns negativ if elem1 < elem2, zero if elem1 equals elem2
- *  and positiv if elem1 > elem2.
- *  If elem2 is a copy of elem1 then the elements are equal.
- */
+  /** Compare to elements. returns negativ if elem1 < elem2, zero if elem1 equals elem2
+   *  and positiv if elem1 > elem2.
+   *  If elem2 is a copy of elem1 then the elements are equal.
+   */
   virtual int         t8_element_compare (const t8_element_t *elem1,
                                           const t8_element_t *elem2);
 
-/** Construct the parent of a given element. */
+  /** Construct the parent of a given element. */
   virtual void        t8_element_parent (const t8_element_t *elem,
                                          t8_element_t *parent);
 
-/** Construct a same-size sibling of a given element. */
+  /** Construct a same-size sibling of a given element. */
   virtual void        t8_element_sibling (const t8_element_t *elem,
                                           int sibid, t8_element_t *sibling);
 
-  /** Compute the number of face of a given element. */
+   /** Compute the number of face of a given element. */
   virtual int         t8_element_num_faces (const t8_element_t *elem);
 
   /** Compute the maximum number of faces of a given element and all of its
@@ -143,25 +104,25 @@ public:
   virtual int         t8_element_get_corner_face (const t8_element_t *element,
                                                   int corner, int face);
 
-/** Construct the child element of a given number. */
+  /** Construct the child element of a given number. */
   virtual void        t8_element_child (const t8_element_t *elem,
                                         int childid, t8_element_t *child);
 
-/** Construct all children of a given element. */
+  /** Construct all children of a given element. */
   virtual void        t8_element_children (const t8_element_t *elem,
                                            int length, t8_element_t *c[]);
 
-/** Return the child id of an element */
+  /** Return the child id of an element */
   virtual int         t8_element_child_id (const t8_element_t *elem);
 
   /** Compute the ancestor id of an element */
   virtual int         t8_element_ancestor_id (const t8_element_t *elem,
                                               int level);
 
-/** Return nonzero if collection of elements is a family */
+  /** Return nonzero if collection of elements is a family */
   virtual int         t8_element_is_family (t8_element_t **fam);
 
-/** Construct the nearest common ancestor of two elements in the same tree. */
+  /** Construct the nearest common ancestor of two elements in the same tree. */
   virtual void        t8_element_nca (const t8_element_t *elem1,
                                       const t8_element_t *elem2,
                                       t8_element_t *nca);
@@ -231,7 +192,7 @@ public:
                                                 const t8_eclass_scheme_c
                                                 *boundary_scheme);
 
-/** Construct all codimension-one boundary elements of a given element. */
+  /** Construct all codimension-one boundary elements of a given element. */
   virtual void        t8_element_boundary (const t8_element_t *elem,
                                            int min_dim, int length,
                                            t8_element_t **boundary);
@@ -252,40 +213,40 @@ public:
                                                        int face,
                                                        int *neigh_face);
 
-/** Initialize an element according to a given linear id */
+  /** Initialize an element according to a given linear id */
   virtual void        t8_element_set_linear_id (t8_element_t *elem,
                                                 int level, t8_linearidx_t id);
 
-/** Calculate the linear id of an element */
+  /** Calculate the linear id of an element */
   virtual t8_linearidx_t t8_element_get_linear_id (const
                                                    t8_element_t *elem,
                                                    int level);
 
-/** Calculate the first descendant of a given element e. That is, the
- *  first element in a uniform refinement of e of the maximal possible level.
- */
+  /** Calculate the first descendant of a given element e. That is, the
+   *  first element in a uniform refinement of e of the maximal possible level.
+   */
   virtual void        t8_element_first_descendant (const t8_element_t *elem,
                                                    t8_element_t *desc,
                                                    int level);
 
-/** Calculate the last descendant of a given element e. That is, the
- *  last element in a uniform refinement of e of the maximal possible level.
- */
+  /** Calculate the last descendant of a given element e. That is, the
+   *  last element in a uniform refinement of e of the maximal possible level.
+   */
   virtual void        t8_element_last_descendant (const t8_element_t *elem,
                                                   t8_element_t *desc,
                                                   int level);
 
-/** Compute s as a successor of t*/
+  /** Compute s as a successor of t*/
   virtual void        t8_element_successor (const t8_element_t *t,
                                             t8_element_t *s, int level);
 
-/** Get the integer coordinates of the anchor node of an element */
+  /** Get the integer coordinates of the anchor node of an element */
   virtual void        t8_element_anchor (const t8_element_t *elem,
                                          int anchor[3]);
 
-/** Get the integer root length of an element, that is the length of
- *  the level 0 ancestor.
- */
+  /** Get the integer root length of an element, that is the length of
+   *  the level 0 ancestor.
+   */
   virtual int         t8_element_root_len (const t8_element_t *elem);
 
   /** Compute the integer coordinates of a given element vertex. */

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_default_quad_cxx.hxx
@@ -21,26 +21,19 @@
 */
 
 /** \file t8_default_quad.h
- * We use a p4est_quadrant_t object as storage for the T8 quadrant.
+ * We use a T8 quadrant object as basic storage unit per element.
  * To record if and if yes, how this quadrant is part of a 3D octant, we use
  * the member pad8 for the surrounding toplevel dimension (2 or 3), pad16 for
  * the direction of its normal relative to a toplevel octant (0, 1, or 2), and
- * p.user_long for the p4est_qcoord_t coordinate in the normal direction.
+ * p.user_long for the t8_qcoord_t coordinate in the normal direction.
  */
 
 #ifndef T8_DEFAULT_QUAD_CXX_HXX
 #define T8_DEFAULT_QUAD_CXX_HXX
 
-#include <p4est.h>
 #include <t8_element_cxx.hxx>
 #include <t8_schemes/t8_default/t8_default_line/t8_default_line_cxx.hxx>
 #include <t8_schemes/t8_default/t8_default_common/t8_default_common_cxx.hxx>
-
-/** The structure holding a quadrilateral element in the default scheme.
- * We make this definition public for interoperability of element classes.
- * We might want to put this into a private, scheme-specific header file.
- */
-typedef p4est_quadrant_t t8_pquad_t;
 
 /** Return the toplevel dimension. */
 #define T8_QUAD_GET_TDIM(quad) ((int) (quad)->pad8)

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_dquad.h
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_dquad.h
@@ -3,45 +3,43 @@
 
 #include <t8.h>
 
-#define T8_QUAD_QMAXLEVEL 29
+#define T8_DQUAD_DIM 2
 
-#define T8_QUAD_MAXLEVEL 30
+#define T8_DQUAD_CHILDREN 4
 
-#define T8_QUAD_ROOT_LEN ((t8_qcoord_t) 1 << T8_QUAD_MAXLEVEL)
+#define T8_DQUAD_MAXLEVEL 30
 
-#define T8_QUAD_CHILDREN 4
+#define T8_DQUAD_QMAXLEVEL 29
 
-#define T8_QUAD_DIM 2
+#define T8_DQUAD_FACES (2 * T8_DQUAD_DIM)
 
-#define T8_QUAD_FACES (2 * T8_QUAD_DIM)
+#define T8_DQUAD_ROOT_LEN ((t8_qcoord_t) 1 << T8_DQUAD_MAXLEVEL)
 
-#define T8_QUAD_QUADRANT_LEN(l) ((t8_qcoord_t) 1 << (T8_QUAD_MAXLEVEL - (l)))
+#define T8_DQUAD_LEN(l) ((t8_qcoord_t) 1 << (T8_DQUAD_MAXLEVEL - (l)))
 
-#define T8_QUAD_LAST_OFFSET(l) (T8_QUAD_ROOT_LEN - T8_QUAD_QUADRANT_LEN (l))
+#define T8_DQUAD_LAST_OFFSET(l) (T8_DQUAD_ROOT_LEN - T8_DQUAD_LEN (l))
 
-#define T8_QUAD_LEN(l) ((t8_qcoord_t) 1 << (T8_QUAD_MAXLEVEL - (l)))
-
-static const int           t8_quad_face_corners[4][2] =
+static const int t8_dquad_face_corners[4][2] =
 {{ 0, 2 },
  { 1, 3 },
  { 0, 1 },
  { 2, 3 }};
 
-static const int           t8_quad_face_dual[4] = { 1, 0, 3, 2 };
+static const int t8_dquad_face_dual[4] = { 1, 0, 3, 2 };
 
-static const int           t8_quad_corner_faces[4][2] =
+static const int t8_dquad_corner_faces[4][2] =
 {{ 0, 2 },
  { 1, 2 },
  { 0, 3 },
  { 1, 3 }};
 
-static const int           t8_quad_corner_face_corners[4][4] =
+static const int t8_dquad_corner_face_corners[4][4] =
 {{  0, -1,  0, -1 },
  { -1,  0,  1, -1 },
  {  1, -1, -1,  0 },
  { -1,  1, -1,  1 }};
 
-static const int           t8_quad_child_corner_faces[4][4] =
+static const int t8_dquad_child_corner_faces[4][4] =
 {{ -1,  2,  0, -1 },
  {  2, -1, -1,  1 },
  {  0, -1, -1,  3 },
@@ -49,16 +47,9 @@ static const int           t8_quad_child_corner_faces[4][4] =
 
 typedef struct t8_dquad
 {
-  t8_qcoord_t         x, y;  /**< coordinates */
-  int8_t              level,    /**< level of refinement */
-                      pad8;     /**< padding */
-  int16_t             pad16;    /**< padding */
-
-  union t8_quadrant_data
-  {
-    long user_long;
-  } p;
+  t8_qcoord_t         x, y;
+  int8_t              level;
 }
-t8_pquad_t;
+t8_dquad_t;
 
 #endif /* T8_DQUAD_H */

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_dquad.h
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_dquad.h
@@ -1,50 +1,57 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element classes in parallel.
+
+  Copyright (C) 2015 the developers
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+/** \file t8_dquad.h */
+
 #ifndef T8_DQUAD_H
 #define T8_DQUAD_H
 
 #include <t8.h>
 
+/** Spatial dimension of a quadrant. */
 #define T8_DQUAD_DIM 2
 
+/** The number of children that a quadrant is refined into. */
 #define T8_DQUAD_CHILDREN 4
 
+/** The maximum refinement level allowed for a node within a quadrant. */
 #define T8_DQUAD_MAXLEVEL 30
 
+/** The maximum refinement level allowed for a quadrant. */
 #define T8_DQUAD_QMAXLEVEL 29
 
+/** The number of faces of a quadrant. */
 #define T8_DQUAD_FACES (2 * T8_DQUAD_DIM)
 
+/** The length of the root quadrant in integer coordinates. */
 #define T8_DQUAD_ROOT_LEN ((t8_qcoord_t) 1 << T8_DQUAD_MAXLEVEL)
 
+/** The length of a quadrant at a given level in integer coordinates. */
 #define T8_DQUAD_LEN(l) ((t8_qcoord_t) 1 << (T8_DQUAD_MAXLEVEL - (l)))
 
+/** The offset of the highest (farthest from the origin) quadrant at level l. */
 #define T8_DQUAD_LAST_OFFSET(l) (T8_DQUAD_ROOT_LEN - T8_DQUAD_LEN (l))
 
-static const int t8_dquad_face_corners[4][2] =
-{{ 0, 2 },
- { 1, 3 },
- { 0, 1 },
- { 2, 3 }};
-
-static const int t8_dquad_face_dual[4] = { 1, 0, 3, 2 };
-
-static const int t8_dquad_corner_faces[4][2] =
-{{ 0, 2 },
- { 1, 2 },
- { 0, 3 },
- { 1, 3 }};
-
-static const int t8_dquad_corner_face_corners[4][4] =
-{{  0, -1,  0, -1 },
- { -1,  0,  1, -1 },
- {  1, -1, -1,  0 },
- { -1,  1, -1,  1 }};
-
-static const int t8_dquad_child_corner_faces[4][4] =
-{{ -1,  2,  0, -1 },
- {  2, -1, -1,  1 },
- {  0, -1, -1,  3 },
- { -1,  1,  3, -1 }};
-
+/** This data type encodes a quadrant. */
 typedef struct t8_dquad
 {
   t8_qcoord_t         x, y;

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_dquad.h
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_dquad.h
@@ -1,0 +1,64 @@
+#ifndef T8_DQUAD_H
+#define T8_DQUAD_H
+
+#include <t8.h>
+
+#define T8_QUAD_QMAXLEVEL 29
+
+#define T8_QUAD_MAXLEVEL 30
+
+#define T8_QUAD_ROOT_LEN ((t8_qcoord_t) 1 << T8_QUAD_MAXLEVEL)
+
+#define T8_QUAD_CHILDREN 4
+
+#define T8_QUAD_DIM 2
+
+#define T8_QUAD_FACES (2 * T8_QUAD_DIM)
+
+#define T8_QUAD_QUADRANT_LEN(l) ((t8_qcoord_t) 1 << (T8_QUAD_MAXLEVEL - (l)))
+
+#define T8_QUAD_LAST_OFFSET(l) (T8_QUAD_ROOT_LEN - T8_QUAD_QUADRANT_LEN (l))
+
+#define T8_QUAD_LEN(l) ((t8_qcoord_t) 1 << (T8_QUAD_MAXLEVEL - (l)))
+
+static const int           t8_quad_face_corners[4][2] =
+{{ 0, 2 },
+ { 1, 3 },
+ { 0, 1 },
+ { 2, 3 }};
+
+static const int           t8_quad_face_dual[4] = { 1, 0, 3, 2 };
+
+static const int           t8_quad_corner_faces[4][2] =
+{{ 0, 2 },
+ { 1, 2 },
+ { 0, 3 },
+ { 1, 3 }};
+
+static const int           t8_quad_corner_face_corners[4][4] =
+{{  0, -1,  0, -1 },
+ { -1,  0,  1, -1 },
+ {  1, -1, -1,  0 },
+ { -1,  1, -1,  1 }};
+
+static const int           t8_quad_child_corner_faces[4][4] =
+{{ -1,  2,  0, -1 },
+ {  2, -1, -1,  1 },
+ {  0, -1, -1,  3 },
+ { -1,  1,  3, -1 }};
+
+typedef struct t8_dquad
+{
+  t8_qcoord_t         x, y;  /**< coordinates */
+  int8_t              level,    /**< level of refinement */
+                      pad8;     /**< padding */
+  int16_t             pad16;    /**< padding */
+
+  union t8_quadrant_data
+  {
+    long user_long;
+  } p;
+}
+t8_pquad_t;
+
+#endif /* T8_DQUAD_H */

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.c
@@ -1,0 +1,605 @@
+#ifdef T8_QUAD_TO_HEX
+#include <t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.h>
+
+#define t8_pquad_t t8_phex_t
+
+#define T8_QUAD_QMAXLEVEL   T8_HEX_QMAXLEVEL
+#define T8_QUAD_MAXLEVEL    T8_HEX_MAXLEVEL
+#define T8_QUAD_ROOT_LEN    T8_HEX_ROOT_LEN
+#define T8_QUAD_CHILDREN    T8_HEX_CHILDREN
+#define T8_QUAD_DIM         T8_HEX_DIM
+#define T8_QUAD_FACES       T8_HEX_FACES
+#define T8_QUAD_LEN         T8_HEX_LEN
+#define T8_QUAD_LAST_OFFSET T8_HEX_LAST_OFFSET
+
+#define t8_quad_parent t8_hex_parent
+#define t8_quad_sibling t8_hex_sibling
+#define t8_quad_compare t8_hex_compare
+#define t8_quad_is_extended t8_hex_is_extended
+#define t8_quad_is_parent t8_hex_is_parent
+#define t8_quad_childrenpv t8_hex_childrenpv
+#define t8_quad_ancestor_id t8_hex_ancestor_id
+#define t8_quad_is_familypv t8_hex_is_familypv
+#define t8_quad_set_morton t8_hex_set_morton
+#define t8_quad_linear_id t8_hex_linear_id
+#define t8_quad_first_descendant t8_hex_first_descendant
+#define t8_quad_nearest_common_ancestor t8_hex_nearest_common_ancestor
+#define t8_quad_corner_descendant t8_hex_corner_descendant
+#define t8_quad_face_neighbor t8_hex_face_neighbor
+#define t8_quad_is_inside_root t8_hex_is_inside_root
+#define t8_quad_print t8_hex_print
+#define t8_quad_last_descendant t8_hex_last_descendant
+#define t8_quad_is_node t8_hex_is_node
+#define t8_quad_is_inside_3x3 t8_hex_is_inside_3x3
+#define t8_quad_is_valid t8_hex_is_valid
+#define t8_quad_is_family t8_hex_is_family
+#define t8_quad_children t8_hex_children
+#define t8_quad_child_id t8_hex_child_id
+
+#else
+#include <t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.h>
+#endif
+
+void
+t8_quad_parent (const t8_pquad_t * q, t8_pquad_t * r)
+{
+  T8_ASSERT (t8_quad_is_extended (q));
+  T8_ASSERT (q->level > 0);
+
+  r->x = q->x & ~T8_QUAD_LEN (q->level);
+  r->y = q->y & ~T8_QUAD_LEN (q->level);
+#ifdef T8_QUAD_TO_HEX
+  r->z = q->z & ~T8_QUAD_LEN (q->level);
+#endif
+  r->level = (int8_t) (q->level - 1);
+  T8_ASSERT (t8_quad_is_extended (r));
+}
+
+void
+t8_quad_sibling (const t8_pquad_t * q, t8_pquad_t * r,
+                        int sibling_id)
+{
+  const int           addx = (sibling_id & 0x01);
+  const int           addy = (sibling_id & 0x02) >> 1;
+#ifdef T8_QUAD_TO_HEX
+  const int           addz = (sibling_id & 0x04) >> 2;
+#endif
+  const t8_qcoord_t shift = T8_QUAD_LEN (q->level);
+
+  T8_ASSERT (t8_quad_is_extended (q));
+  T8_ASSERT (q->level > 0);
+  T8_ASSERT (sibling_id >= 0 && sibling_id < T8_QUAD_CHILDREN);
+
+  r->x = (addx ? (q->x | shift) : (q->x & ~shift));
+  r->y = (addy ? (q->y | shift) : (q->y & ~shift));
+#ifdef T8_QUAD_TO_HEX
+  r->z = (addz ? (q->z | shift) : (q->z & ~shift));
+#endif
+  r->level = q->level;
+  T8_ASSERT (t8_quad_is_extended (r));
+}
+
+int
+t8_quad_compare (const void *v1, const void *v2)
+{
+  const t8_pquad_t *q1 = (const t8_pquad_t *) v1;
+  const t8_pquad_t *q2 = (const t8_pquad_t *) v2;
+
+  uint32_t            exclorx, exclory, exclorxy, exclor;
+#ifdef T8_QUAD_TO_HEX
+  uint32_t            exclorz;
+#endif
+  int64_t             p1, p2, diff;
+
+  T8_ASSERT (t8_quad_is_node (q1, 1) ||
+                t8_quad_is_extended (q1));
+  T8_ASSERT (t8_quad_is_node (q2, 1) ||
+                t8_quad_is_extended (q2));
+
+  /* these are unsigned variables that inherit the sign bits */
+  exclorx = q1->x ^ q2->x;
+  exclory = q1->y ^ q2->y;
+  exclor = exclorxy = exclorx | exclory;
+#ifdef T8_QUAD_TO_HEX
+  exclorz = q1->z ^ q2->z;
+  exclor = exclorxy | exclorz;
+#endif
+
+  if (!exclor) {
+    return (int) q1->level - (int) q2->level;
+  }
+
+#ifdef T8_QUAD_TO_HEX
+  /* if (exclor ^ exclorz) > exclorz, then exclorxy has a more significant bit
+   * than exclorz; also exclor and (exclor ^ exclorz) cannot be equal */
+  if (exclorz > (exclor ^ exclorz)) {
+    p1 = q1->z + ((q1->z >= 0) ? 0 : ((int64_t) 1 << (T8_QUAD_MAXLEVEL + 2)));
+    p2 = q2->z + ((q2->z >= 0) ? 0 : ((int64_t) 1 << (T8_QUAD_MAXLEVEL + 2)));
+  }
+  else
+#if 0
+    ;
+#endif
+#endif
+  if (exclory > (exclorxy ^ exclory)) {
+    p1 = q1->y + ((q1->y >= 0) ? 0 : ((int64_t) 1 << (T8_QUAD_MAXLEVEL + 2)));
+    p2 = q2->y + ((q2->y >= 0) ? 0 : ((int64_t) 1 << (T8_QUAD_MAXLEVEL + 2)));
+  }
+  else {
+    p1 = q1->x + ((q1->x >= 0) ? 0 : ((int64_t) 1 << (T8_QUAD_MAXLEVEL + 2)));
+    p2 = q2->x + ((q2->x >= 0) ? 0 : ((int64_t) 1 << (T8_QUAD_MAXLEVEL + 2)));
+  }
+  diff = p1 - p2;
+  return (diff == 0) ? 0 : ((diff < 0) ? -1 : 1);
+}
+
+int
+t8_quad_is_extended (const t8_pquad_t * q)
+{
+  return
+    (q->level >= 0 && q->level <= T8_QUAD_QMAXLEVEL) &&
+    ((q->x & (T8_QUAD_LEN (q->level) - 1)) == 0) &&
+    ((q->y & (T8_QUAD_LEN (q->level) - 1)) == 0) &&
+#ifdef T8_QUAD_TO_HEX
+    ((q->z & (T8_QUAD_LEN (q->level) - 1)) == 0) &&
+#endif
+    t8_quad_is_inside_3x3 (q);
+}
+
+int
+t8_quad_is_parent (const t8_pquad_t * q,
+                          const t8_pquad_t * r)
+{
+  T8_ASSERT (t8_quad_is_extended (q));
+  T8_ASSERT (t8_quad_is_extended (r));
+
+  return
+    (q->level + 1 == r->level) &&
+    (q->x == (r->x & ~T8_QUAD_LEN (r->level))) &&
+    (q->y == (r->y & ~T8_QUAD_LEN (r->level))) &&
+#ifdef T8_QUAD_TO_HEX
+    (q->z == (r->z & ~T8_QUAD_LEN (r->level))) &&
+#endif
+    1;
+}
+
+void
+t8_quad_childrenpv (const t8_pquad_t * q, t8_pquad_t * c[])
+{
+  t8_quad_children (q, c[0], c[1], c[2], c[3]
+#ifdef T8_QUAD_TO_HEX
+                           , c[4], c[5], c[6], c[7]
+#endif
+    );
+}
+
+int
+t8_quad_child_id (const t8_pquad_t * q)
+{
+  return t8_quad_ancestor_id (q, (int) q->level);
+}
+
+int
+t8_quad_ancestor_id (const t8_pquad_t * q, int level)
+{
+  int                 id = 0;
+
+  T8_ASSERT (t8_quad_is_extended (q));
+  T8_ASSERT (0 <= level && level <= T8_QUAD_MAXLEVEL);
+  T8_ASSERT ((int) q->level >= level);
+
+  if (level == 0) {
+    return 0;
+  }
+
+  id |= ((q->x & T8_QUAD_LEN (level)) ? 0x01 : 0);
+  id |= ((q->y & T8_QUAD_LEN (level)) ? 0x02 : 0);
+#ifdef T8_QUAD_TO_HEX
+  id |= ((q->z & T8_QUAD_LEN (level)) ? 0x04 : 0);
+#endif
+
+  return id;
+}
+
+int
+t8_quad_is_familypv (t8_pquad_t * q[])
+{
+  return t8_quad_is_family (q[0], q[1], q[2], q[3]
+#ifdef T8_QUAD_TO_HEX
+                                   , q[4], q[5], q[6], q[7]
+#endif
+    );
+}
+
+void
+t8_quad_set_morton (t8_pquad_t * quadrant,
+                           int level, uint64_t id)
+{
+  int                 i;
+
+  T8_ASSERT (0 <= level && level <= T8_QUAD_QMAXLEVEL);
+  if (level < T8_QUAD_QMAXLEVEL) {
+    T8_ASSERT (id < ((uint64_t) 1 << T8_QUAD_DIM * (level + 2)));
+  }
+
+  quadrant->level = (int8_t) level;
+  quadrant->x = 0;
+  quadrant->y = 0;
+#ifdef T8_QUAD_TO_HEX
+  quadrant->z = 0;
+#endif
+
+  /* this may set the sign bit to create negative numbers */
+  for (i = 0; i < level + 2; ++i) {
+    quadrant->x |= (t8_qcoord_t) ((id & (1ULL << (T8_QUAD_DIM * i)))
+                                     >> ((T8_QUAD_DIM - 1) * i));
+    quadrant->y |= (t8_qcoord_t) ((id & (1ULL << (T8_QUAD_DIM * i + 1)))
+                                     >> ((T8_QUAD_DIM - 1) * i + 1));
+#ifdef T8_QUAD_TO_HEX
+    quadrant->z |= (t8_qcoord_t) ((id & (1ULL << (T8_QUAD_DIM * i + 2)))
+                                     >> ((T8_QUAD_DIM - 1) * i + 2));
+#endif
+  }
+
+  quadrant->x <<= (T8_QUAD_MAXLEVEL - level);
+  quadrant->y <<= (T8_QUAD_MAXLEVEL - level);
+#ifdef T8_QUAD_TO_HEX
+  quadrant->z <<= (T8_QUAD_MAXLEVEL - level);
+
+  /* this is needed whenever the number of bits is more than MAXLEVEL + 2 */
+  if (quadrant->x >= (t8_qcoord_t) 1 << (T8_QUAD_MAXLEVEL + 1))
+    quadrant->x -= (t8_qcoord_t) 1 << (T8_QUAD_MAXLEVEL + 2);
+  if (quadrant->y >= (t8_qcoord_t) 1 << (T8_QUAD_MAXLEVEL + 1))
+    quadrant->y -= (t8_qcoord_t) 1 << (T8_QUAD_MAXLEVEL + 2);
+  if (quadrant->z >= (t8_qcoord_t) 1 << (T8_QUAD_MAXLEVEL + 1))
+    quadrant->z -= (t8_qcoord_t) 1 << (T8_QUAD_MAXLEVEL + 2);
+#endif
+
+  T8_ASSERT (t8_quad_is_extended (quadrant));
+}
+
+uint64_t
+t8_quad_linear_id (const t8_pquad_t * quadrant, int level)
+{
+  int                 i;
+  uint64_t            id;
+  uint64_t            x, y;
+#ifdef T8_QUAD_TO_HEX
+  uint64_t            z;
+#endif
+
+  T8_ASSERT (t8_quad_is_extended (quadrant));
+  T8_ASSERT (0 <= level && level <= T8_QUAD_MAXLEVEL);
+
+  /* this preserves the high bits from negative numbers */
+  x = quadrant->x >> (T8_QUAD_MAXLEVEL - level);
+  y = quadrant->y >> (T8_QUAD_MAXLEVEL - level);
+#ifdef T8_QUAD_TO_HEX
+  z = quadrant->z >> (T8_QUAD_MAXLEVEL - level);
+#endif
+
+  id = 0;
+  for (i = 0; i < level + 2; ++i) {
+    id |= ((x & ((uint64_t) 1 << i)) << ((T8_QUAD_DIM - 1) * i));
+    id |= ((y & ((uint64_t) 1 << i)) << ((T8_QUAD_DIM - 1) * i + 1));
+#ifdef T8_QUAD_TO_HEX
+    id |= ((z & ((uint64_t) 1 << i)) << ((T8_QUAD_DIM - 1) * i + 2));
+#endif
+  }
+
+  return id;
+}
+
+void
+t8_quad_first_descendant (const t8_pquad_t * q,
+                                 t8_pquad_t * fd, int level)
+{
+  T8_ASSERT (t8_quad_is_extended (q));
+  T8_ASSERT ((int) q->level <= level && level <= T8_QUAD_QMAXLEVEL);
+
+  fd->x = q->x;
+  fd->y = q->y;
+#ifdef T8_QUAD_TO_HEX
+  fd->z = q->z;
+#endif
+  fd->level = (int8_t) level;
+}
+
+void
+t8_quad_last_descendant (const t8_pquad_t * q,
+                                t8_pquad_t * ld, int level)
+{
+  t8_qcoord_t      shift;
+
+  T8_ASSERT (t8_quad_is_extended (q));
+  T8_ASSERT ((int) q->level <= level && level <= T8_QUAD_QMAXLEVEL);
+
+  shift = T8_QUAD_LEN (q->level) - T8_QUAD_LEN (level);
+
+  ld->x = q->x + shift;
+  ld->y = q->y + shift;
+#ifdef T8_QUAD_TO_HEX
+  ld->z = q->z + shift;
+#endif
+  ld->level = (int8_t) level;
+}
+
+void
+t8_quad_nearest_common_ancestor (const t8_pquad_t * q1,
+                               const t8_pquad_t * q2,
+                               t8_pquad_t * r)
+{
+  int                 maxlevel;
+  uint32_t            exclorx, exclory;
+#ifdef T8_QUAD_TO_HEX
+  uint32_t            exclorz;
+#endif
+  uint32_t            maxclor;
+
+  T8_ASSERT (t8_quad_is_extended (q1));
+  T8_ASSERT (t8_quad_is_extended (q2));
+
+  exclorx = q1->x ^ q2->x;
+  exclory = q1->y ^ q2->y;
+#ifdef T8_QUAD_TO_HEX
+  exclorz = q1->z ^ q2->z;
+
+  maxclor = exclorx | exclory | exclorz;
+#else
+  maxclor = exclorx | exclory;
+#endif
+  maxlevel = SC_LOG2_32 (maxclor) + 1;
+
+  T8_ASSERT (maxlevel <= T8_QUAD_MAXLEVEL);
+
+  r->x = q1->x & ~((1 << maxlevel) - 1);
+  r->y = q1->y & ~((1 << maxlevel) - 1);
+#ifdef T8_QUAD_TO_HEX
+  r->z = q1->z & ~((1 << maxlevel) - 1);
+#endif
+  r->level = (int8_t) SC_MIN (T8_QUAD_MAXLEVEL - maxlevel,
+                              (int) SC_MIN (q1->level, q2->level));
+
+  T8_ASSERT (t8_quad_is_extended (r));
+}
+
+void
+t8_quad_corner_descendant (const t8_pquad_t * q,
+                                  t8_pquad_t * r, int c, int level)
+{
+  t8_qcoord_t      shift = T8_QUAD_LEN (q->level) -
+    T8_QUAD_LEN (level);
+  T8_ASSERT (level >= (int) q->level && level <= T8_QUAD_QMAXLEVEL);
+  r->x = q->x + ((c & 1) ? shift : 0);
+  r->y = q->y + (((c >> 1) & 1) ? shift : 0);
+#ifdef T8_QUAD_TO_HEX
+  r->z = q->z + ((c >> 2) ? shift : 0);
+#endif
+  r->level = (int8_t) level;
+}
+
+void
+t8_quad_face_neighbor (const t8_pquad_t * q,
+                              int face, t8_pquad_t * r)
+{
+  const t8_qcoord_t qh = T8_QUAD_LEN (q->level);
+
+  T8_ASSERT (0 <= face && face < T8_QUAD_FACES);
+  T8_ASSERT (t8_quad_is_valid (q));
+
+  r->x = q->x + ((face == 0) ? -qh : (face == 1) ? qh : 0);
+  r->y = q->y + ((face == 2) ? -qh : (face == 3) ? qh : 0);
+#ifdef T8_QUAD_TO_HEX
+  r->z = q->z + ((face == 4) ? -qh : (face == 5) ? qh : 0);
+#endif
+  r->level = q->level;
+  T8_ASSERT (t8_quad_is_extended (r));
+}
+
+int
+t8_quad_is_inside_root (const t8_pquad_t * q)
+{
+  return
+    (q->x >= 0 && q->x < T8_QUAD_ROOT_LEN) &&
+    (q->y >= 0 && q->y < T8_QUAD_ROOT_LEN) &&
+#ifdef T8_QUAD_TO_HEX
+    (q->z >= 0 && q->z < T8_QUAD_ROOT_LEN) &&
+#endif
+    1;
+}
+
+void
+t8_quad_print (int log_priority, const t8_pquad_t * q)
+{
+  /*t8_debugf ("x 0x%x y 0x%x z 0x%x level %d\n",q->x, q->y, q->z, q->level); */
+  t8_debugf ("x 0x%x y 0x%x level %d\n",q->x, q->y, q->level);
+}
+
+int
+t8_quad_is_node (const t8_pquad_t * q, int inside)
+{
+  return
+    q->level == T8_QUAD_MAXLEVEL &&
+    q->x >= 0 && q->x <= T8_QUAD_ROOT_LEN - (inside ? 1 : 0) &&
+    q->y >= 0 && q->y <= T8_QUAD_ROOT_LEN - (inside ? 1 : 0) &&
+#ifdef T8_QUAD_TO_HEX
+    q->z >= 0 && q->z <= T8_QUAD_ROOT_LEN - (inside ? 1 : 0) &&
+#endif
+    (!(q->x & ((1 << (T8_QUAD_MAXLEVEL - T8_QUAD_QMAXLEVEL)) - 1))
+     || (inside && q->x == T8_QUAD_ROOT_LEN - 1)) &&
+    (!(q->y & ((1 << (T8_QUAD_MAXLEVEL - T8_QUAD_QMAXLEVEL)) - 1))
+     || (inside && q->y == T8_QUAD_ROOT_LEN - 1)) &&
+#ifdef T8_QUAD_TO_HEX
+    (!(q->z & ((1 << (T8_QUAD_MAXLEVEL - T8_QUAD_QMAXLEVEL)) - 1))
+     || (inside && q->z == T8_QUAD_ROOT_LEN - 1)) &&
+#endif
+    1;
+}
+
+void
+t8_quad_children (const t8_pquad_t * q,
+                         t8_pquad_t * c0, t8_pquad_t * c1,
+                         t8_pquad_t * c2, t8_pquad_t * c3
+#ifdef T8_QUAD_TO_HEX
+                         , t8_pquad_t * c4, t8_pquad_t * c5,
+                         t8_pquad_t * c6, t8_pquad_t * c7
+#endif
+  )
+{
+  const int8_t        level = (int8_t) (q->level + 1);
+  const t8_qcoord_t inc = T8_QUAD_LEN (level);
+
+  T8_ASSERT (t8_quad_is_extended (q));
+  T8_ASSERT (q->level < T8_QUAD_QMAXLEVEL);
+
+  c0->x = q->x;
+  c0->y = q->y;
+#ifdef T8_QUAD_TO_HEX
+  c0->z = q->z;
+#endif
+  c0->level = level;
+
+  c1->x = c0->x | inc;
+  c1->y = c0->y;
+#ifdef T8_QUAD_TO_HEX
+  c1->z = c0->z;
+#endif
+  c1->level = level;
+
+  c2->x = c0->x;
+  c2->y = c0->y | inc;
+#ifdef T8_QUAD_TO_HEX
+  c2->z = c0->z;
+#endif
+  c2->level = level;
+
+  c3->x = c1->x;
+  c3->y = c2->y;
+#ifdef T8_QUAD_TO_HEX
+  c3->z = c0->z;
+#endif
+  c3->level = level;
+
+#ifdef T8_QUAD_TO_HEX
+  c4->x = c0->x;
+  c4->y = c0->y;
+  c4->z = c0->z | inc;
+  c4->level = level;
+
+  c5->x = c1->x;
+  c5->y = c1->y;
+  c5->z = c4->z;
+  c5->level = level;
+
+  c6->x = c2->x;
+  c6->y = c2->y;
+  c6->z = c4->z;
+  c6->level = level;
+
+  c7->x = c3->x;
+  c7->y = c3->y;
+  c7->z = c4->z;
+  c7->level = level;
+#endif
+
+  /* this also verifies t8_quad_is_extended (c[i]) */
+#ifndef T8_QUAD_TO_HEX
+  T8_ASSERT (t8_quad_is_family (c0, c1, c2, c3));
+#else
+  T8_ASSERT (t8_quad_is_family (c0, c1, c2, c3, c4, c5, c6, c7));
+#endif
+}
+
+#ifndef T8_QUAD_TO_HEX
+int
+t8_quad_is_family (const t8_pquad_t * q0,
+                   const t8_pquad_t * q1,
+                   const t8_pquad_t * q2,
+                   const t8_pquad_t * q3)
+{
+  const int8_t      level = q0->level;
+  t8_qcoord_t       inc;
+
+  T8_ASSERT (t8_quad_is_extended (q0));
+  T8_ASSERT (t8_quad_is_extended (q1));
+  T8_ASSERT (t8_quad_is_extended (q2));
+  T8_ASSERT (t8_quad_is_extended (q3));
+
+  if (level == 0 || level != q1->level ||
+      level != q2->level || level != q3->level) {
+    return 0;
+  }
+
+  inc = T8_QUAD_LEN (level);
+  return ((q0->x + inc == q1->x && q0->y == q1->y) &&
+          (q0->x == q2->x && q0->y + inc == q2->y) &&
+          (q1->x == q3->x && q2->y == q3->y));
+}
+#else
+int
+t8_hex_is_family (const t8_phex_t * q0,
+                          const t8_phex_t * q1,
+                          const t8_phex_t * q2,
+                          const t8_phex_t * q3,
+                          const t8_phex_t * q4,
+                          const t8_phex_t * q5,
+                          const t8_phex_t * q6,
+                          const t8_phex_t * q7)
+{
+  const int8_t        level = q0->level;
+  t8_qcoord_t      inc;
+
+  T8_ASSERT (t8_hex_is_extended (q0));
+  T8_ASSERT (t8_hex_is_extended (q1));
+  T8_ASSERT (t8_hex_is_extended (q2));
+  T8_ASSERT (t8_hex_is_extended (q3));
+  T8_ASSERT (t8_hex_is_extended (q4));
+  T8_ASSERT (t8_hex_is_extended (q5));
+  T8_ASSERT (t8_hex_is_extended (q6));
+  T8_ASSERT (t8_hex_is_extended (q7));
+
+  if (level == 0 || level != q1->level ||
+      level != q2->level || level != q3->level ||
+      level != q4->level || level != q5->level ||
+      level != q6->level || level != q7->level) {
+    return 0;
+  }
+
+  inc = T8_HEX_LEN (level);
+  return ((q0->x + inc == q1->x && q0->y == q1->y && q0->z == q1->z) &&
+          (q0->x == q2->x && q0->y + inc == q2->y && q0->z == q2->z) &&
+          (q1->x == q3->x && q2->y == q3->y && q0->z == q3->z) &&
+          (q0->x == q4->x && q0->y == q4->y && q0->z + inc == q4->z) &&
+          (q1->x == q5->x && q1->y == q5->y && q4->z == q5->z) &&
+          (q2->x == q6->x && q2->y == q6->y && q4->z == q6->z) &&
+          (q3->x == q7->x && q3->y == q7->y && q4->z == q7->z));
+}
+#endif
+
+int
+t8_quad_is_valid (const t8_pquad_t * q)
+{
+  return
+    (q->level >= 0 && q->level <= T8_QUAD_QMAXLEVEL) &&
+    ((q->x & (T8_QUAD_LEN (q->level) - 1)) == 0) &&
+    ((q->y & (T8_QUAD_LEN (q->level) - 1)) == 0) &&
+#ifdef T8_QUAD_TO_HEX
+    ((q->z & (T8_QUAD_LEN (q->level) - 1)) == 0) &&
+#endif
+    t8_quad_is_inside_root (q);
+}
+
+int
+t8_quad_is_inside_3x3 (const t8_pquad_t * q)
+{
+  return
+    (q->x >= -T8_QUAD_ROOT_LEN &&
+     q->x <= T8_QUAD_ROOT_LEN + (T8_QUAD_ROOT_LEN - 1)) &&
+    (q->y >= -T8_QUAD_ROOT_LEN &&
+     q->y <= T8_QUAD_ROOT_LEN + (T8_QUAD_ROOT_LEN - 1)) &&
+#ifdef T8_QUAD_TO_HEX
+    (q->z >= -T8_QUAD_ROOT_LEN &&
+     q->z <= T8_QUAD_ROOT_LEN + (T8_QUAD_ROOT_LEN - 1)) &&
+#endif
+    1;
+}

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.c
@@ -1,3 +1,25 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element classes in parallel.
+
+  Copyright (C) 2015 the developers
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
 #ifdef T8_DQUAD_TO_DHEX
 #include <t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.h>
 
@@ -23,7 +45,6 @@
 #define t8_dquad_is_extended t8_dhex_is_extended
 #define t8_dquad_is_family t8_dhex_is_family
 #define t8_dquad_is_familypv t8_dhex_is_familypv
-#define t8_dquad_is_inside_3x3 t8_dhex_is_inside_3x3
 #define t8_dquad_is_inside_root t8_dhex_is_inside_root
 #define t8_dquad_is_node t8_dhex_is_node
 #define t8_dquad_is_parent t8_dhex_is_parent
@@ -56,15 +77,14 @@ t8_dquad_parent (const t8_dquad_t * q, t8_dquad_t * r)
 }
 
 void
-t8_dquad_sibling (const t8_dquad_t * q, t8_dquad_t * r,
-                        int sibling_id)
+t8_dquad_sibling (const t8_dquad_t * q, t8_dquad_t * r, int sibling_id)
 {
-  const int addx = (sibling_id & 0x01);
-  const int addy = (sibling_id & 0x02) >> 1;
+  const int           addx = (sibling_id & 0x01);
+  const int           addy = (sibling_id & 0x02) >> 1;
 #ifdef T8_DQUAD_TO_DHEX
-  const int addz = (sibling_id & 0x04) >> 2;
+  const int           addz = (sibling_id & 0x04) >> 2;
 #endif
-  const t8_qcoord_t shift = T8_DQUAD_LEN (q->level);
+  const t8_qcoord_t   shift = T8_DQUAD_LEN (q->level);
 
   T8_ASSERT (t8_dquad_is_extended (q));
   T8_ASSERT (q->level > 0);
@@ -82,19 +102,17 @@ t8_dquad_sibling (const t8_dquad_t * q, t8_dquad_t * r,
 int
 t8_dquad_compare (const void *v1, const void *v2)
 {
-  const t8_dquad_t *q1 = (const t8_dquad_t *) v1;
-  const t8_dquad_t *q2 = (const t8_dquad_t *) v2;
+  const t8_dquad_t   *q1 = (const t8_dquad_t *) v1;
+  const t8_dquad_t   *q2 = (const t8_dquad_t *) v2;
 
-  uint32_t exclorx, exclory, exclorxy, exclor;
+  uint32_t            exclorx, exclory, exclorxy, exclor;
 #ifdef T8_DQUAD_TO_DHEX
-  uint32_t exclorz;
+  uint32_t            exclorz;
 #endif
-  int64_t p1, p2, diff;
+  int64_t             p1, p2, diff;
 
-  T8_ASSERT (t8_dquad_is_node (q1, 1) ||
-                t8_dquad_is_extended (q1));
-  T8_ASSERT (t8_dquad_is_node (q2, 1) ||
-                t8_dquad_is_extended (q2));
+  T8_ASSERT (t8_dquad_is_node (q1, 1) || t8_dquad_is_extended (q1));
+  T8_ASSERT (t8_dquad_is_node (q2, 1) || t8_dquad_is_extended (q2));
 
   /* these are unsigned variables that inherit the sign bits */
   exclorx = q1->x ^ q2->x;
@@ -113,8 +131,10 @@ t8_dquad_compare (const void *v1, const void *v2)
   /* if (exclor ^ exclorz) > exclorz, then exclorxy has a more significant bit
    * than exclorz; also exclor and (exclor ^ exclorz) cannot be equal */
   if (exclorz > (exclor ^ exclorz)) {
-    p1 = q1->z + ((q1->z >= 0) ? 0 : ((int64_t) 1 << (T8_DQUAD_MAXLEVEL + 2)));
-    p2 = q2->z + ((q2->z >= 0) ? 0 : ((int64_t) 1 << (T8_DQUAD_MAXLEVEL + 2)));
+    p1 =
+      q1->z + ((q1->z >= 0) ? 0 : ((int64_t) 1 << (T8_DQUAD_MAXLEVEL + 2)));
+    p2 =
+      q2->z + ((q2->z >= 0) ? 0 : ((int64_t) 1 << (T8_DQUAD_MAXLEVEL + 2)));
   }
   else
 #if 0
@@ -122,15 +142,34 @@ t8_dquad_compare (const void *v1, const void *v2)
 #endif
 #endif
   if (exclory > (exclorxy ^ exclory)) {
-    p1 = q1->y + ((q1->y >= 0) ? 0 : ((int64_t) 1 << (T8_DQUAD_MAXLEVEL + 2)));
-    p2 = q2->y + ((q2->y >= 0) ? 0 : ((int64_t) 1 << (T8_DQUAD_MAXLEVEL + 2)));
+    p1 =
+      q1->y + ((q1->y >= 0) ? 0 : ((int64_t) 1 << (T8_DQUAD_MAXLEVEL + 2)));
+    p2 =
+      q2->y + ((q2->y >= 0) ? 0 : ((int64_t) 1 << (T8_DQUAD_MAXLEVEL + 2)));
   }
   else {
-    p1 = q1->x + ((q1->x >= 0) ? 0 : ((int64_t) 1 << (T8_DQUAD_MAXLEVEL + 2)));
-    p2 = q2->x + ((q2->x >= 0) ? 0 : ((int64_t) 1 << (T8_DQUAD_MAXLEVEL + 2)));
+    p1 =
+      q1->x + ((q1->x >= 0) ? 0 : ((int64_t) 1 << (T8_DQUAD_MAXLEVEL + 2)));
+    p2 =
+      q2->x + ((q2->x >= 0) ? 0 : ((int64_t) 1 << (T8_DQUAD_MAXLEVEL + 2)));
   }
   diff = p1 - p2;
   return (diff == 0) ? 0 : ((diff < 0) ? -1 : 1);
+}
+
+static inline int
+_is_inside_3x3_box (const t8_dquad_t * q)
+{
+  return
+    (q->x >= -T8_DQUAD_ROOT_LEN &&
+     q->x <= T8_DQUAD_ROOT_LEN + (T8_DQUAD_ROOT_LEN - 1)) &&
+    (q->y >= -T8_DQUAD_ROOT_LEN &&
+     q->y <= T8_DQUAD_ROOT_LEN + (T8_DQUAD_ROOT_LEN - 1)) &&
+#ifdef T8_DQUAD_TO_DHEX
+    (q->z >= -T8_DQUAD_ROOT_LEN &&
+     q->z <= T8_DQUAD_ROOT_LEN + (T8_DQUAD_ROOT_LEN - 1)) &&
+#endif
+    1;
 }
 
 int
@@ -143,12 +182,11 @@ t8_dquad_is_extended (const t8_dquad_t * q)
 #ifdef T8_DQUAD_TO_DHEX
     ((q->z & (T8_DQUAD_LEN (q->level) - 1)) == 0) &&
 #endif
-    t8_dquad_is_inside_3x3 (q);
+    _is_inside_3x3_box (q);
 }
 
 int
-t8_dquad_is_parent (const t8_dquad_t * q,
-                          const t8_dquad_t * r)
+t8_dquad_is_parent (const t8_dquad_t * q, const t8_dquad_t * r)
 {
   T8_ASSERT (t8_dquad_is_extended (q));
   T8_ASSERT (t8_dquad_is_extended (r));
@@ -168,7 +206,7 @@ t8_dquad_childrenpv (const t8_dquad_t * q, t8_dquad_t * c[])
 {
   t8_dquad_children (q, c[0], c[1], c[2], c[3]
 #ifdef T8_DQUAD_TO_DHEX
-                           , c[4], c[5], c[6], c[7]
+                     , c[4], c[5], c[6], c[7]
 #endif
     );
 }
@@ -206,14 +244,13 @@ t8_dquad_is_familypv (t8_dquad_t * q[])
 {
   return t8_dquad_is_family (q[0], q[1], q[2], q[3]
 #ifdef T8_DQUAD_TO_DHEX
-                                   , q[4], q[5], q[6], q[7]
+                             , q[4], q[5], q[6], q[7]
 #endif
     );
 }
 
 void
-t8_dquad_set_morton (t8_dquad_t * quadrant,
-                           int level, uint64_t id)
+t8_dquad_set_morton (t8_dquad_t * q, int level, uint64_t id)
 {
   int                 i;
 
@@ -222,44 +259,44 @@ t8_dquad_set_morton (t8_dquad_t * quadrant,
     T8_ASSERT (id < ((uint64_t) 1 << T8_DQUAD_DIM * (level + 2)));
   }
 
-  quadrant->level = (int8_t) level;
-  quadrant->x = 0;
-  quadrant->y = 0;
+  q->level = (int8_t) level;
+  q->x = 0;
+  q->y = 0;
 #ifdef T8_DQUAD_TO_DHEX
-  quadrant->z = 0;
+  q->z = 0;
 #endif
 
   /* this may set the sign bit to create negative numbers */
   for (i = 0; i < level + 2; ++i) {
-    quadrant->x |= (t8_qcoord_t) ((id & (1ULL << (T8_DQUAD_DIM * i)))
-                                     >> ((T8_DQUAD_DIM - 1) * i));
-    quadrant->y |= (t8_qcoord_t) ((id & (1ULL << (T8_DQUAD_DIM * i + 1)))
-                                     >> ((T8_DQUAD_DIM - 1) * i + 1));
+    q->x |= (t8_qcoord_t) ((id & (1ULL << (T8_DQUAD_DIM * i)))
+                                  >> ((T8_DQUAD_DIM - 1) * i));
+    q->y |= (t8_qcoord_t) ((id & (1ULL << (T8_DQUAD_DIM * i + 1)))
+                                  >> ((T8_DQUAD_DIM - 1) * i + 1));
 #ifdef T8_DQUAD_TO_DHEX
-    quadrant->z |= (t8_qcoord_t) ((id & (1ULL << (T8_DQUAD_DIM * i + 2)))
-                                     >> ((T8_DQUAD_DIM - 1) * i + 2));
+    q->z |= (t8_qcoord_t) ((id & (1ULL << (T8_DQUAD_DIM * i + 2)))
+                                  >> ((T8_DQUAD_DIM - 1) * i + 2));
 #endif
   }
 
-  quadrant->x <<= (T8_DQUAD_MAXLEVEL - level);
-  quadrant->y <<= (T8_DQUAD_MAXLEVEL - level);
+  q->x <<= (T8_DQUAD_MAXLEVEL - level);
+  q->y <<= (T8_DQUAD_MAXLEVEL - level);
 #ifdef T8_DQUAD_TO_DHEX
-  quadrant->z <<= (T8_DQUAD_MAXLEVEL - level);
+  q->z <<= (T8_DQUAD_MAXLEVEL - level);
 
   /* this is needed whenever the number of bits is more than MAXLEVEL + 2 */
-  if (quadrant->x >= (t8_qcoord_t) 1 << (T8_DQUAD_MAXLEVEL + 1))
-    quadrant->x -= (t8_qcoord_t) 1 << (T8_DQUAD_MAXLEVEL + 2);
-  if (quadrant->y >= (t8_qcoord_t) 1 << (T8_DQUAD_MAXLEVEL + 1))
-    quadrant->y -= (t8_qcoord_t) 1 << (T8_DQUAD_MAXLEVEL + 2);
-  if (quadrant->z >= (t8_qcoord_t) 1 << (T8_DQUAD_MAXLEVEL + 1))
-    quadrant->z -= (t8_qcoord_t) 1 << (T8_DQUAD_MAXLEVEL + 2);
+  if (q->x >= (t8_qcoord_t) 1 << (T8_DQUAD_MAXLEVEL + 1))
+      q->x -= (t8_qcoord_t) 1 << (T8_DQUAD_MAXLEVEL + 2);
+  if (q->y >= (t8_qcoord_t) 1 << (T8_DQUAD_MAXLEVEL + 1))
+      q->y -= (t8_qcoord_t) 1 << (T8_DQUAD_MAXLEVEL + 2);
+  if (q->z >= (t8_qcoord_t) 1 << (T8_DQUAD_MAXLEVEL + 1))
+      q->z -= (t8_qcoord_t) 1 << (T8_DQUAD_MAXLEVEL + 2);
 #endif
 
-  T8_ASSERT (t8_dquad_is_extended (quadrant));
+  T8_ASSERT (t8_dquad_is_extended (q));
 }
 
 uint64_t
-t8_dquad_linear_id (const t8_dquad_t * quadrant, int level)
+t8_dquad_linear_id (const t8_dquad_t * q, int level)
 {
   int                 i;
   uint64_t            id;
@@ -268,14 +305,14 @@ t8_dquad_linear_id (const t8_dquad_t * quadrant, int level)
   uint64_t            z;
 #endif
 
-  T8_ASSERT (t8_dquad_is_extended (quadrant));
+  T8_ASSERT (t8_dquad_is_extended (q));
   T8_ASSERT (0 <= level && level <= T8_DQUAD_MAXLEVEL);
 
   /* this preserves the high bits from negative numbers */
-  x = quadrant->x >> (T8_DQUAD_MAXLEVEL - level);
-  y = quadrant->y >> (T8_DQUAD_MAXLEVEL - level);
+  x = q->x >> (T8_DQUAD_MAXLEVEL - level);
+  y = q->y >> (T8_DQUAD_MAXLEVEL - level);
 #ifdef T8_DQUAD_TO_DHEX
-  z = quadrant->z >> (T8_DQUAD_MAXLEVEL - level);
+  z = q->z >> (T8_DQUAD_MAXLEVEL - level);
 #endif
 
   id = 0;
@@ -291,8 +328,7 @@ t8_dquad_linear_id (const t8_dquad_t * quadrant, int level)
 }
 
 void
-t8_dquad_first_descendant (const t8_dquad_t * q,
-                                 t8_dquad_t * fd, int level)
+t8_dquad_first_descendant (const t8_dquad_t * q, t8_dquad_t * fd, int level)
 {
   T8_ASSERT (t8_dquad_is_extended (q));
   T8_ASSERT ((int) q->level <= level && level <= T8_DQUAD_QMAXLEVEL);
@@ -306,10 +342,9 @@ t8_dquad_first_descendant (const t8_dquad_t * q,
 }
 
 void
-t8_dquad_last_descendant (const t8_dquad_t * q,
-                                t8_dquad_t * ld, int level)
+t8_dquad_last_descendant (const t8_dquad_t * q, t8_dquad_t * ld, int level)
 {
-  t8_qcoord_t      shift;
+  t8_qcoord_t         shift;
 
   T8_ASSERT (t8_dquad_is_extended (q));
   T8_ASSERT ((int) q->level <= level && level <= T8_DQUAD_QMAXLEVEL);
@@ -326,8 +361,7 @@ t8_dquad_last_descendant (const t8_dquad_t * q,
 
 void
 t8_dquad_nearest_common_ancestor (const t8_dquad_t * q1,
-                               const t8_dquad_t * q2,
-                               t8_dquad_t * r)
+                                  const t8_dquad_t * q2, t8_dquad_t * r)
 {
   int                 maxlevel;
   uint32_t            exclorx, exclory;
@@ -365,10 +399,9 @@ t8_dquad_nearest_common_ancestor (const t8_dquad_t * q1,
 
 void
 t8_dquad_corner_descendant (const t8_dquad_t * q,
-                                  t8_dquad_t * r, int c, int level)
+                            t8_dquad_t * r, int c, int level)
 {
-  t8_qcoord_t      shift = T8_DQUAD_LEN (q->level) -
-    T8_DQUAD_LEN (level);
+  t8_qcoord_t         shift = T8_DQUAD_LEN (q->level) - T8_DQUAD_LEN (level);
   T8_ASSERT (level >= (int) q->level && level <= T8_DQUAD_QMAXLEVEL);
   r->x = q->x + ((c & 1) ? shift : 0);
   r->y = q->y + (((c >> 1) & 1) ? shift : 0);
@@ -379,10 +412,9 @@ t8_dquad_corner_descendant (const t8_dquad_t * q,
 }
 
 void
-t8_dquad_face_neighbor (const t8_dquad_t * q,
-                              int face, t8_dquad_t * r)
+t8_dquad_face_neighbor (const t8_dquad_t * q, int face, t8_dquad_t * r)
 {
-  const t8_qcoord_t qh = T8_DQUAD_LEN (q->level);
+  const t8_qcoord_t   qh = T8_DQUAD_LEN (q->level);
 
   T8_ASSERT (0 <= face && face < T8_DQUAD_FACES);
   T8_ASSERT (t8_dquad_is_valid (q));
@@ -412,7 +444,7 @@ void
 t8_dquad_print (int log_priority, const t8_dquad_t * q)
 {
   /*t8_debugf ("x 0x%x y 0x%x z 0x%x level %d\n",q->x, q->y, q->z, q->level); */
-  t8_debugf ("x 0x%x y 0x%x level %d\n",q->x, q->y, q->level);
+  t8_debugf ("x 0x%x y 0x%x level %d\n", q->x, q->y, q->level);
 }
 
 int
@@ -438,16 +470,16 @@ t8_dquad_is_node (const t8_dquad_t * q, int inside)
 
 void
 t8_dquad_children (const t8_dquad_t * q,
-                         t8_dquad_t * c0, t8_dquad_t * c1,
-                         t8_dquad_t * c2, t8_dquad_t * c3
+                   t8_dquad_t * c0, t8_dquad_t * c1,
+                   t8_dquad_t * c2, t8_dquad_t * c3
 #ifdef T8_DQUAD_TO_DHEX
-                         , t8_dquad_t * c4, t8_dquad_t * c5,
-                         t8_dquad_t * c6, t8_dquad_t * c7
+                   , t8_dquad_t * c4, t8_dquad_t * c5,
+                   t8_dquad_t * c6, t8_dquad_t * c7
 #endif
   )
 {
   const int8_t        level = (int8_t) (q->level + 1);
-  const t8_qcoord_t inc = T8_DQUAD_LEN (level);
+  const t8_qcoord_t   inc = T8_DQUAD_LEN (level);
 
   T8_ASSERT (t8_dquad_is_extended (q));
   T8_ASSERT (q->level < T8_DQUAD_QMAXLEVEL);
@@ -513,12 +545,11 @@ t8_dquad_children (const t8_dquad_t * q,
 #ifndef T8_DQUAD_TO_DHEX
 int
 t8_dquad_is_family (const t8_dquad_t * q0,
-                   const t8_dquad_t * q1,
-                   const t8_dquad_t * q2,
-                   const t8_dquad_t * q3)
+                    const t8_dquad_t * q1,
+                    const t8_dquad_t * q2, const t8_dquad_t * q3)
 {
-  const int8_t      level = q0->level;
-  t8_qcoord_t       inc;
+  const int8_t        level = q0->level;
+  t8_qcoord_t         inc;
 
   T8_ASSERT (t8_dquad_is_extended (q0));
   T8_ASSERT (t8_dquad_is_extended (q1));
@@ -538,16 +569,15 @@ t8_dquad_is_family (const t8_dquad_t * q0,
 #else
 int
 t8_dhex_is_family (const t8_dhex_t * q0,
-                          const t8_dhex_t * q1,
-                          const t8_dhex_t * q2,
-                          const t8_dhex_t * q3,
-                          const t8_dhex_t * q4,
-                          const t8_dhex_t * q5,
-                          const t8_dhex_t * q6,
-                          const t8_dhex_t * q7)
+                   const t8_dhex_t * q1,
+                   const t8_dhex_t * q2,
+                   const t8_dhex_t * q3,
+                   const t8_dhex_t * q4,
+                   const t8_dhex_t * q5,
+                   const t8_dhex_t * q6, const t8_dhex_t * q7)
 {
   const int8_t        level = q0->level;
-  t8_qcoord_t      inc;
+  t8_qcoord_t         inc;
 
   T8_ASSERT (t8_dhex_is_extended (q0));
   T8_ASSERT (t8_dhex_is_extended (q1));
@@ -587,19 +617,4 @@ t8_dquad_is_valid (const t8_dquad_t * q)
     ((q->z & (T8_DQUAD_LEN (q->level) - 1)) == 0) &&
 #endif
     t8_dquad_is_inside_root (q);
-}
-
-int
-t8_dquad_is_inside_3x3 (const t8_dquad_t * q)
-{
-  return
-    (q->x >= -T8_DQUAD_ROOT_LEN &&
-     q->x <= T8_DQUAD_ROOT_LEN + (T8_DQUAD_ROOT_LEN - 1)) &&
-    (q->y >= -T8_DQUAD_ROOT_LEN &&
-     q->y <= T8_DQUAD_ROOT_LEN + (T8_DQUAD_ROOT_LEN - 1)) &&
-#ifdef T8_DQUAD_TO_DHEX
-    (q->z >= -T8_DQUAD_ROOT_LEN &&
-     q->z <= T8_DQUAD_ROOT_LEN + (T8_DQUAD_ROOT_LEN - 1)) &&
-#endif
-    1;
 }

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.c
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.c
@@ -1,106 +1,106 @@
-#ifdef T8_QUAD_TO_HEX
+#ifdef T8_DQUAD_TO_DHEX
 #include <t8_schemes/t8_default/t8_default_hex/t8_dhex_bits.h>
 
-#define t8_pquad_t t8_phex_t
+#define t8_dquad_t t8_dhex_t
 
-#define T8_QUAD_QMAXLEVEL   T8_HEX_QMAXLEVEL
-#define T8_QUAD_MAXLEVEL    T8_HEX_MAXLEVEL
-#define T8_QUAD_ROOT_LEN    T8_HEX_ROOT_LEN
-#define T8_QUAD_CHILDREN    T8_HEX_CHILDREN
-#define T8_QUAD_DIM         T8_HEX_DIM
-#define T8_QUAD_FACES       T8_HEX_FACES
-#define T8_QUAD_LEN         T8_HEX_LEN
-#define T8_QUAD_LAST_OFFSET T8_HEX_LAST_OFFSET
+#define T8_DQUAD_CHILDREN    T8_DHEX_CHILDREN
+#define T8_DQUAD_DIM         T8_DHEX_DIM
+#define T8_DQUAD_FACES       T8_DHEX_FACES
+#define T8_DQUAD_LAST_OFFSET T8_DHEX_LAST_OFFSET
+#define T8_DQUAD_LEN         T8_DHEX_LEN
+#define T8_DQUAD_MAXLEVEL    T8_DHEX_MAXLEVEL
+#define T8_DQUAD_QMAXLEVEL   T8_DHEX_QMAXLEVEL
+#define T8_DQUAD_ROOT_LEN    T8_DHEX_ROOT_LEN
 
-#define t8_quad_parent t8_hex_parent
-#define t8_quad_sibling t8_hex_sibling
-#define t8_quad_compare t8_hex_compare
-#define t8_quad_is_extended t8_hex_is_extended
-#define t8_quad_is_parent t8_hex_is_parent
-#define t8_quad_childrenpv t8_hex_childrenpv
-#define t8_quad_ancestor_id t8_hex_ancestor_id
-#define t8_quad_is_familypv t8_hex_is_familypv
-#define t8_quad_set_morton t8_hex_set_morton
-#define t8_quad_linear_id t8_hex_linear_id
-#define t8_quad_first_descendant t8_hex_first_descendant
-#define t8_quad_nearest_common_ancestor t8_hex_nearest_common_ancestor
-#define t8_quad_corner_descendant t8_hex_corner_descendant
-#define t8_quad_face_neighbor t8_hex_face_neighbor
-#define t8_quad_is_inside_root t8_hex_is_inside_root
-#define t8_quad_print t8_hex_print
-#define t8_quad_last_descendant t8_hex_last_descendant
-#define t8_quad_is_node t8_hex_is_node
-#define t8_quad_is_inside_3x3 t8_hex_is_inside_3x3
-#define t8_quad_is_valid t8_hex_is_valid
-#define t8_quad_is_family t8_hex_is_family
-#define t8_quad_children t8_hex_children
-#define t8_quad_child_id t8_hex_child_id
+#define t8_dquad_ancestor_id t8_dhex_ancestor_id
+#define t8_dquad_child_id t8_dhex_child_id
+#define t8_dquad_children t8_dhex_children
+#define t8_dquad_childrenpv t8_dhex_childrenpv
+#define t8_dquad_compare t8_dhex_compare
+#define t8_dquad_corner_descendant t8_dhex_corner_descendant
+#define t8_dquad_face_neighbor t8_dhex_face_neighbor
+#define t8_dquad_first_descendant t8_dhex_first_descendant
+#define t8_dquad_is_extended t8_dhex_is_extended
+#define t8_dquad_is_family t8_dhex_is_family
+#define t8_dquad_is_familypv t8_dhex_is_familypv
+#define t8_dquad_is_inside_3x3 t8_dhex_is_inside_3x3
+#define t8_dquad_is_inside_root t8_dhex_is_inside_root
+#define t8_dquad_is_node t8_dhex_is_node
+#define t8_dquad_is_parent t8_dhex_is_parent
+#define t8_dquad_is_valid t8_dhex_is_valid
+#define t8_dquad_last_descendant t8_dhex_last_descendant
+#define t8_dquad_linear_id t8_dhex_linear_id
+#define t8_dquad_nearest_common_ancestor t8_dhex_nearest_common_ancestor
+#define t8_dquad_parent t8_dhex_parent
+#define t8_dquad_print t8_dhex_print
+#define t8_dquad_set_morton t8_dhex_set_morton
+#define t8_dquad_sibling t8_dhex_sibling
 
 #else
 #include <t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.h>
 #endif
 
 void
-t8_quad_parent (const t8_pquad_t * q, t8_pquad_t * r)
+t8_dquad_parent (const t8_dquad_t * q, t8_dquad_t * r)
 {
-  T8_ASSERT (t8_quad_is_extended (q));
+  T8_ASSERT (t8_dquad_is_extended (q));
   T8_ASSERT (q->level > 0);
 
-  r->x = q->x & ~T8_QUAD_LEN (q->level);
-  r->y = q->y & ~T8_QUAD_LEN (q->level);
-#ifdef T8_QUAD_TO_HEX
-  r->z = q->z & ~T8_QUAD_LEN (q->level);
+  r->x = q->x & ~T8_DQUAD_LEN (q->level);
+  r->y = q->y & ~T8_DQUAD_LEN (q->level);
+#ifdef T8_DQUAD_TO_DHEX
+  r->z = q->z & ~T8_DQUAD_LEN (q->level);
 #endif
   r->level = (int8_t) (q->level - 1);
-  T8_ASSERT (t8_quad_is_extended (r));
+  T8_ASSERT (t8_dquad_is_extended (r));
 }
 
 void
-t8_quad_sibling (const t8_pquad_t * q, t8_pquad_t * r,
+t8_dquad_sibling (const t8_dquad_t * q, t8_dquad_t * r,
                         int sibling_id)
 {
-  const int           addx = (sibling_id & 0x01);
-  const int           addy = (sibling_id & 0x02) >> 1;
-#ifdef T8_QUAD_TO_HEX
-  const int           addz = (sibling_id & 0x04) >> 2;
+  const int addx = (sibling_id & 0x01);
+  const int addy = (sibling_id & 0x02) >> 1;
+#ifdef T8_DQUAD_TO_DHEX
+  const int addz = (sibling_id & 0x04) >> 2;
 #endif
-  const t8_qcoord_t shift = T8_QUAD_LEN (q->level);
+  const t8_qcoord_t shift = T8_DQUAD_LEN (q->level);
 
-  T8_ASSERT (t8_quad_is_extended (q));
+  T8_ASSERT (t8_dquad_is_extended (q));
   T8_ASSERT (q->level > 0);
-  T8_ASSERT (sibling_id >= 0 && sibling_id < T8_QUAD_CHILDREN);
+  T8_ASSERT (sibling_id >= 0 && sibling_id < T8_DQUAD_CHILDREN);
 
   r->x = (addx ? (q->x | shift) : (q->x & ~shift));
   r->y = (addy ? (q->y | shift) : (q->y & ~shift));
-#ifdef T8_QUAD_TO_HEX
+#ifdef T8_DQUAD_TO_DHEX
   r->z = (addz ? (q->z | shift) : (q->z & ~shift));
 #endif
   r->level = q->level;
-  T8_ASSERT (t8_quad_is_extended (r));
+  T8_ASSERT (t8_dquad_is_extended (r));
 }
 
 int
-t8_quad_compare (const void *v1, const void *v2)
+t8_dquad_compare (const void *v1, const void *v2)
 {
-  const t8_pquad_t *q1 = (const t8_pquad_t *) v1;
-  const t8_pquad_t *q2 = (const t8_pquad_t *) v2;
+  const t8_dquad_t *q1 = (const t8_dquad_t *) v1;
+  const t8_dquad_t *q2 = (const t8_dquad_t *) v2;
 
-  uint32_t            exclorx, exclory, exclorxy, exclor;
-#ifdef T8_QUAD_TO_HEX
-  uint32_t            exclorz;
+  uint32_t exclorx, exclory, exclorxy, exclor;
+#ifdef T8_DQUAD_TO_DHEX
+  uint32_t exclorz;
 #endif
-  int64_t             p1, p2, diff;
+  int64_t p1, p2, diff;
 
-  T8_ASSERT (t8_quad_is_node (q1, 1) ||
-                t8_quad_is_extended (q1));
-  T8_ASSERT (t8_quad_is_node (q2, 1) ||
-                t8_quad_is_extended (q2));
+  T8_ASSERT (t8_dquad_is_node (q1, 1) ||
+                t8_dquad_is_extended (q1));
+  T8_ASSERT (t8_dquad_is_node (q2, 1) ||
+                t8_dquad_is_extended (q2));
 
   /* these are unsigned variables that inherit the sign bits */
   exclorx = q1->x ^ q2->x;
   exclory = q1->y ^ q2->y;
   exclor = exclorxy = exclorx | exclory;
-#ifdef T8_QUAD_TO_HEX
+#ifdef T8_DQUAD_TO_DHEX
   exclorz = q1->z ^ q2->z;
   exclor = exclorxy | exclorz;
 #endif
@@ -109,12 +109,12 @@ t8_quad_compare (const void *v1, const void *v2)
     return (int) q1->level - (int) q2->level;
   }
 
-#ifdef T8_QUAD_TO_HEX
+#ifdef T8_DQUAD_TO_DHEX
   /* if (exclor ^ exclorz) > exclorz, then exclorxy has a more significant bit
    * than exclorz; also exclor and (exclor ^ exclorz) cannot be equal */
   if (exclorz > (exclor ^ exclorz)) {
-    p1 = q1->z + ((q1->z >= 0) ? 0 : ((int64_t) 1 << (T8_QUAD_MAXLEVEL + 2)));
-    p2 = q2->z + ((q2->z >= 0) ? 0 : ((int64_t) 1 << (T8_QUAD_MAXLEVEL + 2)));
+    p1 = q1->z + ((q1->z >= 0) ? 0 : ((int64_t) 1 << (T8_DQUAD_MAXLEVEL + 2)));
+    p2 = q2->z + ((q2->z >= 0) ? 0 : ((int64_t) 1 << (T8_DQUAD_MAXLEVEL + 2)));
   }
   else
 #if 0
@@ -122,168 +122,168 @@ t8_quad_compare (const void *v1, const void *v2)
 #endif
 #endif
   if (exclory > (exclorxy ^ exclory)) {
-    p1 = q1->y + ((q1->y >= 0) ? 0 : ((int64_t) 1 << (T8_QUAD_MAXLEVEL + 2)));
-    p2 = q2->y + ((q2->y >= 0) ? 0 : ((int64_t) 1 << (T8_QUAD_MAXLEVEL + 2)));
+    p1 = q1->y + ((q1->y >= 0) ? 0 : ((int64_t) 1 << (T8_DQUAD_MAXLEVEL + 2)));
+    p2 = q2->y + ((q2->y >= 0) ? 0 : ((int64_t) 1 << (T8_DQUAD_MAXLEVEL + 2)));
   }
   else {
-    p1 = q1->x + ((q1->x >= 0) ? 0 : ((int64_t) 1 << (T8_QUAD_MAXLEVEL + 2)));
-    p2 = q2->x + ((q2->x >= 0) ? 0 : ((int64_t) 1 << (T8_QUAD_MAXLEVEL + 2)));
+    p1 = q1->x + ((q1->x >= 0) ? 0 : ((int64_t) 1 << (T8_DQUAD_MAXLEVEL + 2)));
+    p2 = q2->x + ((q2->x >= 0) ? 0 : ((int64_t) 1 << (T8_DQUAD_MAXLEVEL + 2)));
   }
   diff = p1 - p2;
   return (diff == 0) ? 0 : ((diff < 0) ? -1 : 1);
 }
 
 int
-t8_quad_is_extended (const t8_pquad_t * q)
+t8_dquad_is_extended (const t8_dquad_t * q)
 {
   return
-    (q->level >= 0 && q->level <= T8_QUAD_QMAXLEVEL) &&
-    ((q->x & (T8_QUAD_LEN (q->level) - 1)) == 0) &&
-    ((q->y & (T8_QUAD_LEN (q->level) - 1)) == 0) &&
-#ifdef T8_QUAD_TO_HEX
-    ((q->z & (T8_QUAD_LEN (q->level) - 1)) == 0) &&
+    (q->level >= 0 && q->level <= T8_DQUAD_QMAXLEVEL) &&
+    ((q->x & (T8_DQUAD_LEN (q->level) - 1)) == 0) &&
+    ((q->y & (T8_DQUAD_LEN (q->level) - 1)) == 0) &&
+#ifdef T8_DQUAD_TO_DHEX
+    ((q->z & (T8_DQUAD_LEN (q->level) - 1)) == 0) &&
 #endif
-    t8_quad_is_inside_3x3 (q);
+    t8_dquad_is_inside_3x3 (q);
 }
 
 int
-t8_quad_is_parent (const t8_pquad_t * q,
-                          const t8_pquad_t * r)
+t8_dquad_is_parent (const t8_dquad_t * q,
+                          const t8_dquad_t * r)
 {
-  T8_ASSERT (t8_quad_is_extended (q));
-  T8_ASSERT (t8_quad_is_extended (r));
+  T8_ASSERT (t8_dquad_is_extended (q));
+  T8_ASSERT (t8_dquad_is_extended (r));
 
   return
     (q->level + 1 == r->level) &&
-    (q->x == (r->x & ~T8_QUAD_LEN (r->level))) &&
-    (q->y == (r->y & ~T8_QUAD_LEN (r->level))) &&
-#ifdef T8_QUAD_TO_HEX
-    (q->z == (r->z & ~T8_QUAD_LEN (r->level))) &&
+    (q->x == (r->x & ~T8_DQUAD_LEN (r->level))) &&
+    (q->y == (r->y & ~T8_DQUAD_LEN (r->level))) &&
+#ifdef T8_DQUAD_TO_DHEX
+    (q->z == (r->z & ~T8_DQUAD_LEN (r->level))) &&
 #endif
     1;
 }
 
 void
-t8_quad_childrenpv (const t8_pquad_t * q, t8_pquad_t * c[])
+t8_dquad_childrenpv (const t8_dquad_t * q, t8_dquad_t * c[])
 {
-  t8_quad_children (q, c[0], c[1], c[2], c[3]
-#ifdef T8_QUAD_TO_HEX
+  t8_dquad_children (q, c[0], c[1], c[2], c[3]
+#ifdef T8_DQUAD_TO_DHEX
                            , c[4], c[5], c[6], c[7]
 #endif
     );
 }
 
 int
-t8_quad_child_id (const t8_pquad_t * q)
+t8_dquad_child_id (const t8_dquad_t * q)
 {
-  return t8_quad_ancestor_id (q, (int) q->level);
+  return t8_dquad_ancestor_id (q, (int) q->level);
 }
 
 int
-t8_quad_ancestor_id (const t8_pquad_t * q, int level)
+t8_dquad_ancestor_id (const t8_dquad_t * q, int level)
 {
   int                 id = 0;
 
-  T8_ASSERT (t8_quad_is_extended (q));
-  T8_ASSERT (0 <= level && level <= T8_QUAD_MAXLEVEL);
+  T8_ASSERT (t8_dquad_is_extended (q));
+  T8_ASSERT (0 <= level && level <= T8_DQUAD_MAXLEVEL);
   T8_ASSERT ((int) q->level >= level);
 
   if (level == 0) {
     return 0;
   }
 
-  id |= ((q->x & T8_QUAD_LEN (level)) ? 0x01 : 0);
-  id |= ((q->y & T8_QUAD_LEN (level)) ? 0x02 : 0);
-#ifdef T8_QUAD_TO_HEX
-  id |= ((q->z & T8_QUAD_LEN (level)) ? 0x04 : 0);
+  id |= ((q->x & T8_DQUAD_LEN (level)) ? 0x01 : 0);
+  id |= ((q->y & T8_DQUAD_LEN (level)) ? 0x02 : 0);
+#ifdef T8_DQUAD_TO_DHEX
+  id |= ((q->z & T8_DQUAD_LEN (level)) ? 0x04 : 0);
 #endif
 
   return id;
 }
 
 int
-t8_quad_is_familypv (t8_pquad_t * q[])
+t8_dquad_is_familypv (t8_dquad_t * q[])
 {
-  return t8_quad_is_family (q[0], q[1], q[2], q[3]
-#ifdef T8_QUAD_TO_HEX
+  return t8_dquad_is_family (q[0], q[1], q[2], q[3]
+#ifdef T8_DQUAD_TO_DHEX
                                    , q[4], q[5], q[6], q[7]
 #endif
     );
 }
 
 void
-t8_quad_set_morton (t8_pquad_t * quadrant,
+t8_dquad_set_morton (t8_dquad_t * quadrant,
                            int level, uint64_t id)
 {
   int                 i;
 
-  T8_ASSERT (0 <= level && level <= T8_QUAD_QMAXLEVEL);
-  if (level < T8_QUAD_QMAXLEVEL) {
-    T8_ASSERT (id < ((uint64_t) 1 << T8_QUAD_DIM * (level + 2)));
+  T8_ASSERT (0 <= level && level <= T8_DQUAD_QMAXLEVEL);
+  if (level < T8_DQUAD_QMAXLEVEL) {
+    T8_ASSERT (id < ((uint64_t) 1 << T8_DQUAD_DIM * (level + 2)));
   }
 
   quadrant->level = (int8_t) level;
   quadrant->x = 0;
   quadrant->y = 0;
-#ifdef T8_QUAD_TO_HEX
+#ifdef T8_DQUAD_TO_DHEX
   quadrant->z = 0;
 #endif
 
   /* this may set the sign bit to create negative numbers */
   for (i = 0; i < level + 2; ++i) {
-    quadrant->x |= (t8_qcoord_t) ((id & (1ULL << (T8_QUAD_DIM * i)))
-                                     >> ((T8_QUAD_DIM - 1) * i));
-    quadrant->y |= (t8_qcoord_t) ((id & (1ULL << (T8_QUAD_DIM * i + 1)))
-                                     >> ((T8_QUAD_DIM - 1) * i + 1));
-#ifdef T8_QUAD_TO_HEX
-    quadrant->z |= (t8_qcoord_t) ((id & (1ULL << (T8_QUAD_DIM * i + 2)))
-                                     >> ((T8_QUAD_DIM - 1) * i + 2));
+    quadrant->x |= (t8_qcoord_t) ((id & (1ULL << (T8_DQUAD_DIM * i)))
+                                     >> ((T8_DQUAD_DIM - 1) * i));
+    quadrant->y |= (t8_qcoord_t) ((id & (1ULL << (T8_DQUAD_DIM * i + 1)))
+                                     >> ((T8_DQUAD_DIM - 1) * i + 1));
+#ifdef T8_DQUAD_TO_DHEX
+    quadrant->z |= (t8_qcoord_t) ((id & (1ULL << (T8_DQUAD_DIM * i + 2)))
+                                     >> ((T8_DQUAD_DIM - 1) * i + 2));
 #endif
   }
 
-  quadrant->x <<= (T8_QUAD_MAXLEVEL - level);
-  quadrant->y <<= (T8_QUAD_MAXLEVEL - level);
-#ifdef T8_QUAD_TO_HEX
-  quadrant->z <<= (T8_QUAD_MAXLEVEL - level);
+  quadrant->x <<= (T8_DQUAD_MAXLEVEL - level);
+  quadrant->y <<= (T8_DQUAD_MAXLEVEL - level);
+#ifdef T8_DQUAD_TO_DHEX
+  quadrant->z <<= (T8_DQUAD_MAXLEVEL - level);
 
   /* this is needed whenever the number of bits is more than MAXLEVEL + 2 */
-  if (quadrant->x >= (t8_qcoord_t) 1 << (T8_QUAD_MAXLEVEL + 1))
-    quadrant->x -= (t8_qcoord_t) 1 << (T8_QUAD_MAXLEVEL + 2);
-  if (quadrant->y >= (t8_qcoord_t) 1 << (T8_QUAD_MAXLEVEL + 1))
-    quadrant->y -= (t8_qcoord_t) 1 << (T8_QUAD_MAXLEVEL + 2);
-  if (quadrant->z >= (t8_qcoord_t) 1 << (T8_QUAD_MAXLEVEL + 1))
-    quadrant->z -= (t8_qcoord_t) 1 << (T8_QUAD_MAXLEVEL + 2);
+  if (quadrant->x >= (t8_qcoord_t) 1 << (T8_DQUAD_MAXLEVEL + 1))
+    quadrant->x -= (t8_qcoord_t) 1 << (T8_DQUAD_MAXLEVEL + 2);
+  if (quadrant->y >= (t8_qcoord_t) 1 << (T8_DQUAD_MAXLEVEL + 1))
+    quadrant->y -= (t8_qcoord_t) 1 << (T8_DQUAD_MAXLEVEL + 2);
+  if (quadrant->z >= (t8_qcoord_t) 1 << (T8_DQUAD_MAXLEVEL + 1))
+    quadrant->z -= (t8_qcoord_t) 1 << (T8_DQUAD_MAXLEVEL + 2);
 #endif
 
-  T8_ASSERT (t8_quad_is_extended (quadrant));
+  T8_ASSERT (t8_dquad_is_extended (quadrant));
 }
 
 uint64_t
-t8_quad_linear_id (const t8_pquad_t * quadrant, int level)
+t8_dquad_linear_id (const t8_dquad_t * quadrant, int level)
 {
   int                 i;
   uint64_t            id;
   uint64_t            x, y;
-#ifdef T8_QUAD_TO_HEX
+#ifdef T8_DQUAD_TO_DHEX
   uint64_t            z;
 #endif
 
-  T8_ASSERT (t8_quad_is_extended (quadrant));
-  T8_ASSERT (0 <= level && level <= T8_QUAD_MAXLEVEL);
+  T8_ASSERT (t8_dquad_is_extended (quadrant));
+  T8_ASSERT (0 <= level && level <= T8_DQUAD_MAXLEVEL);
 
   /* this preserves the high bits from negative numbers */
-  x = quadrant->x >> (T8_QUAD_MAXLEVEL - level);
-  y = quadrant->y >> (T8_QUAD_MAXLEVEL - level);
-#ifdef T8_QUAD_TO_HEX
-  z = quadrant->z >> (T8_QUAD_MAXLEVEL - level);
+  x = quadrant->x >> (T8_DQUAD_MAXLEVEL - level);
+  y = quadrant->y >> (T8_DQUAD_MAXLEVEL - level);
+#ifdef T8_DQUAD_TO_DHEX
+  z = quadrant->z >> (T8_DQUAD_MAXLEVEL - level);
 #endif
 
   id = 0;
   for (i = 0; i < level + 2; ++i) {
-    id |= ((x & ((uint64_t) 1 << i)) << ((T8_QUAD_DIM - 1) * i));
-    id |= ((y & ((uint64_t) 1 << i)) << ((T8_QUAD_DIM - 1) * i + 1));
-#ifdef T8_QUAD_TO_HEX
-    id |= ((z & ((uint64_t) 1 << i)) << ((T8_QUAD_DIM - 1) * i + 2));
+    id |= ((x & ((uint64_t) 1 << i)) << ((T8_DQUAD_DIM - 1) * i));
+    id |= ((y & ((uint64_t) 1 << i)) << ((T8_DQUAD_DIM - 1) * i + 1));
+#ifdef T8_DQUAD_TO_DHEX
+    id |= ((z & ((uint64_t) 1 << i)) << ((T8_DQUAD_DIM - 1) * i + 2));
 #endif
   }
 
@@ -291,57 +291,57 @@ t8_quad_linear_id (const t8_pquad_t * quadrant, int level)
 }
 
 void
-t8_quad_first_descendant (const t8_pquad_t * q,
-                                 t8_pquad_t * fd, int level)
+t8_dquad_first_descendant (const t8_dquad_t * q,
+                                 t8_dquad_t * fd, int level)
 {
-  T8_ASSERT (t8_quad_is_extended (q));
-  T8_ASSERT ((int) q->level <= level && level <= T8_QUAD_QMAXLEVEL);
+  T8_ASSERT (t8_dquad_is_extended (q));
+  T8_ASSERT ((int) q->level <= level && level <= T8_DQUAD_QMAXLEVEL);
 
   fd->x = q->x;
   fd->y = q->y;
-#ifdef T8_QUAD_TO_HEX
+#ifdef T8_DQUAD_TO_DHEX
   fd->z = q->z;
 #endif
   fd->level = (int8_t) level;
 }
 
 void
-t8_quad_last_descendant (const t8_pquad_t * q,
-                                t8_pquad_t * ld, int level)
+t8_dquad_last_descendant (const t8_dquad_t * q,
+                                t8_dquad_t * ld, int level)
 {
   t8_qcoord_t      shift;
 
-  T8_ASSERT (t8_quad_is_extended (q));
-  T8_ASSERT ((int) q->level <= level && level <= T8_QUAD_QMAXLEVEL);
+  T8_ASSERT (t8_dquad_is_extended (q));
+  T8_ASSERT ((int) q->level <= level && level <= T8_DQUAD_QMAXLEVEL);
 
-  shift = T8_QUAD_LEN (q->level) - T8_QUAD_LEN (level);
+  shift = T8_DQUAD_LEN (q->level) - T8_DQUAD_LEN (level);
 
   ld->x = q->x + shift;
   ld->y = q->y + shift;
-#ifdef T8_QUAD_TO_HEX
+#ifdef T8_DQUAD_TO_DHEX
   ld->z = q->z + shift;
 #endif
   ld->level = (int8_t) level;
 }
 
 void
-t8_quad_nearest_common_ancestor (const t8_pquad_t * q1,
-                               const t8_pquad_t * q2,
-                               t8_pquad_t * r)
+t8_dquad_nearest_common_ancestor (const t8_dquad_t * q1,
+                               const t8_dquad_t * q2,
+                               t8_dquad_t * r)
 {
   int                 maxlevel;
   uint32_t            exclorx, exclory;
-#ifdef T8_QUAD_TO_HEX
+#ifdef T8_DQUAD_TO_DHEX
   uint32_t            exclorz;
 #endif
   uint32_t            maxclor;
 
-  T8_ASSERT (t8_quad_is_extended (q1));
-  T8_ASSERT (t8_quad_is_extended (q2));
+  T8_ASSERT (t8_dquad_is_extended (q1));
+  T8_ASSERT (t8_dquad_is_extended (q2));
 
   exclorx = q1->x ^ q2->x;
   exclory = q1->y ^ q2->y;
-#ifdef T8_QUAD_TO_HEX
+#ifdef T8_DQUAD_TO_DHEX
   exclorz = q1->z ^ q2->z;
 
   maxclor = exclorx | exclory | exclorz;
@@ -350,137 +350,137 @@ t8_quad_nearest_common_ancestor (const t8_pquad_t * q1,
 #endif
   maxlevel = SC_LOG2_32 (maxclor) + 1;
 
-  T8_ASSERT (maxlevel <= T8_QUAD_MAXLEVEL);
+  T8_ASSERT (maxlevel <= T8_DQUAD_MAXLEVEL);
 
   r->x = q1->x & ~((1 << maxlevel) - 1);
   r->y = q1->y & ~((1 << maxlevel) - 1);
-#ifdef T8_QUAD_TO_HEX
+#ifdef T8_DQUAD_TO_DHEX
   r->z = q1->z & ~((1 << maxlevel) - 1);
 #endif
-  r->level = (int8_t) SC_MIN (T8_QUAD_MAXLEVEL - maxlevel,
+  r->level = (int8_t) SC_MIN (T8_DQUAD_MAXLEVEL - maxlevel,
                               (int) SC_MIN (q1->level, q2->level));
 
-  T8_ASSERT (t8_quad_is_extended (r));
+  T8_ASSERT (t8_dquad_is_extended (r));
 }
 
 void
-t8_quad_corner_descendant (const t8_pquad_t * q,
-                                  t8_pquad_t * r, int c, int level)
+t8_dquad_corner_descendant (const t8_dquad_t * q,
+                                  t8_dquad_t * r, int c, int level)
 {
-  t8_qcoord_t      shift = T8_QUAD_LEN (q->level) -
-    T8_QUAD_LEN (level);
-  T8_ASSERT (level >= (int) q->level && level <= T8_QUAD_QMAXLEVEL);
+  t8_qcoord_t      shift = T8_DQUAD_LEN (q->level) -
+    T8_DQUAD_LEN (level);
+  T8_ASSERT (level >= (int) q->level && level <= T8_DQUAD_QMAXLEVEL);
   r->x = q->x + ((c & 1) ? shift : 0);
   r->y = q->y + (((c >> 1) & 1) ? shift : 0);
-#ifdef T8_QUAD_TO_HEX
+#ifdef T8_DQUAD_TO_DHEX
   r->z = q->z + ((c >> 2) ? shift : 0);
 #endif
   r->level = (int8_t) level;
 }
 
 void
-t8_quad_face_neighbor (const t8_pquad_t * q,
-                              int face, t8_pquad_t * r)
+t8_dquad_face_neighbor (const t8_dquad_t * q,
+                              int face, t8_dquad_t * r)
 {
-  const t8_qcoord_t qh = T8_QUAD_LEN (q->level);
+  const t8_qcoord_t qh = T8_DQUAD_LEN (q->level);
 
-  T8_ASSERT (0 <= face && face < T8_QUAD_FACES);
-  T8_ASSERT (t8_quad_is_valid (q));
+  T8_ASSERT (0 <= face && face < T8_DQUAD_FACES);
+  T8_ASSERT (t8_dquad_is_valid (q));
 
   r->x = q->x + ((face == 0) ? -qh : (face == 1) ? qh : 0);
   r->y = q->y + ((face == 2) ? -qh : (face == 3) ? qh : 0);
-#ifdef T8_QUAD_TO_HEX
+#ifdef T8_DQUAD_TO_DHEX
   r->z = q->z + ((face == 4) ? -qh : (face == 5) ? qh : 0);
 #endif
   r->level = q->level;
-  T8_ASSERT (t8_quad_is_extended (r));
+  T8_ASSERT (t8_dquad_is_extended (r));
 }
 
 int
-t8_quad_is_inside_root (const t8_pquad_t * q)
+t8_dquad_is_inside_root (const t8_dquad_t * q)
 {
   return
-    (q->x >= 0 && q->x < T8_QUAD_ROOT_LEN) &&
-    (q->y >= 0 && q->y < T8_QUAD_ROOT_LEN) &&
-#ifdef T8_QUAD_TO_HEX
-    (q->z >= 0 && q->z < T8_QUAD_ROOT_LEN) &&
+    (q->x >= 0 && q->x < T8_DQUAD_ROOT_LEN) &&
+    (q->y >= 0 && q->y < T8_DQUAD_ROOT_LEN) &&
+#ifdef T8_DQUAD_TO_DHEX
+    (q->z >= 0 && q->z < T8_DQUAD_ROOT_LEN) &&
 #endif
     1;
 }
 
 void
-t8_quad_print (int log_priority, const t8_pquad_t * q)
+t8_dquad_print (int log_priority, const t8_dquad_t * q)
 {
   /*t8_debugf ("x 0x%x y 0x%x z 0x%x level %d\n",q->x, q->y, q->z, q->level); */
   t8_debugf ("x 0x%x y 0x%x level %d\n",q->x, q->y, q->level);
 }
 
 int
-t8_quad_is_node (const t8_pquad_t * q, int inside)
+t8_dquad_is_node (const t8_dquad_t * q, int inside)
 {
   return
-    q->level == T8_QUAD_MAXLEVEL &&
-    q->x >= 0 && q->x <= T8_QUAD_ROOT_LEN - (inside ? 1 : 0) &&
-    q->y >= 0 && q->y <= T8_QUAD_ROOT_LEN - (inside ? 1 : 0) &&
-#ifdef T8_QUAD_TO_HEX
-    q->z >= 0 && q->z <= T8_QUAD_ROOT_LEN - (inside ? 1 : 0) &&
+    q->level == T8_DQUAD_MAXLEVEL &&
+    q->x >= 0 && q->x <= T8_DQUAD_ROOT_LEN - (inside ? 1 : 0) &&
+    q->y >= 0 && q->y <= T8_DQUAD_ROOT_LEN - (inside ? 1 : 0) &&
+#ifdef T8_DQUAD_TO_DHEX
+    q->z >= 0 && q->z <= T8_DQUAD_ROOT_LEN - (inside ? 1 : 0) &&
 #endif
-    (!(q->x & ((1 << (T8_QUAD_MAXLEVEL - T8_QUAD_QMAXLEVEL)) - 1))
-     || (inside && q->x == T8_QUAD_ROOT_LEN - 1)) &&
-    (!(q->y & ((1 << (T8_QUAD_MAXLEVEL - T8_QUAD_QMAXLEVEL)) - 1))
-     || (inside && q->y == T8_QUAD_ROOT_LEN - 1)) &&
-#ifdef T8_QUAD_TO_HEX
-    (!(q->z & ((1 << (T8_QUAD_MAXLEVEL - T8_QUAD_QMAXLEVEL)) - 1))
-     || (inside && q->z == T8_QUAD_ROOT_LEN - 1)) &&
+    (!(q->x & ((1 << (T8_DQUAD_MAXLEVEL - T8_DQUAD_QMAXLEVEL)) - 1))
+     || (inside && q->x == T8_DQUAD_ROOT_LEN - 1)) &&
+    (!(q->y & ((1 << (T8_DQUAD_MAXLEVEL - T8_DQUAD_QMAXLEVEL)) - 1))
+     || (inside && q->y == T8_DQUAD_ROOT_LEN - 1)) &&
+#ifdef T8_DQUAD_TO_DHEX
+    (!(q->z & ((1 << (T8_DQUAD_MAXLEVEL - T8_DQUAD_QMAXLEVEL)) - 1))
+     || (inside && q->z == T8_DQUAD_ROOT_LEN - 1)) &&
 #endif
     1;
 }
 
 void
-t8_quad_children (const t8_pquad_t * q,
-                         t8_pquad_t * c0, t8_pquad_t * c1,
-                         t8_pquad_t * c2, t8_pquad_t * c3
-#ifdef T8_QUAD_TO_HEX
-                         , t8_pquad_t * c4, t8_pquad_t * c5,
-                         t8_pquad_t * c6, t8_pquad_t * c7
+t8_dquad_children (const t8_dquad_t * q,
+                         t8_dquad_t * c0, t8_dquad_t * c1,
+                         t8_dquad_t * c2, t8_dquad_t * c3
+#ifdef T8_DQUAD_TO_DHEX
+                         , t8_dquad_t * c4, t8_dquad_t * c5,
+                         t8_dquad_t * c6, t8_dquad_t * c7
 #endif
   )
 {
   const int8_t        level = (int8_t) (q->level + 1);
-  const t8_qcoord_t inc = T8_QUAD_LEN (level);
+  const t8_qcoord_t inc = T8_DQUAD_LEN (level);
 
-  T8_ASSERT (t8_quad_is_extended (q));
-  T8_ASSERT (q->level < T8_QUAD_QMAXLEVEL);
+  T8_ASSERT (t8_dquad_is_extended (q));
+  T8_ASSERT (q->level < T8_DQUAD_QMAXLEVEL);
 
   c0->x = q->x;
   c0->y = q->y;
-#ifdef T8_QUAD_TO_HEX
+#ifdef T8_DQUAD_TO_DHEX
   c0->z = q->z;
 #endif
   c0->level = level;
 
   c1->x = c0->x | inc;
   c1->y = c0->y;
-#ifdef T8_QUAD_TO_HEX
+#ifdef T8_DQUAD_TO_DHEX
   c1->z = c0->z;
 #endif
   c1->level = level;
 
   c2->x = c0->x;
   c2->y = c0->y | inc;
-#ifdef T8_QUAD_TO_HEX
+#ifdef T8_DQUAD_TO_DHEX
   c2->z = c0->z;
 #endif
   c2->level = level;
 
   c3->x = c1->x;
   c3->y = c2->y;
-#ifdef T8_QUAD_TO_HEX
+#ifdef T8_DQUAD_TO_DHEX
   c3->z = c0->z;
 #endif
   c3->level = level;
 
-#ifdef T8_QUAD_TO_HEX
+#ifdef T8_DQUAD_TO_DHEX
   c4->x = c0->x;
   c4->y = c0->y;
   c4->z = c0->z | inc;
@@ -502,61 +502,61 @@ t8_quad_children (const t8_pquad_t * q,
   c7->level = level;
 #endif
 
-  /* this also verifies t8_quad_is_extended (c[i]) */
-#ifndef T8_QUAD_TO_HEX
-  T8_ASSERT (t8_quad_is_family (c0, c1, c2, c3));
+  /* this also verifies t8_dquad_is_extended (c[i]) */
+#ifndef T8_DQUAD_TO_DHEX
+  T8_ASSERT (t8_dquad_is_family (c0, c1, c2, c3));
 #else
-  T8_ASSERT (t8_quad_is_family (c0, c1, c2, c3, c4, c5, c6, c7));
+  T8_ASSERT (t8_dquad_is_family (c0, c1, c2, c3, c4, c5, c6, c7));
 #endif
 }
 
-#ifndef T8_QUAD_TO_HEX
+#ifndef T8_DQUAD_TO_DHEX
 int
-t8_quad_is_family (const t8_pquad_t * q0,
-                   const t8_pquad_t * q1,
-                   const t8_pquad_t * q2,
-                   const t8_pquad_t * q3)
+t8_dquad_is_family (const t8_dquad_t * q0,
+                   const t8_dquad_t * q1,
+                   const t8_dquad_t * q2,
+                   const t8_dquad_t * q3)
 {
   const int8_t      level = q0->level;
   t8_qcoord_t       inc;
 
-  T8_ASSERT (t8_quad_is_extended (q0));
-  T8_ASSERT (t8_quad_is_extended (q1));
-  T8_ASSERT (t8_quad_is_extended (q2));
-  T8_ASSERT (t8_quad_is_extended (q3));
+  T8_ASSERT (t8_dquad_is_extended (q0));
+  T8_ASSERT (t8_dquad_is_extended (q1));
+  T8_ASSERT (t8_dquad_is_extended (q2));
+  T8_ASSERT (t8_dquad_is_extended (q3));
 
   if (level == 0 || level != q1->level ||
       level != q2->level || level != q3->level) {
     return 0;
   }
 
-  inc = T8_QUAD_LEN (level);
+  inc = T8_DQUAD_LEN (level);
   return ((q0->x + inc == q1->x && q0->y == q1->y) &&
           (q0->x == q2->x && q0->y + inc == q2->y) &&
           (q1->x == q3->x && q2->y == q3->y));
 }
 #else
 int
-t8_hex_is_family (const t8_phex_t * q0,
-                          const t8_phex_t * q1,
-                          const t8_phex_t * q2,
-                          const t8_phex_t * q3,
-                          const t8_phex_t * q4,
-                          const t8_phex_t * q5,
-                          const t8_phex_t * q6,
-                          const t8_phex_t * q7)
+t8_dhex_is_family (const t8_dhex_t * q0,
+                          const t8_dhex_t * q1,
+                          const t8_dhex_t * q2,
+                          const t8_dhex_t * q3,
+                          const t8_dhex_t * q4,
+                          const t8_dhex_t * q5,
+                          const t8_dhex_t * q6,
+                          const t8_dhex_t * q7)
 {
   const int8_t        level = q0->level;
   t8_qcoord_t      inc;
 
-  T8_ASSERT (t8_hex_is_extended (q0));
-  T8_ASSERT (t8_hex_is_extended (q1));
-  T8_ASSERT (t8_hex_is_extended (q2));
-  T8_ASSERT (t8_hex_is_extended (q3));
-  T8_ASSERT (t8_hex_is_extended (q4));
-  T8_ASSERT (t8_hex_is_extended (q5));
-  T8_ASSERT (t8_hex_is_extended (q6));
-  T8_ASSERT (t8_hex_is_extended (q7));
+  T8_ASSERT (t8_dhex_is_extended (q0));
+  T8_ASSERT (t8_dhex_is_extended (q1));
+  T8_ASSERT (t8_dhex_is_extended (q2));
+  T8_ASSERT (t8_dhex_is_extended (q3));
+  T8_ASSERT (t8_dhex_is_extended (q4));
+  T8_ASSERT (t8_dhex_is_extended (q5));
+  T8_ASSERT (t8_dhex_is_extended (q6));
+  T8_ASSERT (t8_dhex_is_extended (q7));
 
   if (level == 0 || level != q1->level ||
       level != q2->level || level != q3->level ||
@@ -565,7 +565,7 @@ t8_hex_is_family (const t8_phex_t * q0,
     return 0;
   }
 
-  inc = T8_HEX_LEN (level);
+  inc = T8_DHEX_LEN (level);
   return ((q0->x + inc == q1->x && q0->y == q1->y && q0->z == q1->z) &&
           (q0->x == q2->x && q0->y + inc == q2->y && q0->z == q2->z) &&
           (q1->x == q3->x && q2->y == q3->y && q0->z == q3->z) &&
@@ -577,29 +577,29 @@ t8_hex_is_family (const t8_phex_t * q0,
 #endif
 
 int
-t8_quad_is_valid (const t8_pquad_t * q)
+t8_dquad_is_valid (const t8_dquad_t * q)
 {
   return
-    (q->level >= 0 && q->level <= T8_QUAD_QMAXLEVEL) &&
-    ((q->x & (T8_QUAD_LEN (q->level) - 1)) == 0) &&
-    ((q->y & (T8_QUAD_LEN (q->level) - 1)) == 0) &&
-#ifdef T8_QUAD_TO_HEX
-    ((q->z & (T8_QUAD_LEN (q->level) - 1)) == 0) &&
+    (q->level >= 0 && q->level <= T8_DQUAD_QMAXLEVEL) &&
+    ((q->x & (T8_DQUAD_LEN (q->level) - 1)) == 0) &&
+    ((q->y & (T8_DQUAD_LEN (q->level) - 1)) == 0) &&
+#ifdef T8_DQUAD_TO_DHEX
+    ((q->z & (T8_DQUAD_LEN (q->level) - 1)) == 0) &&
 #endif
-    t8_quad_is_inside_root (q);
+    t8_dquad_is_inside_root (q);
 }
 
 int
-t8_quad_is_inside_3x3 (const t8_pquad_t * q)
+t8_dquad_is_inside_3x3 (const t8_dquad_t * q)
 {
   return
-    (q->x >= -T8_QUAD_ROOT_LEN &&
-     q->x <= T8_QUAD_ROOT_LEN + (T8_QUAD_ROOT_LEN - 1)) &&
-    (q->y >= -T8_QUAD_ROOT_LEN &&
-     q->y <= T8_QUAD_ROOT_LEN + (T8_QUAD_ROOT_LEN - 1)) &&
-#ifdef T8_QUAD_TO_HEX
-    (q->z >= -T8_QUAD_ROOT_LEN &&
-     q->z <= T8_QUAD_ROOT_LEN + (T8_QUAD_ROOT_LEN - 1)) &&
+    (q->x >= -T8_DQUAD_ROOT_LEN &&
+     q->x <= T8_DQUAD_ROOT_LEN + (T8_DQUAD_ROOT_LEN - 1)) &&
+    (q->y >= -T8_DQUAD_ROOT_LEN &&
+     q->y <= T8_DQUAD_ROOT_LEN + (T8_DQUAD_ROOT_LEN - 1)) &&
+#ifdef T8_DQUAD_TO_DHEX
+    (q->z >= -T8_DQUAD_ROOT_LEN &&
+     q->z <= T8_DQUAD_ROOT_LEN + (T8_DQUAD_ROOT_LEN - 1)) &&
 #endif
     1;
 }

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.h
@@ -1,3 +1,28 @@
+/*
+  This file is part of t8code.
+  t8code is a C library to manage a collection (a forest) of multiple
+  connected adaptive space-trees of general element classes in parallel.
+
+  Copyright (C) 2015 the developers
+
+  t8code is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  t8code is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with t8code; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
+/** \file t8_dquad_bits.h
+ */
+
 #ifndef T8_DQUAD_BITS_H
 #define T8_DQUAD_BITS_H
 
@@ -6,58 +31,167 @@
 
 T8_EXTERN_C_BEGIN ();
 
+/** Compute the parent of given quadrant.
+ * \param [in]  q Input quadrant.
+ * \param [in,out] r Existing quadrant whose Morton index will be filled
+ *                   with the Morton index of the parent of \a q.
+ */
 void t8_dquad_parent (const t8_dquad_t * q, t8_dquad_t * r);
 
-void t8_dquad_sibling (const t8_dquad_t * q, t8_dquad_t * r, int sibling_id);
+/** Compute the specified sibling of given quadrant.
+ * \param [in]     q  Input quadrant.
+ * \param [in,out] r  Existing quadrant whose Morton index will be filled
+ *                    with the coordinates of specified sibling.
+ * \param [in]     sibling_id The id of the sibling computed: 0,1,2,3.
+ */
+void t8_dquad_sibling (const t8_dquad_t * q, t8_dquad_t * r,
+                                      int sibling_id);
 
+/** Compare two quadrants with respect to their Morton ordering.
+ * \return < 0 if \a v1 < \a v2,
+ *           0 if \a v1 == \a v2,
+ *         > 0 if \a v1 > \a v2
+ */
 int t8_dquad_compare (const void *v1, const void *v2);
 
+/** Test if a quadrant has valid Morton indices
+ * in the 3x3 box around root.
+ * \param [in] q Quadrant to be tested.
+ * \return True if \a q is extended.
+ */
 int t8_dquad_is_extended (const t8_dquad_t * q);
 
+/** Test if a quadrant is parent of another quadrant.
+ * \param [in] q Quadrant to be tested.
+ * \param [in] r Possible child quadrant.
+ * \return true if \a q is the parent of \a r.
+ */
 int t8_dquad_is_parent (const t8_dquad_t * q, const t8_dquad_t * r);
 
+/** Compute the four children of a quadrant, array version.
+ * \param [in]     q  Input quadrant.
+ * \param [in,out] c  Pointers to the four computed children in z-order.
+ *                    q may point to the same quadrant as c[0].
+ * \note The user_data of c[i] is never modified.
+ */
 void t8_dquad_childrenpv (const t8_dquad_t * q, t8_dquad_t * c[]);
 
+/** Compute the position of this child within its siblings.
+ * \return Child id: 0,1,2,3
+ */
 int t8_dquad_child_id (const t8_dquad_t * q);
 
+/** Compute the position of the ancestor of this child at
+ * level \a level within its siblings.
+ * \return Child id: 0,1,2,3
+ */
 int t8_dquad_ancestor_id (const t8_dquad_t * q, int level);
 
+/** Test if four quadrants are siblings in Morton ordering, array version.
+ * \param [in] q   Array of four pointers to quadrants.
+ */
 int t8_dquad_is_familypv (t8_dquad_t * q[]);
 
-void t8_dquad_set_morton (t8_dquad_t * quadrant, int level, uint64_t id);
+/** Set quadrant Morton indices based on linear position in uniform grid.
+ * \param [in,out] q         Quadrant whose Morton indices will be set.
+ * \param [in]     level     Level of the grid and of the resulting quadrant.
+ * \param [in]     id        Linear index of the quadrant on a uniform grid.
+ */
+void t8_dquad_set_morton (t8_dquad_t * q, int level, uint64_t id);
 
-uint64_t t8_dquad_linear_id (const t8_dquad_t * quadrant, int level);
+/** Computes the linear position of a quadrant in a uniform grid.
+ * \param [in] q         Quadrant whose linear index will be computed.
+ * \param [in] level     The level of the regular grid compared to which the
+ *                       linear position is to be computed.
+ * \return               Linear position of this quadrant on a grid.
+ * \note                 If the quadrant is smaller than the grid (has a higher
+ *                       quadrant->level), the result is computed from its
+ *                       ancestor at the grid's level.
+ *                       If the quadrant has a smaller level than the grid (it
+ *                       is bigger than a grid cell), the grid cell sharing its
+ *                       lower left corner is used as reference.
+ */
+uint64_t t8_dquad_linear_id (const t8_dquad_t * q, int level);
 
+/** Compute the first descendant of a given quadrant on a given level.
+ * \param [in]  q      Input quadrant.
+ * \param [out] fd     First descendant of \a q on level \a level.
+ * \param [in]  level  Level must be greater equal than q's level.
+ */
 void t8_dquad_first_descendant (const t8_dquad_t * q, t8_dquad_t * fd, int level);
 
+/** Computes the nearest common ancestor of two quadrants in the same tree.
+ * \param [in]     q1 First input quadrant.
+ * \param [in]     q2 Second input quadrant.
+ * \param [in,out] r Existing quadrant whose Morton index will be filled.
+ * \note \a q1, \a q2, \a r may point to the same quadrant.
+ */
 void t8_dquad_nearest_common_ancestor (const t8_dquad_t * q1, const t8_dquad_t * q2, t8_dquad_t * r);
 
+/** Compute the descendant of a quadrant touching a given corner.
+ * \param [in]     q   Input quadrant.
+ * \param [in,out] r   Existing quadrant whose Morton index will be filled.
+ * \param [in]     c   The corner of \a q that \a r touches.
+ * \param [in] level   The size of \a r.
+ */
 void t8_dquad_corner_descendant (const t8_dquad_t * q, t8_dquad_t * r, int c, int level);
 
+/** Compute the face neighbor of a quadrant.
+ * \param [in]     q      Input quadrant, must be valid.
+ * \param [in]     face   The face across which to generate the neighbor.
+ * \param [in,out] r      Existing quadrant whose Morton index will be filled.
+ * \note \a q may point to the same quadrant as \a r.
+ */
 void t8_dquad_face_neighbor (const t8_dquad_t * q, int face, t8_dquad_t * r);
 
+/** Test if a quadrant is inside the unit tree.
+ * \param [in] q Quadrant to be tested.
+ * \return True if \a q is inside the unit tree.
+ */
 int t8_dquad_is_inside_root (const t8_dquad_t * q);
 
+/** Prints one line with x, y and level of the quadrant.
+ * \param [in] log_priority  See \ref logpriorities in sc.h.
+ * \param [in] q             Puadrant to print.
+ */
 void t8_dquad_print (int log_priority, const t8_dquad_t * q);
 
+/** Compute the last descendant of a quadrant on a given level.
+ * \param [in]  q      Input quadrant.
+ * \param [out] ld     Last descendant of \a q on level \a level.
+ * \param [in]  level  Level must be greater equal than q's level.
+ */
 void t8_dquad_last_descendant (const t8_dquad_t * q, t8_dquad_t * ld, int level);
 
+/** Test if a quadrant is used to represent a mesh node.
+ * \param [in] q        Quadrant to be tested.
+ * \param [in] inside   If true, boundary nodes must be clamped inside.
+ *                      If false, nodes must align with the quadrant grid.
+ * \return True if \a q is a node.
+ */
 int t8_dquad_is_node (const t8_dquad_t * q, int inside);
 
-int t8_dquad_is_inside_3x3 (const t8_dquad_t * q);
-
+/** Test if a quadrant has valid Morton indices and is inside the unit tree.
+ * \param [in] q Quadrant to be tested.
+ * \return True if \a q is valid.
+ */
 int t8_dquad_is_valid (const t8_dquad_t * q);
 
+/** Test if four quadrants are siblings in Morton ordering.
+ */
 int t8_dquad_is_family (const t8_dquad_t * q0,
-                          const t8_dquad_t * q1,
-                          const t8_dquad_t * q2,
-                          const t8_dquad_t * q3);
+                        const t8_dquad_t * q1,
+                        const t8_dquad_t * q2,
+                        const t8_dquad_t * q3);
 
-void
-t8_dquad_children (const t8_dquad_t * q,
-                         t8_dquad_t * c0, t8_dquad_t * c1,
-                         t8_dquad_t * c2, t8_dquad_t * c3);
-
+/** Compute the four children of a quadrant.
+ * \param [in]     q  Input quadrant.
+ * \param [in,out] c0 First computed child.
+ * \note  \a c0 may point to the same quadrant as \a q.
+ */
+void t8_dquad_children (const t8_dquad_t * q,
+                    t8_dquad_t * c0, t8_dquad_t * c1,
+                    t8_dquad_t * c2, t8_dquad_t * c3);
 
 T8_EXTERN_C_END ();
 

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.h
@@ -6,57 +6,58 @@
 
 T8_EXTERN_C_BEGIN ();
 
-void t8_quad_parent (const t8_pquad_t * q, t8_pquad_t * r);
+void t8_dquad_parent (const t8_dquad_t * q, t8_dquad_t * r);
 
-void t8_quad_sibling (const t8_pquad_t * q, t8_pquad_t * r, int sibling_id);
+void t8_dquad_sibling (const t8_dquad_t * q, t8_dquad_t * r, int sibling_id);
 
-int t8_quad_compare (const void *v1, const void *v2);
+int t8_dquad_compare (const void *v1, const void *v2);
 
-int t8_quad_is_extended (const t8_pquad_t * q);
+int t8_dquad_is_extended (const t8_dquad_t * q);
 
-int t8_quad_is_parent (const t8_pquad_t * q, const t8_pquad_t * r);
+int t8_dquad_is_parent (const t8_dquad_t * q, const t8_dquad_t * r);
 
-void t8_quad_childrenpv (const t8_pquad_t * q, t8_pquad_t * c[]);
+void t8_dquad_childrenpv (const t8_dquad_t * q, t8_dquad_t * c[]);
 
-int t8_quad_child_id (const t8_pquad_t * q);
+int t8_dquad_child_id (const t8_dquad_t * q);
 
-int t8_quad_ancestor_id (const t8_pquad_t * q, int level);
+int t8_dquad_ancestor_id (const t8_dquad_t * q, int level);
 
-int t8_quad_is_familypv (t8_pquad_t * q[]);
+int t8_dquad_is_familypv (t8_dquad_t * q[]);
 
-void t8_quad_set_morton (t8_pquad_t * quadrant, int level, uint64_t id);
+void t8_dquad_set_morton (t8_dquad_t * quadrant, int level, uint64_t id);
 
-uint64_t t8_quad_linear_id (const t8_pquad_t * quadrant, int level);
+uint64_t t8_dquad_linear_id (const t8_dquad_t * quadrant, int level);
 
-void t8_quad_first_descendant (const t8_pquad_t * q, t8_pquad_t * fd, int level);
+void t8_dquad_first_descendant (const t8_dquad_t * q, t8_dquad_t * fd, int level);
 
-void t8_quad_nearest_common_ancestor (const t8_pquad_t * q1, const t8_pquad_t * q2, t8_pquad_t * r);
+void t8_dquad_nearest_common_ancestor (const t8_dquad_t * q1, const t8_dquad_t * q2, t8_dquad_t * r);
 
-void t8_quad_corner_descendant (const t8_pquad_t * q, t8_pquad_t * r, int c, int level);
+void t8_dquad_corner_descendant (const t8_dquad_t * q, t8_dquad_t * r, int c, int level);
 
-void t8_quad_face_neighbor (const t8_pquad_t * q, int face, t8_pquad_t * r);
+void t8_dquad_face_neighbor (const t8_dquad_t * q, int face, t8_dquad_t * r);
 
-int t8_quad_is_inside_root (const t8_pquad_t * q);
+int t8_dquad_is_inside_root (const t8_dquad_t * q);
 
-void t8_quad_print (int log_priority, const t8_pquad_t * q);
+void t8_dquad_print (int log_priority, const t8_dquad_t * q);
 
-void t8_quad_last_descendant (const t8_pquad_t * q, t8_pquad_t * ld, int level);
+void t8_dquad_last_descendant (const t8_dquad_t * q, t8_dquad_t * ld, int level);
 
-int t8_quad_is_node (const t8_pquad_t * q, int inside);
+int t8_dquad_is_node (const t8_dquad_t * q, int inside);
 
-int t8_quad_is_inside_3x3 (const t8_pquad_t * q);
+int t8_dquad_is_inside_3x3 (const t8_dquad_t * q);
 
-int t8_quad_is_valid (const t8_pquad_t * q);
+int t8_dquad_is_valid (const t8_dquad_t * q);
 
-int t8_quad_is_family (const t8_pquad_t * q0,
-                          const t8_pquad_t * q1,
-                          const t8_pquad_t * q2,
-                          const t8_pquad_t * q3);
+int t8_dquad_is_family (const t8_dquad_t * q0,
+                          const t8_dquad_t * q1,
+                          const t8_dquad_t * q2,
+                          const t8_dquad_t * q3);
 
 void
-t8_quad_children (const t8_pquad_t * q,
-                         t8_pquad_t * c0, t8_pquad_t * c1,
-                         t8_pquad_t * c2, t8_pquad_t * c3);
+t8_dquad_children (const t8_dquad_t * q,
+                         t8_dquad_t * c0, t8_dquad_t * c1,
+                         t8_dquad_t * c2, t8_dquad_t * c3);
+
 
 T8_EXTERN_C_END ();
 

--- a/src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.h
+++ b/src/t8_schemes/t8_default/t8_default_quad/t8_dquad_bits.h
@@ -1,0 +1,63 @@
+#ifndef T8_DQUAD_BITS_H
+#define T8_DQUAD_BITS_H
+
+#include <t8.h>
+#include <t8_schemes/t8_default/t8_default_quad/t8_dquad.h>
+
+T8_EXTERN_C_BEGIN ();
+
+void t8_quad_parent (const t8_pquad_t * q, t8_pquad_t * r);
+
+void t8_quad_sibling (const t8_pquad_t * q, t8_pquad_t * r, int sibling_id);
+
+int t8_quad_compare (const void *v1, const void *v2);
+
+int t8_quad_is_extended (const t8_pquad_t * q);
+
+int t8_quad_is_parent (const t8_pquad_t * q, const t8_pquad_t * r);
+
+void t8_quad_childrenpv (const t8_pquad_t * q, t8_pquad_t * c[]);
+
+int t8_quad_child_id (const t8_pquad_t * q);
+
+int t8_quad_ancestor_id (const t8_pquad_t * q, int level);
+
+int t8_quad_is_familypv (t8_pquad_t * q[]);
+
+void t8_quad_set_morton (t8_pquad_t * quadrant, int level, uint64_t id);
+
+uint64_t t8_quad_linear_id (const t8_pquad_t * quadrant, int level);
+
+void t8_quad_first_descendant (const t8_pquad_t * q, t8_pquad_t * fd, int level);
+
+void t8_quad_nearest_common_ancestor (const t8_pquad_t * q1, const t8_pquad_t * q2, t8_pquad_t * r);
+
+void t8_quad_corner_descendant (const t8_pquad_t * q, t8_pquad_t * r, int c, int level);
+
+void t8_quad_face_neighbor (const t8_pquad_t * q, int face, t8_pquad_t * r);
+
+int t8_quad_is_inside_root (const t8_pquad_t * q);
+
+void t8_quad_print (int log_priority, const t8_pquad_t * q);
+
+void t8_quad_last_descendant (const t8_pquad_t * q, t8_pquad_t * ld, int level);
+
+int t8_quad_is_node (const t8_pquad_t * q, int inside);
+
+int t8_quad_is_inside_3x3 (const t8_pquad_t * q);
+
+int t8_quad_is_valid (const t8_pquad_t * q);
+
+int t8_quad_is_family (const t8_pquad_t * q0,
+                          const t8_pquad_t * q1,
+                          const t8_pquad_t * q2,
+                          const t8_pquad_t * q3);
+
+void
+t8_quad_children (const t8_pquad_t * q,
+                         t8_pquad_t * c0, t8_pquad_t * c1,
+                         t8_pquad_t * c2, t8_pquad_t * c3);
+
+T8_EXTERN_C_END ();
+
+#endif /* T8_DEFAULT_QUAD_BITS_H */

--- a/test/t8_gtest_main.cxx
+++ b/test/t8_gtest_main.cxx
@@ -13,7 +13,6 @@ main (int argc, char **argv)
 
   mpic = sc_MPI_COMM_WORLD;
   sc_init (mpic, 1, 1, NULL, SC_LP_PRODUCTION);
-  p4est_init (NULL, SC_LP_ESSENTIAL);
   t8_init (SC_LP_DEFAULT);
 
   ::testing::InitGoogleTest (&argc, argv);

--- a/test/t8_test_cmesh_copy.c
+++ b/test/t8_test_cmesh_copy.c
@@ -94,7 +94,7 @@ main (int argc, char **argv)
 
   comm = sc_MPI_COMM_WORLD;
   sc_init (comm, 1, 1, NULL, SC_LP_PRODUCTION);
-  p4est_init (NULL, SC_LP_ESSENTIAL);
+  
   t8_init (SC_LP_DEFAULT);
 
   t8_global_productionf ("Testing cmesh copy.\n");

--- a/test/t8_test_cmesh_face_is_boundary.cxx
+++ b/test/t8_test_cmesh_face_is_boundary.cxx
@@ -213,7 +213,6 @@ main (int argc, char **argv)
 
   comm = sc_MPI_COMM_WORLD;
   sc_init (comm, 1, 1, NULL, SC_LP_PRODUCTION);
-  p4est_init (NULL, SC_LP_ESSENTIAL);
   t8_init (SC_LP_DEFAULT);
 
   t8_test_face_is_boundary_one_tree (comm);

--- a/test/t8_test_cmesh_partition.cxx
+++ b/test/t8_test_cmesh_partition.cxx
@@ -174,7 +174,6 @@ main (int argc, char **argv)
 
   comm = sc_MPI_COMM_WORLD;
   sc_init (comm, 1, 1, NULL, SC_LP_PRODUCTION);
-  p4est_init (NULL, SC_LP_ESSENTIAL);
   t8_init (SC_LP_DEFAULT);
 
   t8_global_productionf ("Testing cmesh partition.\n");

--- a/test/t8_test_cmesh_readmshfile.c
+++ b/test/t8_test_cmesh_readmshfile.c
@@ -258,7 +258,6 @@ main (int argc, char **argv)
   SC_CHECK_MPI (mpiret);
 
   sc_init (sc_MPI_COMM_WORLD, 1, 1, NULL, SC_LP_ESSENTIAL);
-  p4est_init (NULL, SC_LP_ESSENTIAL);
   t8_init (SC_LP_DEFAULT);
 
 /* The mesh is unpartitioned and all trees are local to the master rank, no other rank has any trees. */

--- a/test/t8_test_element_count_leafs.cxx
+++ b/test/t8_test_element_count_leafs.cxx
@@ -166,7 +166,6 @@ main (int argc, char **argv)
   SC_CHECK_MPI (mpiret);
 
   sc_init (sc_MPI_COMM_WORLD, 1, 1, NULL, SC_LP_PRODUCTION);
-  p4est_init (NULL, SC_LP_ESSENTIAL);
   t8_init (SC_LP_DEFAULT);
 
   t8_global_productionf ("Testing element_count_leafs_from_root.\n");

--- a/test/t8_test_element_general_function.cxx
+++ b/test/t8_test_element_general_function.cxx
@@ -117,7 +117,6 @@ main (int argc, char **argv)
   SC_CHECK_MPI (mpiret);
 
   sc_init (sc_MPI_COMM_WORLD, 1, 1, NULL, SC_LP_PRODUCTION);
-  p4est_init (NULL, SC_LP_ESSENTIAL);
   t8_init (SC_LP_DEFAULT);
 
   t8_global_productionf ("Testing element_general_function.\n");

--- a/test/t8_test_find_owner.cxx
+++ b/test/t8_test_find_owner.cxx
@@ -180,7 +180,6 @@ main (int argc, char **argv)
 
   mpic = sc_MPI_COMM_WORLD;
   sc_init (mpic, 1, 1, NULL, SC_LP_PRODUCTION);
-  p4est_init (NULL, SC_LP_ESSENTIAL);
   t8_init (SC_LP_DEFAULT);
 
   for (ieclass = T8_ECLASS_VERTEX; ieclass < T8_ECLASS_COUNT; ieclass++) {

--- a/test/t8_test_find_parent.cxx
+++ b/test/t8_test_find_parent.cxx
@@ -104,7 +104,6 @@ main (int argc, char **argv)
   mpiret = sc_MPI_Init (&argc, &argv);
   SC_CHECK_MPI (mpiret);
   sc_init (sc_MPI_COMM_WORLD, 1, 1, NULL, SC_LP_ESSENTIAL);
-  p4est_init (NULL, SC_LP_ESSENTIAL);
   t8_init (SC_LP_DEFAULT);
 
   t8_compute_child_find_parent (maxlvl);

--- a/test/t8_test_forest_commit.cxx
+++ b/test/t8_test_forest_commit.cxx
@@ -187,7 +187,6 @@ main (int argc, char **argv)
 
   mpic = sc_MPI_COMM_WORLD;
   sc_init (mpic, 1, 1, NULL, SC_LP_PRODUCTION);
-  p4est_init (NULL, SC_LP_ESSENTIAL);
   t8_init (SC_LP_DEFAULT);
 
   test_cmesh_forest_commit_all ();

--- a/test/t8_test_geometry.cxx
+++ b/test/t8_test_geometry.cxx
@@ -296,7 +296,6 @@ main (int argc, char **argv)
 
   mpic = sc_MPI_COMM_WORLD;
   sc_init (mpic, 1, 1, NULL, SC_LP_PRODUCTION);
-  p4est_init (NULL, SC_LP_ESSENTIAL);
   t8_init (SC_LP_DEFAULT);
 
   t8_test_geometry_linear ();

--- a/test/t8_test_ghost_and_owner.cxx
+++ b/test/t8_test_ghost_and_owner.cxx
@@ -176,7 +176,6 @@ main (int argc, char **argv)
 
   mpic = sc_MPI_COMM_WORLD;
   sc_init (mpic, 1, 1, NULL, SC_LP_PRODUCTION);
-  p4est_init (NULL, SC_LP_ESSENTIAL);
   t8_init (SC_LP_DEFAULT);
 
   test_cmesh_ghost_owner_all ();

--- a/test/t8_test_ghost_exchange.cxx
+++ b/test/t8_test_ghost_exchange.cxx
@@ -237,7 +237,6 @@ main (int argc, char **argv)
 
   mpic = sc_MPI_COMM_WORLD;
   sc_init (mpic, 1, 1, NULL, SC_LP_PRODUCTION);
-  p4est_init (NULL, SC_LP_ESSENTIAL);
   t8_init (SC_LP_DEFAULT);
 
   test_cmesh_ghost_exchange_all ();

--- a/test/t8_test_half_neighbors.cxx
+++ b/test/t8_test_half_neighbors.cxx
@@ -155,7 +155,6 @@ main (int argc, char **argv)
 
   mpic = sc_MPI_COMM_WORLD;
   sc_init (mpic, 1, 1, NULL, SC_LP_PRODUCTION);
-  p4est_init (NULL, SC_LP_ESSENTIAL);
   t8_init (SC_LP_DEFAULT);
 
   for (ieclass = T8_ECLASS_VERTEX; ieclass < T8_ECLASS_COUNT; ieclass++) {

--- a/test/t8_test_hypercube.c
+++ b/test/t8_test_hypercube.c
@@ -58,7 +58,6 @@ main (int argc, char **argv)
 
   mpic = sc_MPI_COMM_WORLD;
   sc_init (mpic, 1, 1, NULL, SC_LP_PRODUCTION);
-  p4est_init (NULL, SC_LP_ESSENTIAL);
   t8_init (SC_LP_DEFAULT);
 
   test_hypercube (mpic);

--- a/test/t8_test_point_inside.cxx
+++ b/test/t8_test_point_inside.cxx
@@ -255,7 +255,6 @@ main (int argc, char **argv)
 
   mpic = sc_MPI_COMM_WORLD;
   sc_init (mpic, 1, 1, NULL, SC_LP_PRODUCTION);
-  p4est_init (NULL, SC_LP_ESSENTIAL);
   t8_init (SC_LP_DEFAULT);
 
   t8_global_productionf

--- a/test/t8_test_search.cxx
+++ b/test/t8_test_search.cxx
@@ -178,7 +178,6 @@ main (int argc, char **argv)
 
   mpic = sc_MPI_COMM_WORLD;
   sc_init (mpic, 1, 1, NULL, SC_LP_PRODUCTION);
-  p4est_init (NULL, SC_LP_ESSENTIAL);
   t8_init (SC_LP_DEFAULT);
 
   for (ieclass = T8_ECLASS_VERTEX; ieclass < T8_ECLASS_COUNT; ieclass++) {

--- a/test/t8_test_shmem.cxx
+++ b/test/t8_test_shmem.cxx
@@ -270,7 +270,6 @@ main (int argc, char **argv)
   SC_CHECK_MPI (mpiret);
 
   sc_init (sc_MPI_COMM_WORLD, 1, 1, NULL, SC_LP_PRODUCTION);
-  p4est_init (NULL, SC_LP_ESSENTIAL);
   t8_init (SC_LP_DEFAULT);
 
 #define T8_TEST_SHMEM_NUM_COMMS 2

--- a/test/t8_test_transform.cxx
+++ b/test/t8_test_transform.cxx
@@ -199,7 +199,6 @@ main (int argc, char **argv)
 
   mpic = sc_MPI_COMM_WORLD;
   sc_init (mpic, 1, 1, NULL, SC_LP_PRODUCTION);
-  p4est_init (NULL, SC_LP_ESSENTIAL);
   t8_init (SC_LP_DEFAULT);
 
   t8_test_transform (mpic);

--- a/test/t8_test_user_data.cxx
+++ b/test/t8_test_user_data.cxx
@@ -146,7 +146,6 @@ main (int argc, char **argv)
 
   mpic = sc_MPI_COMM_WORLD;
   sc_init (mpic, 1, 1, NULL, SC_LP_PRODUCTION);
-  p4est_init (NULL, SC_LP_ESSENTIAL);
   t8_init (SC_LP_DEFAULT);
 
   t8_test_user_data (mpic);


### PR DESCRIPTION
**_Describe your changes here:_**
I removed the redundant p4est dependeny within the 'quad' and 'hex' schemes. Along the way the code was tidied out,
simplified, optimized and also streamlined according to the naming conventions in other schemes, e.g., 'tri' or 'tet'.

**_All these boxes must be checked by the reviewers before merging the pull request:_**

- [ ] The author added a BSD statement to `doc/` (or already has one)
- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request indroduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The reviewer executed the new code features at least once and checked the results manually
- [ ] The code is covered in an existing or new test case
- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [ ] Testing of this template: If you feel something is missing from this list, contact the developers
