### PR TITLE
Implement t8_element_anchor for pyramids

### DIFF
--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.cxx
@@ -398,6 +398,18 @@ t8_default_scheme_pyramid_c::t8_element_successor (const t8_element_t *elem,
 }
 
 void
+t8_default_scheme_pyramid_c::t8_element_anchor (const t8_element_t *elem,
+                                                int anchor[3])
+{
+  t8_dpyramid_t      *pyra = (t8_dpyramid_t *) elem;
+
+  T8_ASSERT (t8_element_is_valid (elem));
+  anchor[0] = pyra->x;
+  anchor[1] = pyra->y;
+  anchor[2] = pyra->z;
+}
+
+void
 t8_default_scheme_pyramid_c::t8_element_vertex_coords (const t8_element_t *t,
                                                        int vertex,
                                                        int coords[])

--- a/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx
+++ b/src/t8_schemes/t8_default/t8_default_pyramid/t8_default_pyramid_cxx.hxx
@@ -283,10 +283,7 @@ public:
 
 /** Get the integer coordinates of the anchor node of an element */
   virtual void        t8_element_anchor (const t8_element_t *elem,
-                                         int anchor[3])
-  {
-    SC_ABORT ("This function is not implemented yet.\n");
-  }
+                                         int anchor[3]);
 
 /** Get the integer root length of an element, that is the length of
  *  the level 0 ancestor.


### PR DESCRIPTION
The example t8_face_neighbor was not running for pyramids, because the function t8_element_anchor was not implemented for pyramids. This PR implements the functions and solves the problem.


**_All these boxes must be checked by the reviewers before merging the pull request:_**

- [ ] The author added a BSD statement to `doc/` (or already has one)
- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request indroduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The reviewer executed the new code features at least once and checked the results manually
- [ ] The code is covered in an existing or new test case
- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [ ] Testing of this template: If you feel something is missing from this list, contact the developers
