### PR TITLE
Fix-removed second occurrence of geometry zero in makefile

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -50,8 +50,7 @@ libt8_installed_headers_geometry_impl = \
   src/t8_geometry/t8_geometry_implementations/t8_geometry_linear.h \
   src/t8_geometry/t8_geometry_implementations/t8_geometry_analytic.hxx \
   src/t8_geometry/t8_geometry_implementations/t8_geometry_linear.hxx \
-  src/t8_geometry/t8_geometry_implementations/t8_geometry_zero.hxx \
-  src/t8_geometry/t8_geometry_implementations/t8_geometry_zero.hxx
+  src/t8_geometry/t8_geometry_implementations/t8_geometry_zero.hxx 
 libt8_installed_headers_schemes_default =
 libt8_installed_headers_default_common =
 libt8_installed_headers_default_vertex =


### PR DESCRIPTION
**_Describe your changes here:_**
`src/t8_geometry/t8_geometry_implementations/t8_geometry_zero.hxx ` was listed twice in the Makefile, which lead to an error in my `make install`. I do not know why this doe not result in any problems on @Davknapp's system.


**_All these boxes must be checked by the reviewers before merging the pull request:_**

- [x] The author added a BSD statement to `doc/` (or already has one)
- [x] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request indroduces code that is not covered by the github action (for example coupling with a new library):
  - [x] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [x] All tests pass (in various configurations, this should be executed automatically in a github action)
- [x] New source/header files are properly added to the Makefiles
- [x] The reviewer executed the new code features at least once and checked the results manually
- [ ] The code is covered in an existing or new test case
- [x] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [x] The code is well documented
- [x] All function declarations, structs/classes and their members have a proper doxygen documentation
- [x] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [ ] Testing of this template: If you feel something is missing from this list, contact the developers
