### PR TITLE
fixed bug that elements on maxlevel cannot be coarsened

### DIFF
--- a/example/common/t8_example_common.cxx
+++ b/example/common/t8_example_common.cxx
@@ -145,12 +145,9 @@ t8_common_adapt_level_set (t8_forest_t forest,
   /* Get the minimum and maximum x-coordinate from the user data pointer of forest */
   data = (t8_example_level_set_struct_t *) t8_forest_get_user_data (forest);
 
-  /* If maxlevel is exceeded, coarsen or do not refine */
+  /* If maxlevel is exceeded then coarsen */
   if (level > data->max_level && is_family) {
     return -1;
-  }
-  if (level >= data->max_level) {
-    return 0;
   }
   /* Refine at least until min level */
   if (level < data->min_level) {


### PR DESCRIPTION
**_Describe your changes here:_**
The `t8_common_adapt_level_set` function is currently only used in `t8_test_ghost.cxx`. Here, only one time step gets calculated. But if someone would use this function in a scenario with multiple time steps, each element with the max level will be stuck at the max level and cannot be coarsened again.
This happens, because the condition in line
https://github.com/holke/t8code/blob/d025b43064cc8261c83bfeeacdef9e2aa1e908cd/example/common/t8_example_common.cxx#L152
gets triggered on max level and returns 0. Even if the element is outside the refinement zone.


**_All these boxes must be checked by the reviewers before merging the pull request:_**

As a reviewer please read through all the code lines and make sure that the code is fully understood, bug free, well-documented and well-structured.

- [ ] The author added a BSD statement to `doc/` (or already has one)
- [ ] The code compiles without warning in debugging and release mode, with and without MPI (this should be executed automatically in a github action)

  If the Pull request indroduces code that is not covered by the github action (for example coupling with a new library):
  - [ ] Should this use case be added to the github action?
  - [ ] If not, does the specific use case compile and all tests pass (check manually)

- [ ] All tests pass (in various configurations, this should be executed automatically in a github action)
- [ ] New source/header files are properly added to the Makefiles
- [ ] The reviewer executed the new code features at least once and checked the results manually
- [ ] The code is covered in an existing or new test case
- [ ] The code follows the [t8code coding guidelines](https://github.com/holke/t8code/wiki/Coding-Guideline)
- [ ] The code is well documented
- [ ] All function declarations, structs/classes and their members have a proper doxygen documentation
- [ ] All new algorithms and data structures are sufficiently optimal in terms of memory and runtime (If this should be merged, but there is still potential for optimization, create a new issue)
- [ ] Testing of this template: If you feel something is missing from this list, contact the developers
